### PR TITLE
Make Param Decorators handle dupe FMG entries instead of crashing

### DIFF
--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -59,7 +59,7 @@ namespace StudioCore.ParamEditor
                 var fmgEntries = FMGBank.GetFmgEntriesByType(_category, FMGBank.FmgEntryTextType.Title, false);
                 foreach (var fmgEntry in fmgEntries)
                 {
-                    _entryCache.Add(fmgEntry.ID, fmgEntry);
+                    _entryCache[fmgEntry.ID] = fmgEntry;
                 }
             }
         }

--- a/StudioCore/ParamEditor/SearchEngine.cs
+++ b/StudioCore/ParamEditor/SearchEngine.cs
@@ -253,7 +253,7 @@ namespace StudioCore.Editor
                     Dictionary<int, FMG.Entry> _cache = new Dictionary<int, FMG.Entry>();
                     foreach (var fmgEntry in fmgEntries)
                     {
-                        _cache.Add(fmgEntry.ID, fmgEntry);
+                        _cache[fmgEntry.ID] = fmgEntry;
                     }
                     return (row)=>{
                         if (!_cache.ContainsKey(row.ID))


### PR DESCRIPTION
Fixes dupe FMG entries crashing the program.