### PR TITLE
Add bounds check for selections

### DIFF
--- a/StudioCore/Scene/SceneRenderPipeline.cs
+++ b/StudioCore/Scene/SceneRenderPipeline.cs
@@ -183,10 +183,15 @@ namespace StudioCore.Scene
             WeakReference<ISelectable> sel;
             if (renderableSystemIndex == 0)
             {
+                // TODO: Logging?
+                if ((_pickingEntity & 0x3FFFFFFF) >= Scene.OpaqueRenderables.cSelectables.Length)
+                    return null;
                 sel = Scene.OpaqueRenderables.cSelectables[_pickingEntity & 0x3FFFFFFF];
             }
             else
             {
+                if ((_pickingEntity & 0x3FFFFFFF) >= Scene.OverlayRenderables.cSelectables.Length)
+                    return null;
                 sel = Scene.OverlayRenderables.cSelectables[_pickingEntity & 0x3FFFFFFF];
             }
             ISelectable selected;


### PR DESCRIPTION
For whatever reason we're sometimes getting out of bounds indices for selections. Root causing this will take some effort but in the meantime checking the bounds should help.