### PR TITLE
Add preliminary support for loading map pieces in the model editor

### DIFF
--- a/StudioCore/AssetLocator.cs
+++ b/StudioCore/AssetLocator.cs
@@ -331,8 +331,9 @@ namespace StudioCore
                 }
             }
             var mapRegex = new Regex(@"^m\d{2}_\d{2}_\d{2}_\d{2}$");
-            FullMapList = mapSet.Where(x => mapRegex.IsMatch(x)).ToList();
-            FullMapList.Sort();
+            var mapList = mapSet.Where(x => mapRegex.IsMatch(x)).ToList();
+            mapList.Sort();
+            FullMapList = mapList;
             return FullMapList;
         }
 
@@ -696,6 +697,8 @@ namespace StudioCore
             var ret = new List<AssetDescription>();
             if (Type == GameType.DarkSoulsIII || Type == GameType.Sekiro)
             {
+                if (!Directory.Exists(GameRootDirectory + $@"\map\{mapid}\"))
+                    return ret;
                 var mapfiles = Directory.GetFileSystemEntries(GameRootDirectory + $@"\map\{mapid}\", @"*.mapbnd.dcx").ToList();
                 foreach (var f in mapfiles)
                 {
@@ -718,6 +721,8 @@ namespace StudioCore
             }
             else
             {
+                if (!Directory.Exists(GameRootDirectory + $@"\map\{mapid}\"))
+                    return ret;
                 var ext = Type == GameType.DarkSoulsPTDE ? @"*.flver" : @"*.flver.dcx";
                 var mapfiles = Directory.GetFileSystemEntries(GameRootDirectory + $@"\map\{mapid}\", ext).ToList();
                 foreach (var f in mapfiles)
@@ -751,6 +756,28 @@ namespace StudioCore
             return $@"{mapid}_{modelname.Substring(1)}";
         }
 
+        /// <summary>
+        /// Gets the adjusted map ID that contains all the map assets
+        /// </summary>
+        /// <param name="mapid">The msb map ID to adjust</param>
+        /// <returns>The map ID for the purpose of asset storage</returns>
+        public string GetAssetMapID(string mapid)
+        {
+            var amapid = mapid.Substring(0, 6) + "_00_00";
+            if (Type == GameType.EldenRing)
+            {
+                // Elden Ring all maps have their own assets
+                amapid = mapid;
+            }
+            // Special case for chalice dungeon assets
+            if (mapid.StartsWith("m29"))
+            {
+                amapid = "m29_00_00_00";
+            }
+
+            return amapid;
+        }
+        
         public AssetDescription GetMapModel(string mapid, string model)
         {
             var ret = new AssetDescription();

--- a/StudioCore/MsbEditor/AssetBrowser.cs
+++ b/StudioCore/MsbEditor/AssetBrowser.cs
@@ -9,6 +9,7 @@ namespace StudioCore.MsbEditor
     {
         public void OnInstantiateChr(string chrid);
         public void OnInstantiateObj(string objid);
+        public void OnInstantiateMapPiece(string mapid, string modelid);
     }
 
     public class AssetBrowser
@@ -17,6 +18,7 @@ namespace StudioCore.MsbEditor
 
         private List<string> _chrCache = new List<string>();
         private List<string> _objCache = new List<string>();
+        private Dictionary<string, List<string>> _mapModelCache = new Dictionary<string, List<string>>();
 
         private AssetLocator _locator;
 
@@ -37,6 +39,21 @@ namespace StudioCore.MsbEditor
             _objCache = new List<string>();
             _chrCache = _locator.GetChrModels();
             _objCache = _locator.GetObjModels();
+            var mapList = _locator.GetFullMapList();
+            foreach (var m in mapList)
+            {
+                var adjm = _locator.GetAssetMapID(m);
+                if (!_mapModelCache.ContainsKey(adjm))
+                {
+                    var modelList = _locator.GetMapModels(adjm);
+                    var cache = new List<string>();
+                    foreach (var model in modelList)
+                    {
+                        cache.Add(model.AssetName);
+                    }
+                    _mapModelCache.Add(adjm, cache);
+                }
+            }
         }
 
 
@@ -53,6 +70,14 @@ namespace StudioCore.MsbEditor
                 if (ImGui.Selectable("Obj", _selected == "Obj"))
                 {
                     _selected = "Obj";
+                }
+
+                foreach (var m in _mapModelCache.Keys)
+                {
+                    if (ImGui.Selectable(m, _selected == m))
+                    {
+                        _selected = m;
+                    }
                 }
                 ImGui.EndChild();
                 ImGui.NextColumn();
@@ -80,6 +105,23 @@ namespace StudioCore.MsbEditor
                         if (ImGui.IsItemClicked() && ImGui.IsMouseDoubleClicked(0))
                         {
                             _handler.OnInstantiateObj(obj);
+                        }
+                    }
+                }
+                else if (_selected != null && _selected.StartsWith("m"))
+                {
+                    if (_mapModelCache.ContainsKey(_selected))
+                    {
+                        foreach (var model in _mapModelCache[_selected])
+                        {
+                            if (ImGui.Selectable(model))
+                            {
+                            }
+
+                            if (ImGui.IsItemClicked() && ImGui.IsMouseDoubleClicked(0))
+                            {
+                                _handler.OnInstantiateMapPiece(_selected, model);
+                            }
                         }
                     }
                 }

--- a/StudioCore/MsbEditor/ModelEditorScreen.cs
+++ b/StudioCore/MsbEditor/ModelEditorScreen.cs
@@ -109,7 +109,7 @@ namespace StudioCore.MsbEditor
             
         }
 
-        public void LoadModel(string modelid)
+        public void LoadModel(string modelid, string mapid = null)
         {
             AssetDescription asset;
             AssetDescription assettex;
@@ -123,6 +123,11 @@ namespace StudioCore.MsbEditor
             else if (modelid.StartsWith("o") || modelid.StartsWith("aeg"))
             {
                 asset = AssetLocator.GetObjModel(modelid);
+                assettex = AssetLocator.GetNullAsset();
+            }
+            else if (modelid.StartsWith("m"))
+            {
+                asset = AssetLocator.GetMapModel(mapid, modelid);
                 assettex = AssetLocator.GetNullAsset();
             }
             else
@@ -171,6 +176,11 @@ namespace StudioCore.MsbEditor
         public void OnInstantiateObj(string objid)
         {
             LoadModel(objid);
+        }
+
+        public void OnInstantiateMapPiece(string mapid, string modelid)
+        {
+            LoadModel(modelid, mapid);
         }
 
         public void OnGUI()

--- a/StudioCore/MsbEditor/Universe.cs
+++ b/StudioCore/MsbEditor/Universe.cs
@@ -565,17 +565,7 @@ namespace StudioCore.MsbEditor
             }
             map.LoadMSB(msb);
 
-            var amapid = mapid.Substring(0, 6) + "_00_00";
-            if (_assetLocator.Type == GameType.EldenRing)
-            {
-                // Elden Ring all maps have their own assets
-                amapid = mapid;
-            }
-            // Special case for chalice dungeon assets
-            if (mapid.StartsWith("m29"))
-            {
-                amapid = "m29_00_00_00";
-            }
+            var amapid = _assetLocator.GetAssetMapID(mapid);
 
             foreach (var model in msb.Models.GetEntries())
             {


### PR DESCRIPTION
Add preliminary support for map pieces in the model editor. This is useful for debugging or just seeing what some of the map piece flvers look like inside.