### PR TITLE
Don't create a byte[] array for every UTF16 codepoint

### DIFF
--- a/SoulsFormats/SoulsFormats/Util/BinaryReaderEx.cs
+++ b/SoulsFormats/SoulsFormats/Util/BinaryReaderEx.cs
@@ -982,12 +982,14 @@ namespace SoulsFormats
         public string ReadUTF16()
         {
             List<byte> bytes = new List<byte>();
-            byte[] pair = ReadBytes(2);
-            while (pair[0] != 0 || pair[1] != 0)
+            byte a = ReadByte();
+            byte b = ReadByte();
+            while (a != 0 || b != 0)
             {
-                bytes.Add(pair[0]);
-                bytes.Add(pair[1]);
-                pair = ReadBytes(2);
+                bytes.Add(a);
+                bytes.Add(b);
+                a = ReadByte(); 
+                b = ReadByte();
             }
 
             if (BigEndian)


### PR DESCRIPTION
This optimizes ReadUTF16, previously a huge source of temporary allocations that had to be GCed, to not need all the allocations and improves loading performance significantly.