### PR TITLE
Fix/param diff issues

### DIFF
--- a/FSParam/Param.cs
+++ b/FSParam/Param.cs
@@ -121,7 +121,7 @@ namespace FSParam
             Flag80 = 0b1000_0000,
         }
 
-        public class Row : IEquatable<Row>
+        public class Row
         {
             internal Param Parent;
             public int ID { get; set; }
@@ -180,7 +180,7 @@ namespace FSParam
                 clone.Parent._paramData.CopyData(Parent._paramData, DataIndex, clone.DataIndex);
             }
 
-            public bool Equals(Row? other)
+            public bool DataEquals(Row? other)
             {
                 if (other == null)
                     return false;

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -736,7 +736,7 @@ namespace StudioCore.ParamEditor
                 
                 var vanillaIndex = 0;
                 int lastID = -1;
-                Span<Param.Row> lastVanillaRows = default;
+                ReadOnlySpan<Param.Row> lastVanillaRows = default;
                 for (int i = 0; i < rows.Length; i++)
                 {
                     int ID = rows[i].ID;
@@ -746,6 +746,7 @@ namespace StudioCore.ParamEditor
                     }
                     else
                     {
+                        lastID = ID;
                         while (vanillaIndex < vrows.Length && vrows[vanillaIndex].ID < ID)
                             vanillaIndex++;
                         if (vanillaIndex >= vrows.Length)
@@ -757,7 +758,8 @@ namespace StudioCore.ParamEditor
                             int count = 0;
                             while (vanillaIndex + count < vrows.Length && vrows[vanillaIndex + count].ID == ID)
                                 count++;
-                            refreshParamRowDirtyCache(rows[i], new ReadOnlySpan<Param.Row>(vrows, vanillaIndex, count), cache);
+                            lastVanillaRows = new ReadOnlySpan<Param.Row>(vrows, vanillaIndex, count);
+                            refreshParamRowDirtyCache(rows[i], lastVanillaRows, cache);
                             vanillaIndex += count;
                         }
                     }

--- a/StudioCore/ParamEditor/ParamUtils.cs
+++ b/StudioCore/ParamEditor/ParamUtils.cs
@@ -48,7 +48,7 @@ namespace StudioCore.ParamEditor
             if (row.Def != vrow.Def)
                 return false;
             
-            return row.Equals(vrow);
+            return row.DataEquals(vrow);
         }
         public static bool ByteArrayEquals(byte[] v1, byte[] v2) {
             if (v1.Length!=v2.Length)


### PR DESCRIPTION
- Removes Equals for Param.Row
- Fixes diff test for duplicate IDs
- Fixes selection of duplicate rows
- dirtyCache remains ID-bound and a changed row will still cause other unchanged rows with the same ID to be flagged.