### PR TITLE
Create parammeta file if not existing

### DIFF
--- a/StudioCore/ParamEditor/ParamMeta.cs
+++ b/StudioCore/ParamEditor/ParamMeta.cs
@@ -249,6 +249,8 @@ namespace StudioCore.ParamEditor
             XmlWriterSettings writeSettings = new XmlWriterSettings();
             writeSettings.Indent = true;
             writeSettings.NewLineHandling = NewLineHandling.None;
+            if (!File.Exists(_path))
+                File.WriteAllBytes(_path, new byte[0]);
             _xml.Save(XmlWriter.Create(_path, writeSettings));
         }
 


### PR DESCRIPTION
prevents crash when it tries to write to the file