### PR TITLE
Fix old type view caches being kept and used when a map is unloaded then re-loaded

### DIFF
--- a/StudioCore/MsbEditor/SceneTree.cs
+++ b/StudioCore/MsbEditor/SceneTree.cs
@@ -758,6 +758,12 @@ namespace StudioCore.MsbEditor
                         ImGui.PopStyleVar();
                         ImGui.TreePop();
                     }
+
+                    // Update type cache when a map is no longer loaded
+                    if (_cachedTypeView != null && map == null && _cachedTypeView.ContainsKey(mapid))
+                    {
+                        _cachedTypeView.Remove(mapid);
+                    }
                 }
                 if (_assetLocator.Type == GameType.Bloodborne && _configuration == Configuration.MapEditor)
                 {


### PR DESCRIPTION
This prevents several bugs from cropping up, including at least one that ends up crashing the program.