### PR TITLE
Remove user-harmful assert

### DIFF
--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PartsParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PartsParam.cs
@@ -473,7 +473,7 @@ namespace SoulsFormats
                 br.AssertByte(0); // Former lantern ID
                 LodParamID = br.ReadByte();
                 UnkE09 = br.ReadByte();
-                IsPointLightShadowSrc = br.AssertSByte(0, -1); // Seems to be 0 or -1
+                IsPointLightShadowSrc = br.ReadSByte(); // Seems to be 0 or -1
                 UnkE0B = br.ReadByte();
                 IsShadowSrc = br.ReadBoolean();
                 IsStaticShadowSrc = br.ReadByte();


### PR DESCRIPTION
This assert allows the user to render an MSB completely inaccessible to SF, as the assert is only checked on MSB read and not write. So an MSB can be saved successfully at first, but upon re-save or re-load (when MSB is read) the assert will render the MSB unusable from then on.