### PR TITLE
Resource loading fixes

### DIFF
--- a/StudioCore/Resource/ResourceLoadPipeline.cs
+++ b/StudioCore/Resource/ResourceLoadPipeline.cs
@@ -67,9 +67,7 @@ public class ResourceLoadPipeline<T> : IResourceLoadPipeline where T : class, IR
             try
             {
                 var res = new T();
-                bool success = false;
-
-                success = res._Load(r.File, r.AccessLevel, r.GameType);
+                bool success = res._Load(r.File, r.AccessLevel, r.GameType);
                 if (success)
                 {
                     _loadedResources.Post(new ResourceLoadedReply(r.VirtualPath, r.AccessLevel, res));

--- a/StudioCore/Resource/ResourceLoadPipeline.cs
+++ b/StudioCore/Resource/ResourceLoadPipeline.cs
@@ -2,6 +2,7 @@
 using System;
 namespace StudioCore.Resource;
 
+using System.IO;
 using System.Threading.Tasks.Dataflow;
 
 public readonly record struct LoadByteResourceRequest(
@@ -66,13 +67,16 @@ public class ResourceLoadPipeline<T> : IResourceLoadPipeline where T : class, IR
             try
             {
                 var res = new T();
-                bool success = res._Load(r.File, r.AccessLevel, r.GameType);
+                bool success = false;
+
+                success = res._Load(r.File, r.AccessLevel, r.GameType);
                 if (success)
                 {
                     _loadedResources.Post(new ResourceLoadedReply(r.VirtualPath, r.AccessLevel, res));
                 }
             }
             catch (System.IO.FileNotFoundException) { }
+            catch (System.IO.DirectoryNotFoundException) { }
         }, options);
     }
 }

--- a/StudioCore/Resource/ResourceManager.cs
+++ b/StudioCore/Resource/ResourceManager.cs
@@ -257,12 +257,11 @@ namespace StudioCore.Resource
                     try
                     {
                         f = TPF.Read(action.Binder.ReadFile(t.Item2));
+                        action._job.AddLoadTPFResources(new LoadTPFResourcesAction(action._job, t.Item1, f, action.AccessLevel, ResourceManager.Locator.Type));
                     }
-                    catch 
-                    {
-                        continue; 
+                    catch  
+                    { 
                     }
-                    action._job.AddLoadTPFResources(new LoadTPFResourcesAction(action._job, t.Item1, f, action.AccessLevel, ResourceManager.Locator.Type));
                     i++;
                 }
             }

--- a/StudioCore/Resource/ResourceManager.cs
+++ b/StudioCore/Resource/ResourceManager.cs
@@ -253,10 +253,9 @@ namespace StudioCore.Resource
 
                 foreach (var t in action.PendingTPFs)
                 {
-                    TPF f = null;
                     try
                     {
-                        f = TPF.Read(action.Binder.ReadFile(t.Item2));
+                        TPF f = TPF.Read(action.Binder.ReadFile(t.Item2));
                         action._job.AddLoadTPFResources(new LoadTPFResourcesAction(action._job, t.Item1, f, action.AccessLevel, ResourceManager.Locator.Type));
                     }
                     catch  

--- a/StudioCore/Resource/ResourceManager.cs
+++ b/StudioCore/Resource/ResourceManager.cs
@@ -253,7 +253,15 @@ namespace StudioCore.Resource
 
                 foreach (var t in action.PendingTPFs)
                 {
-                    var f = TPF.Read(action.Binder.ReadFile(t.Item2));
+                    TPF f = null;
+                    try
+                    {
+                        f = TPF.Read(action.Binder.ReadFile(t.Item2));
+                    }
+                    catch 
+                    {
+                        continue; 
+                    }
                     action._job.AddLoadTPFResources(new LoadTPFResourcesAction(action._job, t.Item1, f, action.AccessLevel, ResourceManager.Locator.Type));
                     i++;
                 }


### PR DESCRIPTION
I think something that happened with resource loading may have made DSMapStudio less stable. TPF resources that don't load are causing hard crashes. DirectoryNotFoundExceptions are also happening because of some of the debug maps referencing directories that just aren't on the disc. 

Specifically, `DemonsSoul\data\Model\obj\o0050\tex\o0050.tpf` fails when loading m99_99_97_00 and a good few of them reference a file in a folder that doesn't exist which ends up giving that exception instead of the FileNotFoundException you cover for.