### PR TITLE
More 1.07 param upgrade tasks

### DIFF
--- a/StudioCore/ParamEditor/MassParamEdit.cs
+++ b/StudioCore/ParamEditor/MassParamEdit.cs
@@ -556,10 +556,10 @@ namespace StudioCore.ParamEditor
                 };
             }));
             argumentGetters.Add("vanillafield", (1, (param, field) => {
-                string paramName = ParamBank.VanillaBank.GetKeyForParam(param);
-                if (paramName == null)
+                var paramName = ParamBank.PrimaryBank.GetKeyForParam(param);
+                var vParam = ParamBank.VanillaBank.GetParamFromName(paramName);
+                if (vParam == null)
                     throw new Exception($@"Could not locate vanilla param for {param.ParamType}");
-                Param vParam = ParamBank.VanillaBank.Params[paramName];
                 Param.Column? col = vParam?[field[0]];
                 if (col == null)
                     throw new Exception($@"Could not locate field {field[0]}");

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -1467,11 +1467,16 @@ namespace StudioCore.ParamEditor
             {
                 // Note these all use modified as any unmodified row already matches the target. This only fails if a mod pre-empts fromsoft's exact change.
                 paramUpgradeTasks = new (ulong, string, string)[]{
-                    (10701000l, "1.07 - Move swordArtsType to swordArtsTypeNew", "param SwordArtsParam: modified: swordArtsTypeNew: = field swordArtsType;"),
-                    (10701000l, "1.07 - Set swordArtsType to 0", "param SwordArtsParam: modified && notadded: swordArtsType: = 0;"),
-                    (10701000l, "1.07 - Set added atkParam finalAttackDamageRate refs to -1", "param AtkParam_(Pc|Npc): modified && added: finalDamageRateId: = -1;"),
-                    (10701000l, "1.07 - Set notadded atkParam finalAttackDamageRate refs to vanilla", "param AtkParam_(Pc|Npc): modified && notadded: finalDamageRateId: = vanillafield finalDamageRateId;"),
-                    (10701000l, "1.07 - Set reserved_124 to Vanilla v1.07 values", "param GameSystemCommonParam: modified: reserved_124: = [1|173|7|0|10|10|3|4|5|6|7|8|10|11|12|13|14|15|17|18|19|20|21|22|24|25|25|25|25|25|25|25|0|0|22|67|0|0|240|65|0|0|135|67|0|0|240|65|0|0|135|67|0|0|240|65|0|0|135|67|0|0|240|65|0|0|135|67|0|0|240|65|0|0|135|67|0|0|240|65|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0];"),
+                    (10701000l, "1.07 - (SwordArtsParam) Move swordArtsType to swordArtsTypeNew", "param SwordArtsParam: modified: swordArtsTypeNew: = field swordArtsType;"),
+                    (10701000l, "1.07 - (SwordArtsParam) Set swordArtsType to 0", "param SwordArtsParam: modified && notadded: swordArtsType: = 0;"),
+                    (10701000l, "1.07 - (AtkParam PC/NPC) Set added finalAttackDamageRate refs to -1", "param AtkParam_(Pc|Npc): modified && added: finalDamageRateId: = -1;"),
+                    (10701000l, "1.07 - (AtkParam PC/NPC) Set notadded finalAttackDamageRate refs to vanilla", "param AtkParam_(Pc|Npc): modified && notadded: finalDamageRateId: = vanillafield finalDamageRateId;"),
+                    (10701000l, "1.07 - (AssetEnvironmentGeometryParam) Set reserved_124 to Vanilla v1.07 values", "param GameSystemCommonParam: modified && notadded: reserved_124: = vanillafield reserved_124;"),
+                    (10701000l, "1.07 - (AssetEnvironmentGeometryParam) Set reserved41 to Vanilla v1.07 values", "param PlayerCommonParam: modified: reserved41: = vanillafield reserved41;"),
+                    (10701000l, "1.07 - (AssetEnvironmentGeometryParam) Set Reserve_1 to Vanilla v1.07 values", "param AssetEnvironmentGeometryParam: modified: Reserve_1: = vanillafield Reserve_1;"),
+                    (10701000l, "1.07 - (AssetEnvironmentGeometryParam) Set Reserve_2 to Vanilla v1.07 values", "param AssetEnvironmentGeometryParam: modified: Reserve_2: = vanillafield Reserve_2;"),
+                    (10701000l, "1.07 - (AssetEnvironmentGeometryParam) Set Reserve_3 to Vanilla v1.07 values", "param AssetEnvironmentGeometryParam: modified: Reserve_3: = vanillafield Reserve_3;"),
+                    (10701000l, "1.07 - (AssetEnvironmentGeometryParam) Set Reserve_4 to Vanilla v1.07 values", "param AssetEnvironmentGeometryParam: modified: Reserve_4: = vanillafield Reserve_4;"),
                 };
             }
 
@@ -1517,6 +1522,16 @@ namespace StudioCore.ParamEditor
             {
                 if (param == pair.Value)
                     return pair.Key;
+            }
+            return null;
+        }
+
+        public Param GetParamFromName(string param)
+        {
+            foreach (KeyValuePair<string, Param> pair in Params)
+            {
+                if (param == pair.Key)
+                    return pair.Value;
             }
             return null;
         }

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -1469,6 +1469,7 @@ namespace StudioCore.ParamEditor
                 paramUpgradeTasks = new (ulong, string, string)[]{
                     (10701000l, "1.07 - Move swordArtsType to swordArtsTypeNew", "param SwordArtsParam: modified: swordArtsTypeNew: = field swordArtsType;"),
                     (10701000l, "1.07 - Set swordArtsType to 0", "param SwordArtsParam: modified: swordArtsType: = 0;"),
+                    (10701000l, "1.07 - Set reserved_124 to Vanilla v1.07 values", "param GameSystemCommonParam: modified: reserved_124: = [1|173|7|0|10|10|3|4|5|6|7|8|10|11|12|13|14|15|17|18|19|20|21|22|24|25|25|25|25|25|25|25|0|0|22|67|0|0|240|65|0|0|135|67|0|0|240|65|0|0|135|67|0|0|240|65|0|0|135|67|0|0|240|65|0|0|135|67|0|0|240|65|0|0|135|67|0|0|240|65|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0];"),
                 };
             }
 


### PR DESCRIPTION
Import newly used fields (including "expanded" byte arrays) from vanilla param while upgrading params.
Also fixes MassEdit VanillaRef .