### PR TITLE
Allow prop search to search dummy8

### DIFF
--- a/StudioCore/ParamEditor/SearchEngine.cs
+++ b/StudioCore/ParamEditor/SearchEngine.cs
@@ -187,6 +187,8 @@ namespace StudioCore.Editor
                 return noContext((row)=>{
                         PARAM.Cell c = row[field];
                         string term = c.Value.ToString();
+                        if (c.Def.InternalType=="dummy8")
+                            term = ParamUtils.Dummy8Write((byte[])c.Value);
                         return rx.Match(term).Success;
                 });
             }));


### PR DESCRIPTION
Allows prop search to search dummy8 fields (maybe considered a fix as prior behaviour would match "System.Byte[]")