### PR TITLE
Feat/task manager update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ DS Map Studio is a standalone map editor for all the souls games. It is intended
 * **Dark Souls 3 and Sekiro**: Use UXM to extract the game files.
 * **Demon's Souls**: I test against the US version, but any valid full game dump of Demon's Souls will probably work out of the box. Make sure to disable the RPCS3 file cache to test changes if using the emulator.
 * **Bloodborne**: Any valid full game dump should work out of the box. Note that some dumps will have the base game (1.0) and the patch as separate, so the patch should be merged on top of the base game before use with map studio. You're on your own for installing mods to console at the moment.
+* **Elden Ring**: Use UXM to extract the game files.
 
 ### Mod projects
-Map studio operates on top of something I call mod projects. These are typically stored in a separate directory from the base game, and all modifies files will be saved there instead of overwriting the base game files (there's exceptions for DS1 and DeS because we don't have a mod engine solution for them). The intended workflow is to install mod engine for your respective game and set the modoverridedirectory in modengine.ini to your mod project directory. This way you don't have to modify base game files (and work on multiple mod projects at a time) and you can easily distribute a mod by zipping up the project directory and uploading it.
+Map studio operates on top of something I call mod projects. These are typically stored in a separate directory from the base game, and all modifies files will be saved there instead of overwriting the base game files. The intended workflow is to install mod engine for your respective game and set the modoverridedirectory in modengine.ini to your mod project directory. This way you don't have to modify base game files (and work on multiple mod projects at a time) and you can easily distribute a mod by zipping up the project directory and uploading it.
 
 ## FAQ
 ### Q: Why did you abandon DSTools?
@@ -27,7 +28,7 @@ A: Likely not. Rendering the entirety of the maps for DS3, Bloodborne, and Sekir
 
 ## System Requirements:
 * Windows 7/8/8.1/10 (64-bit only)
-* [Microsoft .Net Core 3.1 **Desktop** Runtime](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+* [Microsoft .Net Core 6.0 **Desktop** Runtime](https://dotnet.microsoft.com/download/dotnet-core/6.0)
 * [Visual C++ Redistributable x64 - INSTALL THIS IF THE PROGRAM CRASHES ON STARTUP](https://aka.ms/vs/16/release/vc_redist.x64.exe)
 * **A Vulkan Compatible Graphics Device with support for descriptor indexing**, even if you're just modding DS1: PTDE
 * Intel GPUs currently don't seem to be working properly. At the moment, you will probably need a somewhat recent (2014+) NVIDIA or AMD GPU

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ DS Map Studio is a standalone map editor for all the souls games. It is intended
 * **Dark Souls 3 and Sekiro**: Use UXM to extract the game files.
 * **Demon's Souls**: I test against the US version, but any valid full game dump of Demon's Souls will probably work out of the box. Make sure to disable the RPCS3 file cache to test changes if using the emulator.
 * **Bloodborne**: Any valid full game dump should work out of the box. Note that some dumps will have the base game (1.0) and the patch as separate, so the patch should be merged on top of the base game before use with map studio. You're on your own for installing mods to console at the moment.
-* **Elden Ring**: Use UXM to extract the game files.
+* **Elden Ring**: Use UXM QuickHack to extract the game files.
 
 ### Mod projects
 Map studio operates on top of something I call mod projects. These are typically stored in a separate directory from the base game, and all modifies files will be saved there instead of overwriting the base game files. The intended workflow is to install mod engine for your respective game and set the modoverridedirectory in modengine.ini to your mod project directory. This way you don't have to modify base game files (and work on multiple mod projects at a time) and you can easily distribute a mod by zipping up the project directory and uploading it.

--- a/SoulsFormats/SoulsFormats/Formats/FMG.cs
+++ b/SoulsFormats/SoulsFormats/Formats/FMG.cs
@@ -217,7 +217,7 @@ namespace SoulsFormats
             /// <summary>
             /// The text of this entry.
             /// </summary>
-            public string Text;
+            public string Text {get;set;}
 
             /// <summary>
             /// Creates a new entry with the specified ID and text.

--- a/StudioCore/Assets/Paramdex/ER/Defs/SpEffect.xml
+++ b/StudioCore/Assets/Paramdex/ER/Defs/SpEffect.xml
@@ -2632,7 +2632,73 @@
       <Increment>0.001</Increment>
       <SortID>300040</SortID>
     </Field>
-    <Field Def="dummy8 pad3[8]">
+    <Field Def="u8 unk3-1.1">
+      <DisplayName>pad</DisplayName>
+      <DisplayFormat>%f</DisplayFormat>
+      <EditFlags>Wrap</EditFlags>
+      <SortID>470002</SortID>
+    </Field>
+    <Field Def="u8 unk3-1.2">
+      <DisplayName>pad</DisplayName>
+      <DisplayFormat>%f</DisplayFormat>
+      <EditFlags>Wrap</EditFlags>
+      <SortID>470002</SortID>
+    </Field>
+    <Field Def="u8 unk3-1.3">
+      <DisplayName>pad</DisplayName>
+      <DisplayFormat>%f</DisplayFormat>
+      <EditFlags>Wrap</EditFlags>
+      <SortID>470002</SortID>
+    </Field>
+    <Field Def="u8 unk3-1.4a:1">
+      <DisplayName>pad</DisplayName>
+      <DisplayFormat>%f</DisplayFormat>
+      <EditFlags>Wrap</EditFlags>
+      <SortID>470002</SortID>
+    </Field>
+    <Field Def="u8 unk3-1.4b:1">
+      <DisplayName>pad</DisplayName>
+      <DisplayFormat>%f</DisplayFormat>
+      <EditFlags>Wrap</EditFlags>
+      <SortID>470002</SortID>
+    </Field>
+    <Field Def="u8 unk3-1.4c:1">
+      <DisplayName>pad</DisplayName>
+      <DisplayFormat>%f</DisplayFormat>
+      <EditFlags>Wrap</EditFlags>
+      <SortID>470002</SortID>
+    </Field>
+    <Field Def="u8 unk3-1.4d:1">
+      <DisplayName>pad</DisplayName>
+      <DisplayFormat>%f</DisplayFormat>
+      <EditFlags>Wrap</EditFlags>
+      <SortID>470002</SortID>
+    </Field>
+    <Field Def="u8 unk3-1.4e:1">
+      <DisplayName>pad</DisplayName>
+      <DisplayFormat>%f</DisplayFormat>
+      <EditFlags>Wrap</EditFlags>
+      <SortID>470002</SortID>
+    </Field>
+    <Field Def="u8 unk3-1.4f:1">
+      <DisplayName>pad</DisplayName>
+      <DisplayFormat>%f</DisplayFormat>
+      <EditFlags>Wrap</EditFlags>
+      <SortID>470002</SortID>
+    </Field>
+    <Field Def="u8 unk3-1.4g:1">
+      <DisplayName>pad</DisplayName>
+      <DisplayFormat>%f</DisplayFormat>
+      <EditFlags>Wrap</EditFlags>
+      <SortID>470002</SortID>
+    </Field>
+    <Field Def="u8 unk3-1.4h:1">
+      <DisplayName>pad</DisplayName>
+      <DisplayFormat>%f</DisplayFormat>
+      <EditFlags>Wrap</EditFlags>
+      <SortID>470002</SortID>
+    </Field>
+    <Field Def="u32 unk3-2">
       <DisplayName>pad</DisplayName>
       <DisplayFormat>%f</DisplayFormat>
       <EditFlags>Wrap</EditFlags>

--- a/StudioCore/Assets/Paramdex/SDT/Defs/OBJECT_PARAM_ST.xml
+++ b/StudioCore/Assets/Paramdex/SDT/Defs/OBJECT_PARAM_ST.xml
@@ -87,6 +87,7 @@
     <Field Def="dummy8 pad1[12]" />
     <Field Def="u8 NULL_BOOLEAN:1" />
     <Field Def="u8 UseHavokFunction:1" />
+    <Field Def="u8 pad2:6" />
     <Field Def="u8 Unk42" />
     <Field Def="u16 Unk43" />
     <Field Def="s32 Unk44" />
@@ -99,6 +100,6 @@
     <Field Def="f32 Unk51" />
     <Field Def="f32 Unk52" />
     <Field Def="f32 UnkParam" />
-    <Field Def="dummy8 pad2[16]" />
+    <Field Def="dummy8 pad3[16]" />
   </Fields>
 </PARAMDEF>

--- a/StudioCore/Editor/AliasBank.cs
+++ b/StudioCore/Editor/AliasBank.cs
@@ -54,15 +54,11 @@ namespace StudioCore.Editor
         {
             _mapNames = new Dictionary<string, string>();
             IsLoadingAliases = true;
-
-            TaskManager.Run("AB:LoadAliases", true, false, () =>
+            if (AssetLocator.Type != GameType.Undefined)
             {
-                if (AssetLocator.Type != GameType.Undefined)
-                {
-                    LoadMapNames();
-                }
-                IsLoadingAliases = false;
-            });
+                LoadMapNames();
+            }
+            IsLoadingAliases = false;
         }
 
         public static void SetAssetLocator(AssetLocator l)

--- a/StudioCore/Editor/UIHints.cs
+++ b/StudioCore/Editor/UIHints.cs
@@ -32,6 +32,7 @@ The valid values of OP are:
     '+' adds the given value to the value of the field
     '-' subtracts the given value from the value of the field
     'ref' searches for a row with a given name in a field supporting references and assigns it to that field
+    'replace' works for names only, and requires an argument in the form stringA:stringB, where stringA is replaced by stringB.
 
 A complete command may look like the following DS3 examples:
 selection: throwAtkRate: = 30;

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -341,24 +341,19 @@ namespace StudioCore
             TaskManager.Run("MB:LoadMtds", true, false, true, ()=>{
                 MsbEditor.MtdBank.ReloadMtds();
             });
+
+            TaskManager.Run("U:LoadUniverse", true, false, true, ()=>{
+                _msbEditor.ReloadUniverse();
+            });
+            TaskManager.Run("Model:LoadAssetBrowser", true, false, true, ()=>{
+                _modelEditor.ReloadAssetBrowser();
+            });
             
             //Resources loaded here should be moved to databanks
-            TaskManager.Run("MSBE:ProjectChanged", true, false, true, ()=>
-            {
-                _msbEditor.OnProjectChanged(_projectSettings);
-            });
-            TaskManager.Run("MODELE:ProjectChanged", true, false, true, ()=>
-            {
-                _modelEditor.OnProjectChanged(_projectSettings);
-            });
-            TaskManager.Run("PARAME:ProjectChanged", true, false, true, ()=>
-            {
-                _paramEditor.OnProjectChanged(_projectSettings);
-            });
-            TaskManager.Run("TEXTE:ProjectChanged", true, false, true, ()=>
-            {
-                _textEditor.OnProjectChanged(_projectSettings);
-            });
+            _msbEditor.OnProjectChanged(_projectSettings);
+            _modelEditor.OnProjectChanged(_projectSettings);
+            _paramEditor.OnProjectChanged(_projectSettings);
+            _textEditor.OnProjectChanged(_projectSettings);
         }
 
         public void ApplyStyle()

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -18,7 +18,7 @@ namespace StudioCore
 {
     public class MapStudioNew
     {
-        private static string _version = "Elden Ring Test 2";
+        private static string _version = "Elden Ring Test 3";
 
         private Sdl2Window _window;
         private GraphicsDevice _gd;
@@ -466,7 +466,7 @@ namespace StudioCore
                         System.Windows.Forms.MessageBoxIcon.None);
                     return false;
                 }
-                if ((settings.GameType == GameType.Sekiro || settings.GameType == GameType.EldenRing) && !File.Exists(Path.Join(settings.GameRoot, "oo2core_6_win64.dll")))
+                if ((settings.GameType == GameType.Sekiro || settings.GameType == GameType.EldenRing) && !File.Exists(Path.Join(Path.GetFullPath("."), "oo2core_6_win64.dll")))
                 {
                     //Technically we're not checking it exists, but the same can be said for many things we assume from CheckFilesExpanded
                     File.Copy(Path.Join(settings.GameRoot, "oo2core_6_win64.dll"), Path.Join(Path.GetFullPath("."), "oo2core_6_win64.dll"));
@@ -672,9 +672,14 @@ namespace StudioCore
                 }
                 if (ImGui.BeginMenu("Help"))
                 {
+                    if (ImGui.BeginMenu("How to use"))
+                    {
+                        ImGui.Text("Usage of many features is assisted through the symbol (?).\nIn many cases, right clicking items will provide further information and options.");
+                        ImGui.EndMenu();
+                    }
                     if (ImGui.BeginMenu("About"))
                     {
-                        ImGui.Text("DSParamStudio is forked from Katalash's DSMapStudio and is currently maintained by Philiquaz.\nFor bug reports and feature requests, ping the right person please.");
+                        ImGui.Text("DSParamStudio was forked and merged back into Katalash's DSMapStudio, and is currently maintained by Philiquaz.\nFor bug reports and feature requests, ping the right person please.");
                         ImGui.EndMenu();
                     }
                     if (ImGui.BeginMenu("Edits aren't sticking!"))
@@ -865,7 +870,7 @@ namespace StudioCore
                         AttemptLoadProject(_newProjectSettings, $@"{_newProjectDirectory}\project.json", true);
                         if (_newProjectLoadDefaultNames)
                         {
-                            ParamEditor.ParamBank.LoadParamDefaultNames();
+                            new Editor.ActionManager().ExecuteAction(ParamEditor.ParamBank.LoadParamDefaultNames());
                             ParamEditor.ParamBank.SaveParams(_newProjectSettings.UseLooseParams);
                         }
 

--- a/StudioCore/MsbEditor/AssetBrowser.cs
+++ b/StudioCore/MsbEditor/AssetBrowser.cs
@@ -33,6 +33,8 @@ namespace StudioCore.MsbEditor
 
         public void RebuildCaches()
         {
+            _chrCache = new List<string>();
+            _objCache = new List<string>();
             _chrCache = _locator.GetChrModels();
             _objCache = _locator.GetObjModels();
         }

--- a/StudioCore/MsbEditor/ModelEditorScreen.cs
+++ b/StudioCore/MsbEditor/ModelEditorScreen.cs
@@ -276,6 +276,11 @@ namespace StudioCore.MsbEditor
 
         public override void OnProjectChanged(Editor.ProjectSettings newSettings)
         {
+            
+        }
+
+        public void ReloadAssetBrowser()
+        {
             if (AssetLocator.Type != GameType.Undefined)
             {
                 _assetBrowser.RebuildCaches();

--- a/StudioCore/MsbEditor/MsbEditorScreen.cs
+++ b/StudioCore/MsbEditor/MsbEditorScreen.cs
@@ -591,6 +591,9 @@ namespace StudioCore.MsbEditor
             _projectSettings = newSettings;
             _selection.ClearSelection();
             EditorActionManager.Clear();
+        }
+        public void ReloadUniverse()
+        {
             Universe.UnloadAllMaps();
             GC.Collect();
             Universe.PopulateMapList();

--- a/StudioCore/MsbEditor/MtdBank.cs
+++ b/StudioCore/MsbEditor/MtdBank.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.IO;
 using SoulsFormats;
+using StudioCore.Editor;
 
 namespace StudioCore.MsbEditor
 {
@@ -76,7 +77,6 @@ namespace StudioCore.MsbEditor
                     }
                 }
             }
-
         }
 
         public static void LoadMtds(AssetLocator l)

--- a/StudioCore/MsbEditor/MtdBank.cs
+++ b/StudioCore/MsbEditor/MtdBank.cs
@@ -37,6 +37,7 @@ namespace StudioCore.MsbEditor
             if (AssetLocator.Type == GameType.DarkSoulsIII || AssetLocator.Type == GameType.Sekiro)
             {
                 mtdBinder = BND4.Read(AssetLocator.GetAssetPath($@"mtd\allmaterialbnd.mtdbnd.dcx"));
+                IsMatbin = false;
             }
             else if (AssetLocator.Type == GameType.EldenRing)
             {

--- a/StudioCore/MsbEditor/SceneTree.cs
+++ b/StudioCore/MsbEditor/SceneTree.cs
@@ -501,6 +501,8 @@ namespace StudioCore.MsbEditor
 
                 ImGui.BeginChild("listtree");
                 Map pendingUnload = null;
+                if (_universe.LoadedObjectContainers.Count==0)
+                    ImGui.Text("This Editor requires game to be unpacked");
                 foreach (var lm in _universe.LoadedObjectContainers.OrderBy((k) => k.Key))
                 {
                     var map = lm.Value;

--- a/StudioCore/MsbEditor/SceneTree.cs
+++ b/StudioCore/MsbEditor/SceneTree.cs
@@ -505,6 +505,8 @@ namespace StudioCore.MsbEditor
                 {
                     var map = lm.Value;
                     var mapid = lm.Key;
+                    if (mapid == null)
+                        continue;
                     var treeflags = ImGuiTreeNodeFlags.OpenOnArrow | ImGuiTreeNodeFlags.SpanAvailWidth;
                     if (map != null && _selection.GetSelection().Contains(map.RootObject))
                     {

--- a/StudioCore/ParamEditor/MassParamEdit.cs
+++ b/StudioCore/ParamEditor/MassParamEdit.cs
@@ -97,6 +97,13 @@ namespace StudioCore.ParamEditor
                 {
                     return name + opparam;
                 }
+                if (op.Equals("replace"))
+                {
+                    string[] split = opparam.Split(":");
+                    if (split.Length!=2)
+                        return null;
+                    return name.Replace(split[0], split[1]);
+                }
             }
             catch
             {
@@ -147,7 +154,7 @@ namespace StudioCore.ParamEditor
         // eg "correctFaith: "
         private static readonly string fieldRx = $@"(?<fieldrx>[^:]+):\s+";
         // eg "* 2;
-        private static readonly string opRx = $@"(?<op>=|\+|-|\*|/|ref)\s+";
+        private static readonly string opRx = $@"(?<op>=|\+|-|\*|/|ref|replace)\s+";
         private static readonly string opFieldRx = $@"{opRx}(?<fieldtype>field\s+)?";
         private static readonly string operationRx = $@"{opFieldRx}(?<opparam>[^;]+);";
 
@@ -184,6 +191,7 @@ namespace StudioCore.ParamEditor
                 options.Add("* ");
                 options.Add("/ ");
                 options.Add("ref ");
+                options.Add("replace ");
                 return options;
             }
             if (new Regex($@"({paramrowfilterselection}|({paramfilterRx}{rowfilterRx}:\s+))").IsMatch(text))
@@ -228,7 +236,7 @@ namespace StudioCore.ParamEditor
             return options;
         }
 
-        public static MassEditResult PerformMassEdit(string commandsString, ActionManager actionManager, string contextActiveParam, List<PARAM.Row> contextActiveRows)
+        public static (MassEditResult, ActionManager child) PerformMassEdit(string commandsString, string contextActiveParam, List<PARAM.Row> contextActiveRows)
         {
             string[] commands = commandsString.Split('\n');
             int changeCount = 0;
@@ -276,7 +284,7 @@ namespace StudioCore.ParamEditor
                                 }
                             }
                             if (opparamcontext.Equals(opparam))
-                                return new MassEditResult(MassEditResultType.OPERATIONERROR, $@"Could not look up field {opparam} in row {row.Name}");
+                                return (new MassEditResult(MassEditResultType.OPERATIONERROR, $@"Could not look up field {opparam} in row {row.Name}"), null);
                         }
                         
                         changeCount += affectedCells.Count;
@@ -285,7 +293,7 @@ namespace StudioCore.ParamEditor
                             object newval = PerformOperation(cell, op, opparamcontext);
                             if (newval == null)
                             {
-                                return new MassEditResult(MassEditResultType.OPERATIONERROR, $@"Could not perform operation {op} {opparamcontext} on field {cell.Def.InternalName}");
+                                return (new MassEditResult(MassEditResultType.OPERATIONERROR, $@"Could not perform operation {op} {opparamcontext} on field {cell.Def.InternalName}"), null);
                             }
                             partialActions.Add(new PropertiesChangedAction(cell.GetType().GetProperty("Value"), -1, cell, newval));
                         }
@@ -294,7 +302,7 @@ namespace StudioCore.ParamEditor
                             string newval = PerformNameOperation(row.Name, op, opparamcontext);
                             if (newval == null)
                             {
-                                return new MassEditResult(MassEditResultType.OPERATIONERROR, $@"Could not perform operation {op} {opparamcontext} on name");
+                                return (new MassEditResult(MassEditResultType.OPERATIONERROR, $@"Could not perform operation {op} {opparamcontext} on name"), null);
                             }
                             partialActions.Add(new PropertiesChangedAction(row.GetType().GetProperty("Name"), -1, row, newval));
                         
@@ -303,12 +311,11 @@ namespace StudioCore.ParamEditor
                 }
                 else
                 {
-                    return new MassEditResult(MassEditResultType.PARSEERROR, $@"Unrecognised command {command}");
+                    return (new MassEditResult(MassEditResultType.PARSEERROR, $@"Unrecognised command {command}"), null);
                 }
                 childManager.ExecuteAction(new CompoundAction(partialActions));
             }
-            actionManager.PushSubManager(childManager);
-            return new MassEditResult(MassEditResultType.SUCCESS, $@"{changeCount} cells affected");
+            return (new MassEditResult(MassEditResultType.SUCCESS, $@"{changeCount} cells affected"), childManager);
         }
 
         public static List<PARAM> GetMatchingParams(Regex paramrx)
@@ -573,13 +580,13 @@ namespace StudioCore.ParamEditor
                 return new MassEditResult(MassEditResultType.PARSEERROR, "Unable to parse CSV into correct data types");
             }
         }
-        public static MassEditResult PerformSingleMassEdit(string csvString, ActionManager actionManager, string param, string field, bool useSpace)
+        public static (MassEditResult, CompoundAction) PerformSingleMassEdit(string csvString, string param, string field, bool useSpace)
         {
             try
             {
                 PARAM p = ParamBank.Params[param];
                 if (p == null)
-                    return new MassEditResult(MassEditResultType.PARSEERROR, "No Param selected");
+                    return (new MassEditResult(MassEditResultType.PARSEERROR, "No Param selected"), null);
                 string[] csvLines = csvString.Split("\n");
                 int changeCount = 0;
                 List<EditorAction> actions = new List<EditorAction>();
@@ -589,12 +596,12 @@ namespace StudioCore.ParamEditor
                         continue;
                     string[] csvs = csvLine.Trim().Split(useSpace ? ' ' : ',', 2, StringSplitOptions.RemoveEmptyEntries);
                     if (csvs.Length != 2)
-                        return new MassEditResult(MassEditResultType.PARSEERROR, "CSV has wrong number of values");
+                        return (new MassEditResult(MassEditResultType.PARSEERROR, "CSV has wrong number of values"), null);
                     int id = int.Parse(csvs[0]);
                     string value = csvs[1];
                     PARAM.Row row = p[id];
                     if (row == null)
-                        return new MassEditResult(MassEditResultType.OPERATIONERROR, $@"Could not locate row {id}");
+                        return (new MassEditResult(MassEditResultType.OPERATIONERROR, $@"Could not locate row {id}"), null);
                     if (field.Equals("Name"))
                     {
                         if (row.Name == null || !row.Name.Equals(value))
@@ -605,38 +612,36 @@ namespace StudioCore.ParamEditor
                         PARAM.Cell cell = row[field];
                         if (cell == null)
                         {
-                            return new MassEditResult(MassEditResultType.OPERATIONERROR, $@"Could not locate field {field}");
+                            return (new MassEditResult(MassEditResultType.OPERATIONERROR, $@"Could not locate field {field}"), null);
                         }
                         // Array types are unhandled
                         if (cell.Value.GetType().IsArray)
                             continue;
                         object newval = PerformOperation(cell, "=", value);
                         if (newval == null)
-                            return new MassEditResult(MassEditResultType.OPERATIONERROR, $@"Could not assign {value} to field {cell.Def.InternalName}");
+                            return (new MassEditResult(MassEditResultType.OPERATIONERROR, $@"Could not assign {value} to field {cell.Def.InternalName}"), null);
                         if (!cell.Value.Equals(newval))
                             actions.Add(new PropertiesChangedAction(cell.GetType().GetProperty("Value"), -1, cell, newval));
                     }
                 }
                 changeCount = actions.Count;
-                if (changeCount != 0)
-                    actionManager.ExecuteAction(new CompoundAction(actions));
-                return new MassEditResult(MassEditResultType.SUCCESS, $@"{changeCount} rows affected");
+                return (new MassEditResult(MassEditResultType.SUCCESS, $@"{changeCount} rows affected"), new CompoundAction(actions));
             }
             catch
             {
-                return new MassEditResult(MassEditResultType.PARSEERROR, "Unable to parse CSV into correct data types");
+                return (new MassEditResult(MassEditResultType.PARSEERROR, "Unable to parse CSV into correct data types"), null);
             }
         }
     }
 
     public class MassParamEditOther
     {
-        public static void SortRows(string paramName, ActionManager manager)
+        public static AddParamsAction SortRows(string paramName)
         {
             PARAM param = ParamBank.Params[paramName];
             List<PARAM.Row> newRows = new List<PARAM.Row>(param.Rows.ToArray());
             newRows.Sort((PARAM.Row a, PARAM.Row b)=>{return a.ID - b.ID;});
-            manager.ExecuteAction(new AddParamsAction(param, paramName, newRows, true, true, false)); //appending same params and allowing overwrite
+            return new AddParamsAction(param, paramName, newRows, true, true, false); //appending same params and allowing overwrite
         }
     }
 }

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -178,8 +178,9 @@ namespace StudioCore.ParamEditor
 
             if (!File.Exists($@"{dir}\\param\gameparam\{paramBinderName}"))
             {
-                MessageBox.Show("Could not find DES regulation file. Functionality will be limited.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return null;
+                //MessageBox.Show("Could not find DES regulation file. Functionality will be limited.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                //return null;
+                throw new FileNotFoundException("Could not find DES regulation file. Functionality will be limited.");
             }
 
             // Load params
@@ -209,8 +210,9 @@ namespace StudioCore.ParamEditor
             var mod = AssetLocator.GameModDirectory;
             if (!File.Exists($@"{dir}\\param\GameParam\GameParam.parambnd"))
             {
-                MessageBox.Show("Could not find DS1 regulation file. Functionality will be limited.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return null;
+                //MessageBox.Show("Could not find DS1 regulation file. Functionality will be limited.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                //return null;
+                throw new FileNotFoundException("Could not find DS1 regulation file. Functionality will be limited.");
             }
 
             // Load params
@@ -235,8 +237,9 @@ namespace StudioCore.ParamEditor
             var mod = AssetLocator.GameModDirectory;
             if (!File.Exists($@"{dir}\\param\GameParam\GameParam.parambnd.dcx"))
             {
-                MessageBox.Show("Could not find DS1 regulation file. Functionality will be limited.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return null;
+                //MessageBox.Show("Could not find DS1 regulation file. Functionality will be limited.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                //return null;
+                throw new FileNotFoundException("Could not find DS1 regulation file. Functionality will be limited.");
             }
 
             // Load params
@@ -261,8 +264,9 @@ namespace StudioCore.ParamEditor
             var mod = AssetLocator.GameModDirectory;
             if (!File.Exists($@"{dir}\\param\gameparam\gameparam.parambnd.dcx"))
             {
-                MessageBox.Show("Could not find param file. Functionality will be limited.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return null;
+                //MessageBox.Show("Could not find param file. Functionality will be limited.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                //return null;
+                throw new FileNotFoundException("Could not find param file. Functionality will be limited.");
             }
 
             // Load params
@@ -305,8 +309,9 @@ namespace StudioCore.ParamEditor
             var mod = AssetLocator.GameModDirectory;
             if (!File.Exists($@"{dir}\enc_regulation.bnd.dcx"))
             {
-                MessageBox.Show("Could not find DS2 regulation file. Functionality will be limited.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return null;
+                //MessageBox.Show("Could not find DS2 regulation file. Functionality will be limited.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                //return null;
+                throw new FileNotFoundException("Could not find DS2 regulation file. Functionality will be limited.");
             }
             if (!BND4.Is($@"{dir}\enc_regulation.bnd.dcx"))
             {
@@ -433,8 +438,9 @@ namespace StudioCore.ParamEditor
             var mod = AssetLocator.GameModDirectory;
             if (!File.Exists($@"{dir}\Data0.bdt"))
             {
-                MessageBox.Show("Could not find DS3 regulation file. Functionality will be limited.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return null;
+                //MessageBox.Show("Could not find DS3 regulation file. Functionality will be limited.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                //return null;
+                throw new FileNotFoundException("Could not find DS3 regulation file. Functionality will be limited.");
             }
 
             var vparam = $@"{dir}\Data0.bdt";
@@ -472,8 +478,9 @@ namespace StudioCore.ParamEditor
             var mod = AssetLocator.GameModDirectory;
             if (!File.Exists($@"{dir}\\regulation.bin"))
             {
-                MessageBox.Show("Could not find param file. Functionality will be limited.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return null;
+                //MessageBox.Show("Could not find param file. Functionality will be limited.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                //return null;
+                throw new FileNotFoundException("Could not find param file. Functionality will be limited.");
             }
 
             // Load params

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -110,10 +110,11 @@ namespace StudioCore.ParamEditor
             }
         }
 
-        public static void LoadParamDefaultNames()
+        public static CompoundAction LoadParamDefaultNames()
         {
             var dir = AssetLocator.GetParamNamesDir();
             var files = Directory.GetFiles(dir, "*.txt");
+            List<EditorAction> actions = new List<EditorAction>();
             while (IsLoadingParams); //super hack
                 Thread.Sleep(100);
             foreach (var f in files)
@@ -124,8 +125,15 @@ namespace StudioCore.ParamEditor
                 if (!_params.ContainsKey(param))
                     continue;
                 string names = File.ReadAllText(f);
-                MassEditResult r = MassParamEditCSV.PerformSingleMassEdit(names, new ActionManager(), param, "Name", true);
+                (MassEditResult r, CompoundAction a) = MassParamEditCSV.PerformSingleMassEdit(names, param, "Name", true);
+                actions.Add(a);
             }
+            return new CompoundAction(actions);
+        }
+        public static ActionManager TrimNewlineChrsFromNames()
+        {
+            (MassEditResult r, ActionManager child) = MassParamEditRegex.PerformMassEdit("param .*: id .*: name: replace \r:0", null, null);
+            return child;
         }
 
         private static void LoadParamFromBinder(IBinder parambnd, ref Dictionary<string, PARAM> paramBank)

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -526,94 +526,91 @@ namespace StudioCore.ParamEditor
         {
             _paramdefs = new Dictionary<string, PARAMDEF>();
             _params = new Dictionary<string, PARAM>();
-            _vanillaParams = new Dictionary<string, PARAM>();
             IsDefsLoaded = false;
-            IsMetaLoaded = false;
             IsLoadingParams = true;
-            IsLoadingVParams = true;
-
-            TaskManager.Run("PB:LoadParams", true, false, () =>
+            
+            if (AssetLocator.Type != GameType.Undefined)
             {
-                if (AssetLocator.Type != GameType.Undefined)
+                List<(string, PARAMDEF)> defPairs = LoadParamdefs();
+                IsDefsLoaded = true;
+                TaskManager.Run("PB:LoadParamMeta", true, false, false, () =>
                 {
-                    List<(string, PARAMDEF)> defPairs = LoadParamdefs();
-                    IsDefsLoaded = true;
-                    TaskManager.Run("PB:LoadParamMeta", true, false, () =>
-                    {
-                        LoadParamMeta(defPairs);
-                        IsMetaLoaded = true;
-                    });
-                }
-                string vparamDir = null;
-                if (AssetLocator.Type == GameType.DemonsSouls)
-                {
-                    vparamDir = LoadParamsDES();
-                }
-                if (AssetLocator.Type == GameType.DarkSoulsPTDE)
-                {
-                    vparamDir = LoadParamsDS1();
-                }
-                if (AssetLocator.Type == GameType.DarkSoulsRemastered)
-                {
-                    vparamDir = LoadParamsDS1R();
-                }
-                if (AssetLocator.Type == GameType.DarkSoulsIISOTFS)
-                {
-                    vparamDir = LoadParamsDS2();
-                }
-                if (AssetLocator.Type == GameType.DarkSoulsIII)
-                {
-                    vparamDir = LoadParamsDS3();
-                }
-                if (AssetLocator.Type == GameType.Bloodborne || AssetLocator.Type == GameType.Sekiro)
-                {
-                    vparamDir = LoadParamsBBSekrio();
-                }
-                if (AssetLocator.Type == GameType.EldenRing)
-                {
-                    vparamDir = LoadParamsER(settings.PartialParams);
-                }
-                _paramDirtyCache = new Dictionary<string, HashSet<int>>();
-                foreach (string param in _params.Keys)
-                    _paramDirtyCache.Add(param, new HashSet<int>());
-                IsLoadingParams = false;
+                    IsMetaLoaded = false;
+                    LoadParamMeta(defPairs);
+                    IsMetaLoaded = true;
+                });
+            }
+            string vparamDir = null;
+            if (AssetLocator.Type == GameType.DemonsSouls)
+            {
+                vparamDir = LoadParamsDES();
+            }
+            if (AssetLocator.Type == GameType.DarkSoulsPTDE)
+            {
+                vparamDir = LoadParamsDS1();
+            }
+            if (AssetLocator.Type == GameType.DarkSoulsRemastered)
+            {
+                vparamDir = LoadParamsDS1R();
+            }
+            if (AssetLocator.Type == GameType.DarkSoulsIISOTFS)
+            {
+                vparamDir = LoadParamsDS2();
+            }
+            if (AssetLocator.Type == GameType.DarkSoulsIII)
+            {
+                vparamDir = LoadParamsDS3();
+            }
+            if (AssetLocator.Type == GameType.Bloodborne || AssetLocator.Type == GameType.Sekiro)
+            {
+                vparamDir = LoadParamsBBSekrio();
+            }
+            if (AssetLocator.Type == GameType.EldenRing)
+            {
+                vparamDir = LoadParamsER(settings.PartialParams);
+            }
 
-                if (vparamDir != null)
-                {
-                    TaskManager.Run("PB:LoadVParams", true, false, () => {
-                        if (AssetLocator.Type == GameType.DemonsSouls)
-                        {
-                            LoadVParamsDES(vparamDir);
-                        }
-                        if (AssetLocator.Type == GameType.DarkSoulsPTDE)
-                        {
-                            LoadVParamsDS1(vparamDir);
-                        }
-                        if (AssetLocator.Type == GameType.DarkSoulsRemastered)
-                        {
-                            LoadVParamsDS1R(vparamDir);
-                        }
-                        if (AssetLocator.Type == GameType.DarkSoulsIISOTFS)
-                        {
-                            LoadVParamsDS2(vparamDir);
-                        }
-                        if (AssetLocator.Type == GameType.DarkSoulsIII)
-                        {
-                            LoadVParamsDS3(vparamDir);
-                        }
-                        if (AssetLocator.Type == GameType.Bloodborne || AssetLocator.Type == GameType.Sekiro)
-                        {
-                            LoadVParamsBBSekrio(vparamDir);
-                        }
-                        if (AssetLocator.Type == GameType.EldenRing)
-                        {
-                            LoadVParamsER(vparamDir);
-                        }
-                        IsLoadingVParams = false;
-                        TaskManager.Run("PB:RefreshDirtyCache", false, true, () => refreshParamDirtyCache());
-                    });
-                }
-            });
+            if (vparamDir != null)
+            {
+                IsLoadingVParams = true;
+                _vanillaParams = new Dictionary<string, PARAM>();
+                TaskManager.Run("PB:LoadVParams", true, false, false, () => {
+                    if (AssetLocator.Type == GameType.DemonsSouls)
+                    {
+                        LoadVParamsDES(vparamDir);
+                    }
+                    if (AssetLocator.Type == GameType.DarkSoulsPTDE)
+                    {
+                        LoadVParamsDS1(vparamDir);
+                    }
+                    if (AssetLocator.Type == GameType.DarkSoulsRemastered)
+                    {
+                        LoadVParamsDS1R(vparamDir);
+                    }
+                    if (AssetLocator.Type == GameType.DarkSoulsIISOTFS)
+                    {
+                        LoadVParamsDS2(vparamDir);
+                    }
+                    if (AssetLocator.Type == GameType.DarkSoulsIII)
+                    {
+                        LoadVParamsDS3(vparamDir);
+                    }
+                    if (AssetLocator.Type == GameType.Bloodborne || AssetLocator.Type == GameType.Sekiro)
+                    {
+                        LoadVParamsBBSekrio(vparamDir);
+                    }
+                    if (AssetLocator.Type == GameType.EldenRing)
+                    {
+                        LoadVParamsER(vparamDir);
+                    }
+                    IsLoadingVParams = false;
+                });
+            }
+
+            _paramDirtyCache = new Dictionary<string, HashSet<int>>();
+            foreach (string param in _params.Keys)
+                _paramDirtyCache.Add(param, new HashSet<int>());
+            IsLoadingParams = false;
         }
 
         public static void refreshParamDirtyCache()

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -344,7 +344,7 @@ namespace StudioCore.ParamEditor
                     {
                         _lastMEditRegexInput = _currentMEditRegexInput;
                         _currentMEditRegexInput = "";
-                        TaskManager.Run("PB:RefreshDirtyCache", false, true, () => ParamBank.refreshParamDirtyCache());
+                        TaskManager.Run("PB:RefreshDirtyCache", false, true, true, () => ParamBank.refreshParamDirtyCache());
                     }
                     _mEditRegexResult = r.Information;
                 }
@@ -374,7 +374,7 @@ namespace StudioCore.ParamEditor
                     MassEditResult r = MassParamEditCSV.PerformMassEdit(_currentMEditCSVInput, EditorActionManager, _activeView._selection.getActiveParam(), _mEditCSVAppendOnly, _mEditCSVAppendOnly && _mEditCSVReplaceRows);
                     if (r.Type == MassEditResultType.SUCCESS)
                     {
-                        TaskManager.Run("PB:RefreshDirtyCache", false, true, () => ParamBank.refreshParamDirtyCache());
+                        TaskManager.Run("PB:RefreshDirtyCache", false, true, true, () => ParamBank.refreshParamDirtyCache());
                     }
                     _mEditCSVResult = r.Information;
                 }
@@ -411,12 +411,12 @@ namespace StudioCore.ParamEditor
                 if (EditorActionManager.CanUndo() && InputTracker.GetControlShortcut(Key.Z))
                 {
                     EditorActionManager.UndoAction();
-                    TaskManager.Run("PB:RefreshDirtyCache", false, true, () => ParamBank.refreshParamDirtyCache());
+                    TaskManager.Run("PB:RefreshDirtyCache", false, true, true, () => ParamBank.refreshParamDirtyCache());
                 }
                 if (EditorActionManager.CanRedo() && InputTracker.GetControlShortcut(Key.Y))
                 {
                     EditorActionManager.RedoAction();
-                    TaskManager.Run("PB:RefreshDirtyCache", false, true, () => ParamBank.refreshParamDirtyCache());
+                    TaskManager.Run("PB:RefreshDirtyCache", false, true, true, () => ParamBank.refreshParamDirtyCache());
                 }
                 if (!ImGui.IsAnyItemActive() && _activeView._selection.paramSelectionExists() && InputTracker.GetControlShortcut(Key.A))
                 {

--- a/StudioCore/TextEditor/FMGBank.cs
+++ b/StudioCore/TextEditor/FMGBank.cs
@@ -495,6 +495,8 @@ namespace StudioCore.TextEditor
 
         public static void SaveFMGs()
         {
+            if (!IsLoaded)
+                return;
             if (AssetLocator.Type == GameType.Undefined)
             {
                 return;

--- a/StudioCore/TextEditor/FMGBank.cs
+++ b/StudioCore/TextEditor/FMGBank.cs
@@ -452,41 +452,37 @@ namespace StudioCore.TextEditor
         {
             IsLoaded = false;
             IsLoading = true;
-
-            TaskManager.Run("FB:Reload", true, false, () =>
+            if (AssetLocator.Type == GameType.Undefined)
             {
-                if (AssetLocator.Type == GameType.Undefined)
-                {
-                    return;
-                }
+                return;
+            }
 
-                if (AssetLocator.Type == GameType.DarkSoulsIISOTFS)
-                {
-                    ReloadFMGsDS2();
-                    IsLoading = false;
-                    IsLoaded = true;
-                    return;
-                }
-
-                IBinder fmgBinder;
-                var desc = AssetLocator.GetEnglishItemMsgbnd();
-                if (AssetLocator.Type == GameType.DemonsSouls || AssetLocator.Type == GameType.DarkSoulsPTDE || AssetLocator.Type == GameType.DarkSoulsRemastered)
-                {
-                    fmgBinder = BND3.Read(desc.AssetPath);
-                }
-                else
-                {
-                    fmgBinder = BND4.Read(desc.AssetPath);
-                }
-
-                _fmgs = new Dictionary<ItemFMGTypes, FMG>();
-                foreach (var file in fmgBinder.Files)
-                {
-                    _fmgs.Add((ItemFMGTypes)file.ID, FMG.Read(file.Bytes));
-                }
-                IsLoaded = true;
+            if (AssetLocator.Type == GameType.DarkSoulsIISOTFS)
+            {
+                ReloadFMGsDS2();
                 IsLoading = false;
-            });
+                IsLoaded = true;
+                return;
+            }
+
+            IBinder fmgBinder;
+            var desc = AssetLocator.GetEnglishItemMsgbnd();
+            if (AssetLocator.Type == GameType.DemonsSouls || AssetLocator.Type == GameType.DarkSoulsPTDE || AssetLocator.Type == GameType.DarkSoulsRemastered)
+            {
+                fmgBinder = BND3.Read(desc.AssetPath);
+            }
+            else
+            {
+                fmgBinder = BND4.Read(desc.AssetPath);
+            }
+
+            _fmgs = new Dictionary<ItemFMGTypes, FMG>();
+            foreach (var file in fmgBinder.Files)
+            {
+                _fmgs.Add((ItemFMGTypes)file.ID, FMG.Read(file.Bytes));
+            }
+            IsLoaded = true;
+            IsLoading = false;
         }
 
         public static void SaveFMGsDS2()


### PR DESCRIPTION
Adds live task management and task error viewing, as well as replacing the error output on existing usages.
As a result, enables running Mapstudio without extracting install (only param editor will be functional)

Some other PRs may depend on this, so this should probably be the first merge.