### PR TITLE
Don't add string.empty at the start of param.

### DIFF
--- a/FSParam/Param.cs
+++ b/FSParam/Param.cs
@@ -897,12 +897,8 @@ namespace FSParam
             }
             
             // Write row names
-            Dictionary<string, long> stringOffsetDictionary = new Dictionary<string, long> 
-            {
-                { string.Empty, bw.Position }
-            };
+            Dictionary<string, long> stringOffsetDictionary = new Dictionary<string, long>();
             
-            bw.WriteInt16(0); //Write empty string right after the ParamTypeOffset
             for (int i = 0; i < Rows.Count; i++) 
             {
                 string rowName = Rows[i].Name ?? string.Empty;

--- a/FSParam/Param.cs
+++ b/FSParam/Param.cs
@@ -646,7 +646,7 @@ namespace FSParam
             // Get the final size and sanity check against our calculated row size
             if (bitOffset != -1)
                 byteOffset += lastSize;
-            if (byteOffset != DetectedSize && byteOffset != DetectedSize - 2)
+            if (byteOffset != DetectedSize)
                 throw new Exception($@"Row size paramdef mismatch for {ParamType}");
 
             Cells = cells;

--- a/FSParam/Param.cs
+++ b/FSParam/Param.cs
@@ -646,7 +646,7 @@ namespace FSParam
             // Get the final size and sanity check against our calculated row size
             if (bitOffset != -1)
                 byteOffset += lastSize;
-            if (byteOffset != DetectedSize)
+            if (byteOffset != DetectedSize && byteOffset != DetectedSize - 2)
                 throw new Exception($@"Row size paramdef mismatch for {ParamType}");
 
             Cells = cells;


### PR DESCRIPTION
Fixes conflict with single entry params in old format that writes the param type in the param header.  