### PR TITLE
Change EntityID and EventFlagID fields to uint in MSBE

### DIFF
--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/EventParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/EventParam.cs
@@ -216,7 +216,7 @@ namespace SoulsFormats
             /// <summary>
             /// Identifies the Event in event scripts.
             /// </summary>
-            public int EntityID { get; set; }
+            public uint EntityID { get; set; }
 
             /// <summary>
             /// Unknown.
@@ -253,7 +253,7 @@ namespace SoulsFormats
                 Name = name;
                 OtherID = -1;
                 EventID = -1;
-                EntityID = -1;
+                EntityID = 0;
             }
 
             /// <summary>
@@ -296,7 +296,7 @@ namespace SoulsFormats
                 br.Position = start + baseDataOffset;
                 PartIndex = br.ReadInt32();
                 RegionIndex = br.ReadInt32();
-                EntityID = br.ReadInt32();
+                EntityID = br.ReadUInt32();
                 UnkE0C = br.ReadByte();
                 br.AssertByte(0);
                 br.AssertByte(0);
@@ -345,7 +345,7 @@ namespace SoulsFormats
                 bw.FillInt64("BaseDataOffset", bw.Position - start);
                 bw.WriteInt32(PartIndex);
                 bw.WriteInt32(RegionIndex);
-                bw.WriteInt32(EntityID);
+                bw.WriteUInt32(EntityID);
                 bw.WriteByte(UnkE0C);
                 bw.WriteByte(0);
                 bw.WriteByte(0);
@@ -665,7 +665,7 @@ namespace SoulsFormats
                 /// Unknown why objacts need an extra entity ID.
                 /// </summary>
                 [MSBEntityReference]
-                public int ObjActEntityID { get; set; }
+                public uint ObjActEntityID { get; set; }
 
                 /// <summary>
                 /// The part to be interacted with.
@@ -688,29 +688,29 @@ namespace SoulsFormats
                 /// <summary>
                 /// Unknown.
                 /// </summary>
-                public int EventFlagID { get; set; }
+                public uint EventFlagID { get; set; }
 
                 /// <summary>
                 /// Creates an ObjAct with default values.
                 /// </summary>
                 public ObjAct() : base($"{nameof(Event)}: {nameof(ObjAct)}")
                 {
-                    ObjActEntityID = -1;
+                    ObjActEntityID = 0;
                     ObjActID = -1;
-                    EventFlagID = -1;
+                    EventFlagID = 0;
                 }
 
                 internal ObjAct(BinaryReaderEx br) : base(br) { }
 
                 private protected override void ReadTypeData(BinaryReaderEx br)
                 {
-                    ObjActEntityID = br.ReadInt32();
+                    ObjActEntityID = br.ReadUInt32();
                     ObjActPartIndex = br.ReadInt32();
                     ObjActID = br.ReadInt32();
                     StateType = br.ReadByte();
                     br.AssertByte(0);
                     br.AssertInt16(0);
-                    EventFlagID = br.ReadInt32();
+                    EventFlagID = br.ReadUInt32();
                     br.AssertInt32(0);
                     br.AssertInt32(0);
                     br.AssertInt32(0);
@@ -718,13 +718,13 @@ namespace SoulsFormats
 
                 private protected override void WriteTypeData(BinaryWriterEx bw)
                 {
-                    bw.WriteInt32(ObjActEntityID);
+                    bw.WriteUInt32(ObjActEntityID);
                     bw.WriteInt32(ObjActPartIndex);
                     bw.WriteInt32(ObjActID);
                     bw.WriteByte(StateType);
                     bw.WriteByte(0);
                     bw.WriteInt16(0);
-                    bw.WriteInt32(EventFlagID);
+                    bw.WriteUInt32(EventFlagID);
                     bw.WriteInt32(0);
                     bw.WriteInt32(0);
                     bw.WriteInt32(0);
@@ -806,12 +806,12 @@ namespace SoulsFormats
                 /// The NPC whose world you're entering.
                 /// </summary>
                 [MSBEntityReference]
-                public int HostEntityID { get; set; }
+                public uint HostEntityID { get; set; }
 
                 /// <summary>
                 /// Set when inside the event's region, unset when outside it.
                 /// </summary>
-                public int EventFlagID { get; set; }
+                public uint EventFlagID { get; set; }
 
                 /// <summary>
                 /// ID of a goods item that is used to trigger the event.
@@ -848,8 +848,8 @@ namespace SoulsFormats
                 /// </summary>
                 public PseudoMultiplayer() : base($"{nameof(Event)}: {nameof(PseudoMultiplayer)}")
                 {
-                    HostEntityID = -1;
-                    EventFlagID = -1;
+                    HostEntityID = 0;
+                    EventFlagID = 0;
                     ActivateGoodsID = -1;
                     UnkT0C = -1;
                     UnkT10 = -1;
@@ -860,8 +860,8 @@ namespace SoulsFormats
 
                 private protected override void ReadTypeData(BinaryReaderEx br)
                 {
-                    HostEntityID = br.ReadInt32();
-                    EventFlagID = br.ReadInt32();
+                    HostEntityID = br.ReadUInt32();
+                    EventFlagID = br.ReadUInt32();
                     ActivateGoodsID = br.ReadInt32();
                     UnkT0C = br.ReadInt32();
                     UnkT10 = br.ReadInt32();
@@ -873,8 +873,8 @@ namespace SoulsFormats
 
                 private protected override void WriteTypeData(BinaryWriterEx bw)
                 {
-                    bw.WriteInt32(HostEntityID);
-                    bw.WriteInt32(EventFlagID);
+                    bw.WriteUInt32(HostEntityID);
+                    bw.WriteUInt32(EventFlagID);
                     bw.WriteInt32(ActivateGoodsID);
                     bw.WriteInt32(UnkT0C);
                     bw.WriteInt32(UnkT10);
@@ -1171,7 +1171,7 @@ namespace SoulsFormats
                 /// <summary>
                 /// Flag that must be set for stake to be available.
                 /// </summary>
-                public int EventFlagID { get; set; }
+                public uint EventFlagID { get; set; }
 
                 /// <summary>
                 /// Unknown.
@@ -1195,7 +1195,7 @@ namespace SoulsFormats
                 private protected override void ReadTypeData(BinaryReaderEx br)
                 {
                     RetryPartIndex = br.ReadInt32();
-                    EventFlagID = br.ReadInt32();
+                    EventFlagID = br.ReadUInt32();
                     UnkT08 = br.ReadSingle();
                     RetryRegionIndex = br.ReadInt16();
                     br.AssertInt16(0);
@@ -1204,7 +1204,7 @@ namespace SoulsFormats
                 private protected override void WriteTypeData(BinaryWriterEx bw)
                 {
                     bw.WriteInt32(RetryPartIndex);
-                    bw.WriteInt32(EventFlagID);
+                    bw.WriteUInt32(EventFlagID);
                     bw.WriteSingle(UnkT08);
                     bw.WriteInt16(RetryRegionIndex);
                     bw.WriteInt16(0);

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PartsParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PartsParam.cs
@@ -208,7 +208,7 @@ namespace SoulsFormats
             /// <summary>
             /// Identifies the part in event scripts.
             /// </summary>
-            public int EntityID { get; set; }
+            public uint EntityID { get; set; }
 
             /// <summary>
             /// Unknown.
@@ -303,7 +303,7 @@ namespace SoulsFormats
             /// <summary>
             /// Allows multiple parts to be identified by the same entity ID.
             /// </summary>
-            public int[] EntityGroupIDs { get; private set; }
+            public uint[] EntityGroupIDs { get; private set; }
 
             /// <summary>
             /// Unknown.
@@ -320,10 +320,8 @@ namespace SoulsFormats
                 Name = name;
                 SibPath = "";
                 Scale = Vector3.One;
-                EntityID = -1;
-                EntityGroupIDs = new int[8];
-                for (int i = 0; i < 8; i++)
-                    EntityGroupIDs[i] = -1;
+                EntityID = 0;
+                EntityGroupIDs = new uint[8];
             }
 
             /// <summary>
@@ -332,7 +330,7 @@ namespace SoulsFormats
             public Part DeepCopy()
             {
                 var part = (Part)MemberwiseClone();
-                part.EntityGroupIDs = (int[])EntityGroupIDs.Clone();
+                part.EntityGroupIDs = (uint[])EntityGroupIDs.Clone();
                 DeepCopyTo(part);
                 return part;
             }
@@ -466,7 +464,7 @@ namespace SoulsFormats
 
             private void ReadEntityData(BinaryReaderEx br)
             {
-                EntityID = br.ReadInt32();
+                EntityID = br.ReadUInt32();
                 UnkE04 = br.ReadByte();
                 br.AssertByte(0);
                 br.AssertByte(0);
@@ -488,7 +486,7 @@ namespace SoulsFormats
                 DisablePointLightEffect = br.ReadBoolean();
                 UnkE17 = br.ReadByte();
                 UnkE18 = br.ReadInt32();
-                EntityGroupIDs = br.ReadInt32s(8);
+                EntityGroupIDs = br.ReadUInt32s(8);
                 UnkE3C = br.ReadInt16();
                 UnkE3E = br.ReadInt16();
                 //br.AssertPattern(0x10, 0x00);
@@ -659,7 +657,7 @@ namespace SoulsFormats
 
             private void WriteEntityData(BinaryWriterEx bw)
             {
-                bw.WriteInt32(EntityID);
+                bw.WriteUInt32(EntityID);
                 bw.WriteByte(UnkE04);
                 bw.WriteByte(0);
                 bw.WriteByte(0);
@@ -681,7 +679,7 @@ namespace SoulsFormats
                 bw.WriteBoolean(DisablePointLightEffect);
                 bw.WriteByte(UnkE17);
                 bw.WriteInt32(UnkE18);
-                bw.WriteInt32s(EntityGroupIDs);
+                bw.WriteUInt32s(EntityGroupIDs);
                 bw.WriteInt16(UnkE3C);
                 bw.WriteInt16(UnkE3E);
                 //bw.WritePattern(0x10, 0x00);
@@ -1980,7 +1978,7 @@ namespace SoulsFormats
                 /// <summary>
                 /// Disables Fast Travel if Event Flag is not set.
                 /// </summary>
-                public int EnableFastTravelEventFlagID { get; set; }
+                public uint EnableFastTravelEventFlagID { get; set; }
 
                 /// <summary>
                 /// Unknown.
@@ -2048,7 +2046,7 @@ namespace SoulsFormats
                     UnkT3E = br.ReadInt16();
                     UnkT40 = br.ReadSingle();
                     br.AssertInt32(0);
-                    EnableFastTravelEventFlagID = br.ReadInt32();
+                    EnableFastTravelEventFlagID = br.ReadUInt32();
                     UnkT4C = br.AssertInt16(0, 1);
                     UnkT4E = br.ReadInt16();
                 }
@@ -2089,7 +2087,7 @@ namespace SoulsFormats
                     bw.WriteInt16(UnkT3E);
                     bw.WriteSingle(UnkT40);
                     bw.WriteInt32(0);
-                    bw.WriteInt32(EnableFastTravelEventFlagID);
+                    bw.WriteUInt32(EnableFastTravelEventFlagID);
                     bw.WriteInt16(UnkT4C);
                     bw.WriteInt16(UnkT4E);
                 }

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PointParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PointParam.cs
@@ -542,7 +542,7 @@ namespace SoulsFormats
             /// <summary>
             /// Identifies the region in event scripts.
             /// </summary>
-            public int EntityID { get; set; }
+            public uint EntityID { get; set; }
 
             private protected Region(string name)
             {
@@ -551,7 +551,7 @@ namespace SoulsFormats
                 MapStudioLayer = 0xFFFFFFFF;
                 UnkA = new List<short>();
                 UnkB = new List<short>();
-                EntityID = -1;
+                EntityID = 0;
             }
 
             /// <summary>
@@ -625,7 +625,7 @@ namespace SoulsFormats
 
                 br.Position = start + baseDataOffset3;
                 ActivationPartIndex = br.ReadInt32();
-                EntityID = br.ReadInt32();
+                EntityID = br.ReadUInt32();
                 UnkE08 = br.ReadByte();
                 br.AssertByte(0);
                 br.AssertByte(0);
@@ -698,7 +698,7 @@ namespace SoulsFormats
 
                 bw.FillInt64("EntityDataOffset", bw.Position - start);
                 bw.WriteInt32(ActivationPartIndex);
-                bw.WriteInt32(EntityID);
+                bw.WriteUInt32(EntityID);
                 bw.WriteByte(UnkE08);
                 bw.WriteByte(0);
                 bw.WriteByte(0);
@@ -1163,7 +1163,7 @@ namespace SoulsFormats
                 /// <summary>
                 /// Event Flag required to be ON for the message to appear.
                 /// </summary>
-                public int EnableEventFlag { get; set; }
+                public uint EnableEventFlagID { get; set; }
 
                 /// <summary>
                 /// ID of character to render along with the message.
@@ -1204,7 +1204,7 @@ namespace SoulsFormats
                     Hidden = br.AssertInt32(0, 1) == 1;
                     UnkT08 = br.ReadInt32();
                     UnkT0C = br.ReadInt32();
-                    EnableEventFlag = br.ReadInt32();
+                    EnableEventFlagID = br.ReadUInt32();
                     CharacterModelName = br.ReadInt32();
                     NPCParamID = br.ReadInt32();
                     AnimationID = br.ReadInt32();
@@ -1218,7 +1218,7 @@ namespace SoulsFormats
                     bw.WriteInt32(Hidden ? 1 : 0);
                     bw.WriteInt32(UnkT08);
                     bw.WriteInt32(UnkT0C);
-                    bw.WriteInt32(EnableEventFlag);
+                    bw.WriteUInt32(EnableEventFlagID);
                     bw.WriteInt32(CharacterModelName);
                     bw.WriteInt32(NPCParamID);
                     bw.WriteInt32(AnimationID);
@@ -2096,7 +2096,7 @@ namespace SoulsFormats
                 /// <summary>
                 /// Disables fast travel when flag is OFF.
                 /// </summary>
-                public int EventFlagID { get; set; }
+                public uint EventFlagID { get; set; }
 
                 /// <summary>
                 /// Creates a FastTravelRestriction with default values.
@@ -2107,13 +2107,13 @@ namespace SoulsFormats
 
                 private protected override void ReadTypeData(BinaryReaderEx br)
                 {
-                    EventFlagID = br.ReadInt32();
+                    EventFlagID = br.ReadUInt32();
                     br.AssertInt32(0);
                 }
 
                 private protected override void WriteTypeData(BinaryWriterEx bw)
                 {
-                    bw.WriteInt32(EventFlagID);
+                    bw.WriteUInt32(EventFlagID);
                     bw.WriteInt32(0);
                 }
             }

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PointParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PointParam.cs
@@ -1928,9 +1928,11 @@ namespace SoulsFormats
                 public int UnkT08 { get; set; }
 
                 /// <summary>
-                /// Unknown.
+                /// References to enemies to defeat to receive the reward.
                 /// </summary>
-                public int[] UnkT14 { get; private set; }
+                [MSBReference(ReferenceType = typeof(Part))]
+                public string[] PartNames { get; private set; }
+                private int[] PartIndices;
 
                 /// <summary>
                 /// Unknown.
@@ -1952,13 +1954,13 @@ namespace SoulsFormats
                 /// </summary>
                 public GroupDefeatReward() : base($"{nameof(Region)}: {nameof(GroupDefeatReward)}")
                 {
-                    UnkT14 = new int[8];
+                    PartNames = new string[8];
                 }
 
                 private protected override void DeepCopyTo(Region region)
                 {
                     var reward = (GroupDefeatReward)region;
-                    reward.UnkT14 = (int[])UnkT14.Clone();
+                    reward.PartNames = (string[])PartNames.Clone();
                 }
 
                 internal GroupDefeatReward(BinaryReaderEx br) : base(br) { }
@@ -1970,7 +1972,7 @@ namespace SoulsFormats
                     UnkT08 = br.ReadInt32();
                     br.AssertInt32(-1);
                     br.AssertInt32(-1);
-                    UnkT14 = br.ReadInt32s(8);
+                    PartIndices = br.ReadInt32s(8);
 
                     UnkT34 = br.ReadInt32();
                     UnkT38 = br.ReadInt32();
@@ -1992,7 +1994,7 @@ namespace SoulsFormats
                     bw.WriteInt32(UnkT08);
                     bw.WriteInt32(-1);
                     bw.WriteInt32(-1);
-                    bw.WriteInt32s(UnkT14);
+                    bw.WriteInt32s(PartIndices);
 
                     bw.WriteInt32(UnkT34);
                     bw.WriteInt32(UnkT38);
@@ -2005,6 +2007,18 @@ namespace SoulsFormats
                     bw.WriteInt32(UnkT54);
                     bw.WriteInt32(0);
                     bw.WriteInt32(0);
+                }
+
+                internal override void GetNames(Entries entries)
+                {
+                    base.GetNames(entries);
+                    PartNames = MSB.FindNames(entries.Parts, PartIndices);
+                }
+
+                internal override void GetIndices(Entries entries)
+                {
+                    base.GetIndices(entries);
+                    PartIndices = MSB.FindIndices(entries.Parts, PartNames);
                 }
             }
 

--- a/StudioCore/MsbEditor/Universe.cs
+++ b/StudioCore/MsbEditor/Universe.cs
@@ -949,11 +949,11 @@ namespace StudioCore.MsbEditor
                         object idObj = entityIDProp.GetValue(obj.WrappedObject);
                         if (idObj is not int entityID)
                         {
-                            // EntityID is uint in Elden Ring. Only <2^31 is used in practice,
-                            // and duplicate checking will work even with the cast.
+                            // EntityID is uint in Elden Ring. Only <2^31 is used in practice.
+                            // If really desired, a separate routine could be created.
                             if (idObj is uint uID)
                             {
-                                entityID = (int)uID;
+                                entityID = unchecked((int)uID);
                             }
                             else
                             {

--- a/StudioCore/MsbEditor/Universe.cs
+++ b/StudioCore/MsbEditor/Universe.cs
@@ -946,7 +946,20 @@ namespace StudioCore.MsbEditor
                     var entityIDProp = obj.GetProperty("EntityID");
                     if (entityIDProp != null)
                     {
-                        int entityID = (int)entityIDProp.GetValue(obj.WrappedObject);
+                        object idObj = entityIDProp.GetValue(obj.WrappedObject);
+                        if (idObj is not int entityID)
+                        {
+                            // EntityID is uint in Elden Ring. Only <2^31 is used in practice,
+                            // and duplicate checking will work even with the cast.
+                            if (idObj is uint uID)
+                            {
+                                entityID = (int)uID;
+                            }
+                            else
+                            {
+                                continue;
+                            }
+                        }
                         if (entityID > 0)
                         {
                             var entryExists = entityIDList.TryGetValue(entityID, out string name);


### PR DESCRIPTION
This change is somewhat inconvenient, because it mismatches other games, but it is the correct thing to do. I've checked all instances of these values in all Elden Ring MSBs and they are always positive and the default values of all of these fields is 0. In all formats for which we have official defs, as well as in decompiled code, these values have all switched to uints. It is what fromsoft has decided, and will probably carry into future RPG titles.

This should be fine for the purpose of migrating existing data files, since there is no data loss. If someone incorrectly entered -1 as the default value of any of these fields, the game is already interpreting it as 4294967295 anyway.