### PR TITLE
Fix crash when model name fields referenced AEG, but weren't long enough to derive AEG folder path

### DIFF
--- a/StudioCore/AssetLocator.cs
+++ b/StudioCore/AssetLocator.cs
@@ -1599,7 +1599,6 @@ namespace StudioCore
                             return GetOverridenFilePath($@"asset\aeg\{objid.Substring(0, 6)}\{objid}.geombnd.dcx");
                         else
                             return null;
-
                     }
                     return GetOverridenFilePath($@"obj\{objid}.objbnd.dcx");
                 }

--- a/StudioCore/AssetLocator.cs
+++ b/StudioCore/AssetLocator.cs
@@ -1594,7 +1594,12 @@ namespace StudioCore
                     }
                     else if (Type == GameType.EldenRing)
                     {
-                        return GetOverridenFilePath($@"asset\aeg\{objid.Substring(0, 6)}\{objid}.geombnd.dcx");
+                        // Derive subfolder path from model name (all vanilla AEG are within subfolders)
+                        if (objid.Length >= 6)
+                            return GetOverridenFilePath($@"asset\aeg\{objid.Substring(0, 6)}\{objid}.geombnd.dcx");
+                        else
+                            return null;
+
                     }
                     return GetOverridenFilePath($@"obj\{objid}.objbnd.dcx");
                 }


### PR DESCRIPTION
Typing "AEG" in a model name field was enough to trip it.