### PR TITLE
fix poor handling of 16-bit indices

### DIFF
--- a/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/FaceSet.cs
+++ b/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/FaceSet.cs
@@ -138,7 +138,7 @@ namespace SoulsFormats
                     Indices = new int[indexCount];
                     for (int i = 0; i < indexCount; i++)
                     {
-                        Indices[i] = br.ReadInt16();
+                        Indices[i] = br.ReadUInt16();
                     }
                     br.StepOut();
 

--- a/StudioCore/Resource/FlverResource.cs
+++ b/StudioCore/Resource/FlverResource.cs
@@ -1512,6 +1512,7 @@ namespace StudioCore.Resource
             foreach (var fsidx in facesetIndices)
             {
                 indicesTotal += facesets[fsidx].indexCount;
+                is32bit = is32bit || facesets[fsidx].indexSize != 16;
             }
             if (is32bit)
             {
@@ -1560,33 +1561,30 @@ namespace StudioCore.Resource
                 }
 
                 br.StepIn(faceset.indicesOffset);
-                if (is32bit)
+                for (int i = 0; i < faceset.indexCount; i++)
                 {
-                    for (int i = 0; i < faceset.indexCount; i++)
+                    if (faceset.indexSize == 16)
                     {
-                        int idx = br.ReadInt32();
-                        if (idx == 0xFFFF && idx > vertexCount)
+                        var idx = br.ReadUInt16();
+                        if (is32bit)
+                        {
+                            fs32[newFaceSet.IndexOffset + i] = (idx == 0xFFFF ? -1 : idx);
+                        }
+                        else
+                        {
+                            fs16[newFaceSet.IndexOffset + i] = idx;
+                        }
+                    }
+                    else
+                    {
+                        var idx = br.ReadInt32();
+                        if (idx > vertexCount)
                         {
                             fs32[newFaceSet.IndexOffset + i] = -1;
                         }
                         else
                         {
                             fs32[newFaceSet.IndexOffset + i] = idx;
-                        }
-                    }
-                }
-                else
-                {
-                    for (int i = 0; i < faceset.indexCount; i++)
-                    {
-                        ushort idx = br.ReadUInt16();
-                        if (idx == 0xFFFF && idx > vertexCount)
-                        {
-                            fs16[newFaceSet.IndexOffset + i] = 0xFFFF;
-                        }
-                        else
-                        {
-                            fs16[newFaceSet.IndexOffset + i] = idx;
                         }
                     }
                 }


### PR DESCRIPTION
Both soulsformats flver and map studio flver didn't handle 16-bit indices well once it increases past a certain size. This should make sure 16-bit and 32-bit indices are handled right no matter the destination buffer size.