### PR TITLE
Fix MSB click-drag properties

### DIFF
--- a/StudioCore/MsbEditor/PropertyEditor.cs
+++ b/StudioCore/MsbEditor/PropertyEditor.cs
@@ -394,8 +394,9 @@ namespace StudioCore.MsbEditor
             }
             if (committed)
             {
-                if (_lastUncommittedAction != null)
+                if (_lastUncommittedAction != null && ContextActionManager.PeekUndoAction() == _lastUncommittedAction)
                 {
+                    ContextActionManager.UndoAction();
                     ContextActionManager.ExecuteAction(_lastUncommittedAction);
                     _lastUncommittedAction = null;
                     _changingPropery = null;
@@ -407,11 +408,10 @@ namespace StudioCore.MsbEditor
         {
             if (prop == _changingPropery && _lastUncommittedAction != null && ContextActionManager.PeekUndoAction() == _lastUncommittedAction)
             {
-                //ContextActionManager.UndoAction();
+                ContextActionManager.UndoAction();
             }
             else
             {
-                // TODO2: Not sure if this is necessary anymore
                 _lastUncommittedAction = null;
             }
             MultipleEntityPropertyChangeAction action;
@@ -425,6 +425,7 @@ namespace StudioCore.MsbEditor
 
             }
             action = new MultipleEntityPropertyChangeAction((PropertyInfo)prop, ents, newval, arrayindex);
+            ContextActionManager.ExecuteAction(action);
 
             _lastUncommittedAction = action;
             _changingPropery = prop;


### PR DESCRIPTION
Fixes MSB properties that are being indirectly modified before changes are committed, such as with click-drag float elements.
Issue was introduced in https://github.com/soulsmods/DSMapStudio/pull/165 multi-selection editing

(Figured out what went wrong the first time, turned out to be simpler than I thought)