### PR TITLE
Feat/massedit replace

### DIFF
--- a/StudioCore/Editor/UIHints.cs
+++ b/StudioCore/Editor/UIHints.cs
@@ -32,6 +32,7 @@ The valid values of OP are:
     '+' adds the given value to the value of the field
     '-' subtracts the given value from the value of the field
     'ref' searches for a row with a given name in a field supporting references and assigns it to that field
+    'replace' works for names only, and requires an argument in the form stringA:stringB, where stringA is replaced by stringB.
 
 A complete command may look like the following DS3 examples:
 selection: throwAtkRate: = 30;

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -837,7 +837,7 @@ namespace StudioCore
                         AttemptLoadProject(_newProjectSettings, $@"{_newProjectDirectory}\project.json", true);
                         if (_newProjectLoadDefaultNames)
                         {
-                            ParamEditor.ParamBank.LoadParamDefaultNames();
+                            new Editor.ActionManager().ExecuteAction(ParamEditor.ParamBank.LoadParamDefaultNames());
                             ParamEditor.ParamBank.SaveParams(_newProjectSettings.UseLooseParams);
                         }
 

--- a/StudioCore/ParamEditor/MassParamEdit.cs
+++ b/StudioCore/ParamEditor/MassParamEdit.cs
@@ -97,6 +97,13 @@ namespace StudioCore.ParamEditor
                 {
                     return name + opparam;
                 }
+                if (op.Equals("replace"))
+                {
+                    string[] split = opparam.Split(":");
+                    if (split.Length!=2)
+                        return null;
+                    return name.Replace(split[0], split[1]);
+                }
             }
             catch
             {
@@ -147,7 +154,7 @@ namespace StudioCore.ParamEditor
         // eg "correctFaith: "
         private static readonly string fieldRx = $@"(?<fieldrx>[^:]+):\s+";
         // eg "* 2;
-        private static readonly string opRx = $@"(?<op>=|\+|-|\*|/|ref)\s+";
+        private static readonly string opRx = $@"(?<op>=|\+|-|\*|/|ref|replace)\s+";
         private static readonly string opFieldRx = $@"{opRx}(?<fieldtype>field\s+)?";
         private static readonly string operationRx = $@"{opFieldRx}(?<opparam>[^;]+);";
 
@@ -184,6 +191,7 @@ namespace StudioCore.ParamEditor
                 options.Add("* ");
                 options.Add("/ ");
                 options.Add("ref ");
+                options.Add("replace ");
                 return options;
             }
             if (new Regex($@"({paramrowfilterselection}|({paramfilterRx}{rowfilterRx}:\s+))").IsMatch(text))

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -110,10 +110,11 @@ namespace StudioCore.ParamEditor
             }
         }
 
-        public static void LoadParamDefaultNames()
+        public static CompoundAction LoadParamDefaultNames()
         {
             var dir = AssetLocator.GetParamNamesDir();
             var files = Directory.GetFiles(dir, "*.txt");
+            List<EditorAction> actions = new List<EditorAction>();
             while (IsLoadingParams); //super hack
                 Thread.Sleep(100);
             foreach (var f in files)
@@ -124,8 +125,15 @@ namespace StudioCore.ParamEditor
                 if (!_params.ContainsKey(param))
                     continue;
                 string names = File.ReadAllText(f);
-                MassEditResult r = MassParamEditCSV.PerformSingleMassEdit(names, new ActionManager(), param, "Name", true);
+                (MassEditResult r, CompoundAction a) = MassParamEditCSV.PerformSingleMassEdit(names, param, "Name", true);
+                actions.Add(a);
             }
+            return new CompoundAction(actions);
+        }
+        public static ActionManager TrimNewlineChrsFromNames()
+        {
+            (MassEditResult r, ActionManager child) = MassParamEditRegex.PerformMassEdit("param .*: id .*: name: replace \r:0", null, null);
+            return child;
         }
 
         private static void LoadParamFromBinder(IBinder parambnd, ref Dictionary<string, PARAM> paramBank)

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -197,14 +197,20 @@ namespace StudioCore.ParamEditor
                 }
                 if (ImGui.MenuItem("Sort rows by ID", _activeView._selection.paramSelectionExists()))
                 {
-                    MassParamEditOther.SortRows(_activeView._selection.getActiveParam(), EditorActionManager);
+                    EditorActionManager.ExecuteAction(MassParamEditOther.SortRows(_activeView._selection.getActiveParam()));
                 }
                 if (ImGui.MenuItem("Load Default Row Names"))
                 {
                     try {
-                        ParamBank.LoadParamDefaultNames();
+                        EditorActionManager.ExecuteAction(ParamBank.LoadParamDefaultNames());
                     } catch {
-
+                    }
+                }
+                if (ImGui.MenuItem("Trim hidden newlines in names"))
+                {
+                    try {
+                        EditorActionManager.PushSubManager(ParamBank.TrimNewlineChrsFromNames());
+                    } catch {
                     }
                 }
                 ImGui.EndMenu();
@@ -316,7 +322,9 @@ namespace StudioCore.ParamEditor
                 if (ImGui.Selectable("Submit", false, ImGuiSelectableFlags.DontClosePopups))
                 {
                     _activeView._selection.sortSelection();
-                    MassEditResult r = MassParamEditRegex.PerformMassEdit(_currentMEditRegexInput, EditorActionManager, _activeView._selection.getActiveParam(), _activeView._selection.getSelectedRows());
+                    (MassEditResult r, ActionManager child) = MassParamEditRegex.PerformMassEdit(_currentMEditRegexInput, _activeView._selection.getActiveParam(), _activeView._selection.getSelectedRows());
+                    if (child != null)
+                        EditorActionManager.PushSubManager(child);
                     if (r.Type == MassEditResultType.SUCCESS)
                     {
                         _lastMEditRegexInput = _currentMEditRegexInput;
@@ -365,7 +373,9 @@ namespace StudioCore.ParamEditor
                 ImGui.InputTextMultiline("MEditRegexInput", ref _currentMEditCSVInput, 256 * 65536, new Vector2(1024, ImGui.GetTextLineHeightWithSpacing() * 4));
                 if (ImGui.Selectable("Submit", false, ImGuiSelectableFlags.DontClosePopups))
                 {
-                    MassEditResult r = MassParamEditCSV.PerformSingleMassEdit(_currentMEditCSVInput, EditorActionManager, _activeView._selection.getActiveParam(), _currentMEditSingleCSVField, _currentMEditSingleCSVSpaces);
+                    (MassEditResult r, CompoundAction a) = MassParamEditCSV.PerformSingleMassEdit(_currentMEditCSVInput, _activeView._selection.getActiveParam(), _currentMEditSingleCSVField, _currentMEditSingleCSVSpaces);
+                    if (a != null)
+                        EditorActionManager.ExecuteAction(a);
                     _mEditCSVResult = r.Information;
                 }
                 ImGui.Text(_mEditCSVResult);


### PR DESCRIPTION
Adds a replace operation to the masseditor.
Also adds a shortcut to replace \r with empty string, as hidden newlines have been an issue for some users.
Further, other quick-operations such as import names and sort rows now properly abide by the actionmanager.