### PR TITLE
MSB map object list multi-select improvements

### DIFF
--- a/StudioCore/Gui/Viewport.cs
+++ b/StudioCore/Gui/Viewport.cs
@@ -254,7 +254,7 @@ namespace StudioCore.Gui
                 if (_viewPipeline.PickingResultsReady)
                 {
                     var sel = _viewPipeline.GetSelection();
-                    if (InputTracker.GetKey(Key.ShiftLeft) || InputTracker.GetKey(Key.ShiftRight))
+                    if (InputTracker.GetKey(Key.ShiftLeft) || InputTracker.GetKey(Key.ShiftRight) || InputTracker.GetKey(Key.ControlLeft) || InputTracker.GetKey(Key.ControlRight))
                     {
                         if (sel != null)
                         {

--- a/StudioCore/MsbEditor/SceneTree.cs
+++ b/StudioCore/MsbEditor/SceneTree.cs
@@ -247,9 +247,13 @@ namespace StudioCore.MsbEditor
                 _pendingClick = null;
             }
 
-            if (ImGui.IsItemFocused() && !_selection.IsSelected(e))
+            // Up/Down arrow mass selection
+            bool arrowKeySelect = false;
+            if (ImGui.IsItemFocused() && !_selection.IsSelected(e) 
+                && (InputTracker.GetKey(Key.Up) || InputTracker.GetKey(Key.Down)))
             {
                 doSelect = true;
+                arrowKeySelect = true;
             }
 
             if (hierarchial && doSelect)
@@ -327,12 +331,45 @@ namespace StudioCore.MsbEditor
             // If the visibility icon wasn't clicked actually perform the selection
             if (doSelect)
             {
-                if (InputTracker.GetKey(Key.ControlLeft) || InputTracker.GetKey(Key.ControlRight))
+                if (arrowKeySelect)
                 {
                     _selection.AddSelection(e);
                 }
+                else if (InputTracker.GetKey(Key.ControlLeft) || InputTracker.GetKey(Key.ControlRight))
+                {
+                    // Toggle Selection
+                    if (_selection.GetSelection().Contains(e))
+                    {
+                        _selection.RemoveSelection(e);
+                    }
+                    else
+                    {
+                        _selection.AddSelection(e);
+                    }
+                }
+                else if (_selection.GetSelection().Count > 0 
+                    && (InputTracker.GetKey(Key.ShiftLeft) || InputTracker.GetKey(Key.ShiftRight)))
+                {
+                    // Select Range
+                    var entList = e.Container.Objects;
+                    var i1 = entList.IndexOf((MapEntity)_selection.GetSelection().First());
+                    var i2 = entList.IndexOf((MapEntity)e);
+
+                    var iStart = i1;
+                    var iEnd = i2;
+                    if (i2 < i1)
+                    {
+                        iStart = i2;
+                        iEnd = i1;
+                    }
+                    for (var i = iStart; i <= iEnd; i++)
+                    {
+                        _selection.AddSelection(entList[i]);
+                    }
+                }
                 else
                 {
+                    // Exclusive Selection
                     _selection.ClearSelection();
                     _selection.AddSelection(e);
                 }

--- a/StudioCore/MsbEditor/SceneTree.cs
+++ b/StudioCore/MsbEditor/SceneTree.cs
@@ -352,19 +352,26 @@ namespace StudioCore.MsbEditor
                 {
                     // Select Range
                     var entList = e.Container.Objects;
-                    var i1 = entList.IndexOf((MapEntity)_selection.GetSelection().First());
+                    var i1 = entList.IndexOf((MapEntity)_selection.GetSelection().FirstOrDefault(fe => ((MapEntity)fe).Container == e.Container));
                     var i2 = entList.IndexOf((MapEntity)e);
 
-                    var iStart = i1;
-                    var iEnd = i2;
-                    if (i2 < i1)
+                    if (i1 != -1 && i2 != -1)
                     {
-                        iStart = i2;
-                        iEnd = i1;
+                        var iStart = i1;
+                        var iEnd = i2;
+                        if (i2 < i1)
+                        {
+                            iStart = i2;
+                            iEnd = i1;
+                        }
+                        for (var i = iStart; i <= iEnd; i++)
+                        {
+                            _selection.AddSelection(entList[i]);
+                        }
                     }
-                    for (var i = iStart; i <= iEnd; i++)
+                    else
                     {
-                        _selection.AddSelection(entList[i]);
+                        _selection.AddSelection(e);
                     }
                 }
                 else

--- a/StudioCore/MsbEditor/Selection.cs
+++ b/StudioCore/MsbEditor/Selection.cs
@@ -130,6 +130,14 @@ namespace StudioCore.MsbEditor
             }
         }
 
+        public void RemoveSelection(Scene.ISelectable selected)
+        {
+            if (selected != null)
+            {
+                selected.OnDeselected();
+                _selected.Remove(selected);
+            }
+        }
         public bool IsSelected(Scene.ISelectable selected)
         {
             foreach (var sel in _selected)


### PR DESCRIPTION
Adds the following functionality:
Ctrl+Click toggles target selection while preserving existing non-target selection.
Shift+Click selects all objects between existing selection and targeted selection.