### PR TITLE
Add CFG options related to loaded maps in map list

### DIFF
--- a/StudioCore/CFG.cs
+++ b/StudioCore/CFG.cs
@@ -123,7 +123,10 @@ namespace StudioCore
         public float GFX_Camera_MoveSpeed_Normal { get; set; } = 20.0f;
         public float GFX_Camera_MoveSpeed_Fast { get; set; } = 200.0f;
         public float GFX_RenderDistance_Max { get; set; } = 50000.0f;
-        
+
+        public bool Map_AlwaysListLoadedMaps = true;
+        public bool Map_PinLoadedMaps = true;
+
         // Font settings
         public bool FontChinese = false;
         public bool FontKorean = false;

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -822,6 +822,12 @@ namespace StudioCore
                     {
                         CFG.Current.EnableTexturing = !CFG.Current.EnableTexturing;
                     }
+                    if (ImGui.BeginMenu("Map Editor"))
+                    {
+                        ImGui.Checkbox("Pin loaded maps to top of list", ref CFG.Current.Map_PinLoadedMaps);
+                        ImGui.Checkbox("Exclude loaded maps from search filter", ref CFG.Current.Map_AlwaysListLoadedMaps);
+                        ImGui.EndMenu();
+                    }
                     if (ImGui.BeginMenu("Viewport Settings"))
                     {
                         if (ImGui.Button("Reset"))

--- a/StudioCore/MsbEditor/SceneTree.cs
+++ b/StudioCore/MsbEditor/SceneTree.cs
@@ -582,7 +582,13 @@ namespace StudioCore.MsbEditor
                 if (_configuration == Configuration.MapEditor && _universe.LoadedObjectContainers.Count == 0)
                     ImGui.Text("This Editor requires game to be unpacked");
 
-                foreach (var lm in _universe.LoadedObjectContainers.OrderBy((k) => k.Key))
+                IOrderedEnumerable<KeyValuePair<string, ObjectContainer>> orderedMaps; 
+                if (CFG.Current.Map_PinLoadedMaps)
+                    orderedMaps = _universe.LoadedObjectContainers.OrderBy(k => k.Value == null).ThenBy(k => k.Key);
+                else
+                    orderedMaps = _universe.LoadedObjectContainers.OrderBy(k => k.Key);
+
+                foreach (var lm in orderedMaps)
                 {
                     string metaName = "";
                     var map = lm.Value;
@@ -595,16 +601,13 @@ namespace StudioCore.MsbEditor
                         metaName = Editor.AliasBank.MapNames[mapid];
                     }
 
-                    if (_mapNameSearchStr != "")
+                    // Map name search filter
+                    if (_mapNameSearchStr != ""
+                        && (!CFG.Current.Map_AlwaysListLoadedMaps || map == null)
+                        && !lm.Key.Contains(_mapNameSearchStr, StringComparison.CurrentCultureIgnoreCase)
+                        && !metaName.Contains(_mapNameSearchStr, StringComparison.CurrentCultureIgnoreCase))
                     {
-                        if (lm.Key.Contains(_mapNameSearchStr, StringComparison.CurrentCultureIgnoreCase) || metaName.Contains(_mapNameSearchStr, StringComparison.CurrentCultureIgnoreCase))
-                        { 
-                            //do nothing
-                        }
-                        else
-                        {
-                            continue; //ID not in search filter
-                        }
+                        continue;
                     }
 
                     Entity mapRoot = map?.RootObject;


### PR DESCRIPTION
Adds CFG options for loaded maps to ignore search filter & loaded maps to be pinned to top of map list
(both are currently on by default)