### PR TITLE
Make gizmo rotation respect GizmoSpace.World with multiple selections

### DIFF
--- a/StudioCore/MsbEditor/Gizmos.cs
+++ b/StudioCore/MsbEditor/Gizmos.cs
@@ -337,10 +337,6 @@ namespace StudioCore.MsbEditor
                         {
                             OriginalTransform.Position = sel.RenderSceneMesh.GetBounds().GetCenter();
                         }
-                        if (Space == GizmosSpace.World)
-                        {
-                            OriginalTransform.Rotation = Quaternion.Identity;
-                        }
                     }
                     else
                     {
@@ -352,6 +348,10 @@ namespace StudioCore.MsbEditor
                             accumPos += sel.GetRootLocalTransform().Position;
                         }
                         OriginalTransform = new Transform(accumPos / (float)_selection.GetSelection().Count, sels.First().GetRootLocalTransform().EulerRotation);
+                    }
+                    if (Space == GizmosSpace.World)
+                    {
+                        OriginalTransform.Rotation = Quaternion.Identity;
                     }
 
                     Axis hoveredAxis = Axis.None;


### PR DESCRIPTION
Fixes Gizmo rotation not being affected when Space is set to World if selection contains more than 1 entity.