### PR TITLE
Fix FMG text changes applying to wrong entry

### DIFF
--- a/StudioCore/TextEditor/FMGEditor.cs
+++ b/StudioCore/TextEditor/FMGEditor.cs
@@ -260,10 +260,10 @@ namespace StudioCore.TextEditor
             }
 
             bool committed = ImGui.IsItemDeactivatedAfterEdit();
-            if (committed && _entryCache == entry)
+            if (committed)
             {
                 if (_textCache != oldval)
-                    UpdateProperty(entry.GetType().GetProperty("Text"), entry, _textCache);
+                    UpdateProperty(_entryCache.GetType().GetProperty("Text"), _entryCache, _textCache);
             }
 
             ImGui.NextColumn();

--- a/StudioCore/TextEditor/FMGEditor.cs
+++ b/StudioCore/TextEditor/FMGEditor.cs
@@ -226,6 +226,7 @@ namespace StudioCore.TextEditor
         }
 
         private string _textCache = "";
+        private FMG.Entry _entryCache;
 
         public void PropEditorFMG(FMG.Entry entry, string name, float boxsize)
         {
@@ -246,6 +247,7 @@ namespace StudioCore.TextEditor
                 if (ImGui.InputTextMultiline("##value", ref val, 2000, new Vector2(-1, boxsize)))
                 {
                     _textCache = val;
+                    _entryCache = entry;
                 }
             }
             else
@@ -253,15 +255,15 @@ namespace StudioCore.TextEditor
                 if (ImGui.InputText("##value", ref val, 2000))
                 {
                     _textCache = val;
+                    _entryCache = entry;
                 }
             }
 
             bool committed = ImGui.IsItemDeactivatedAfterEdit();
-            if (committed)
+            if (committed && _entryCache == entry)
             {
                 if (_textCache != oldval)
                     UpdateProperty(entry.GetType().GetProperty("Text"), entry, _textCache);
-                //UpdateProperty(entry.GetType().GetProperty("Text"), entry, _textCache, change, committed);
             }
 
             ImGui.NextColumn();

--- a/StudioCore/TextEditor/FMGEditor.cs
+++ b/StudioCore/TextEditor/FMGEditor.cs
@@ -262,7 +262,7 @@ namespace StudioCore.TextEditor
             bool committed = ImGui.IsItemDeactivatedAfterEdit();
             if (committed)
             {
-                if (_textCache != oldval)
+                if (_textCache != _entryCache.Text)
                     UpdateProperty(_entryCache.GetType().GetProperty("Text"), _entryCache, _textCache);
             }
 


### PR DESCRIPTION
Fixes FMG text changes applying to wrong entry when another entry is selected while a text box is being edited (when program speed was fast enough)