### PR TITLE
TextEditor misc. improvements

### DIFF
--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -56,7 +56,7 @@ namespace StudioCore.ParamEditor
         {
             if (_entryCache.Count == 0 && FMGBank.IsLoaded)
             {
-                var fmgEntries = FMGBank.GetFmgEntriesByType(_category, FMGBank.FmgEntryTextType.Title, false);
+                var fmgEntries = FMGBank.GetFmgEntriesByCategory(_category, false);
                 foreach (var fmgEntry in fmgEntries)
                 {
                     _entryCache[fmgEntry.ID] = fmgEntry;
@@ -150,6 +150,7 @@ namespace StudioCore.ParamEditor
             _decorators.Add("EquipParamWeapon", new FMGItemParamDecorator(FMGBank.FmgEntryCategory.Weapons));
             _decorators.Add("EquipParamGem", new FMGItemParamDecorator(FMGBank.FmgEntryCategory.Gem));
             _decorators.Add("SwordArtsParam", new FMGItemParamDecorator(FMGBank.FmgEntryCategory.SwordArts));
+            //_decorators.Add("CharacterText", new FMGItemParamDecorator(FMGBank.FmgEntryCategory.Characters)); // TODO: Decorators need to be updated to support text references.
         }
 
         /// <summary>

--- a/StudioCore/ParamEditor/SearchEngine.cs
+++ b/StudioCore/ParamEditor/SearchEngine.cs
@@ -265,11 +265,10 @@ namespace StudioCore.Editor
                         case "EquipParamProtector": category = FMGBank.FmgEntryCategory.Armor; break;
                         case "EquipParamGem": category = FMGBank.FmgEntryCategory.Gem; break;
                         case "SwordArtsParam": category = FMGBank.FmgEntryCategory.SwordArts; break;
-                        case "ActionButtonParam": category = FMGBank.FmgEntryCategory.ActionButtonText; break;
                     }
                     if (category == FMGBank.FmgEntryCategory.None)
                         throw new Exception();
-                    var fmgEntries = FMGBank.GetFmgEntriesByType(category, FMGBank.FmgEntryTextType.Title, false);
+                    var fmgEntries = FMGBank.GetFmgEntriesByCategory(category, false);
                     Dictionary<int, FMG.Entry> _cache = new Dictionary<int, FMG.Entry>();
                     foreach (var fmgEntry in fmgEntries)
                     {

--- a/StudioCore/ParamEditor/SearchEngine.cs
+++ b/StudioCore/ParamEditor/SearchEngine.cs
@@ -265,6 +265,7 @@ namespace StudioCore.Editor
                         case "EquipParamProtector": category = FMGBank.FmgEntryCategory.Armor; break;
                         case "EquipParamGem": category = FMGBank.FmgEntryCategory.Gem; break;
                         case "SwordArtsParam": category = FMGBank.FmgEntryCategory.SwordArts; break;
+                        case "ActionButtonParam": category = FMGBank.FmgEntryCategory.ActionButtonText; break;
                     }
                     if (category == FMGBank.FmgEntryCategory.None)
                         throw new Exception();

--- a/StudioCore/TextEditor/FMGBank.cs
+++ b/StudioCore/TextEditor/FMGBank.cs
@@ -958,7 +958,6 @@ namespace StudioCore.TextEditor
                 }
             }
 
-            ApplyGameDifferences(info);
             ActiveUITypes[info.UICategory] = true;
 
             return info;
@@ -1016,9 +1015,10 @@ namespace StudioCore.TextEditor
             }
 
             foreach (var file in fmgBinder.Files)
-            {
                 _fmgInfoBank.Add(GenerateFMGInfo(file));
-            }
+            foreach (var info in _fmgInfoBank)
+                ApplyGameDifferences(info);
+
             return true;
         }
 
@@ -1100,7 +1100,7 @@ namespace StudioCore.TextEditor
         }
 
         /// <summary>
-        /// Checks for FMG info that differs per-game
+        /// Checks and applies FMG info that differs per-game.
         /// </summary>
         private static void ApplyGameDifferences(FMGInfo info)
         {

--- a/StudioCore/TextEditor/FMGBank.cs
+++ b/StudioCore/TextEditor/FMGBank.cs
@@ -461,6 +461,7 @@ namespace StudioCore.TextEditor
             Message,
             SwordArts,
             Effect,
+            ActionButtonText,
         }
 
         /// <summary>
@@ -733,6 +734,9 @@ namespace StudioCore.TextEditor
 
                 case FmgIDType.TitleMessage:
                     return FmgEntryCategory.Message;
+
+                case FmgIDType.ActionButtonText:
+                    return FmgEntryCategory.ActionButtonText;
 
                 case FmgIDType.WeaponEffect:
                 default:
@@ -1107,6 +1111,13 @@ namespace StudioCore.TextEditor
             var gameType = AssetLocator.Type;
             switch (info.FmgID)
             {
+                case FmgIDType.Event:
+                case FmgIDType.Event_Patch:
+                    if (gameType is GameType.DemonsSouls or GameType.DarkSoulsPTDE or GameType.DarkSoulsRemastered)
+                    {
+                        info.EntryCategory = FmgEntryCategory.ActionButtonText;
+                    }
+                    break;
                 case FmgIDType.ReusedFMG_205:
                     if (gameType == GameType.EldenRing)
                         info.Name = "LoadingTitle";
@@ -1188,38 +1199,32 @@ namespace StudioCore.TextEditor
             {
                 ID = id,
             };
-            if (fmgInfo.EntryCategory == FmgEntryCategory.None)
+            foreach (var info in _fmgInfoBank)
             {
-                var entryPairs = fmgInfo.GetPatchedEntryFMGPairs();
-                var pair = entryPairs.Find(e => e.Entry.ID == id);
-                eGroup.TextBody = pair.Entry;
-                eGroup.TextBodyInfo = pair.FmgInfo;
-            }
-            else
-            {
-                foreach (var info in _fmgInfoBank)
+                if (info.EntryCategory == fmgInfo.EntryCategory && info.PatchParent == null)
                 {
-                    if (info.EntryCategory == fmgInfo.EntryCategory && info.PatchParent == null)
+                    var entryPairs = info.GetPatchedEntryFMGPairs();
+                    var pair = entryPairs.Find(e => e.Entry.ID == id);
+                    if (pair != null)
                     {
-                        var entryPairs = info.GetPatchedEntryFMGPairs();
-                        var pair = entryPairs.Find(e => e.Entry.ID == id);
-                        if (pair != null)
+                        switch (info.EntryType)
                         {
-                            switch (info.EntryType)
-                            {
-                                case FmgEntryTextType.Title:
-                                    eGroup.Title = pair.Entry;
-                                    eGroup.TitleInfo = pair.FmgInfo;
-                                    break;
-                                case FmgEntryTextType.Summary:
-                                    eGroup.Summary = pair.Entry;
-                                    eGroup.SummaryInfo = pair.FmgInfo;
-                                    break;
-                                case FmgEntryTextType.Description:
-                                    eGroup.Description = pair.Entry;
-                                    eGroup.DescriptionInfo = pair.FmgInfo;
-                                    break;
-                            }
+                            case FmgEntryTextType.Title:
+                                eGroup.Title = pair.Entry;
+                                eGroup.TitleInfo = pair.FmgInfo;
+                                break;
+                            case FmgEntryTextType.Summary:
+                                eGroup.Summary = pair.Entry;
+                                eGroup.SummaryInfo = pair.FmgInfo;
+                                break;
+                            case FmgEntryTextType.Description:
+                                eGroup.Description = pair.Entry;
+                                eGroup.DescriptionInfo = pair.FmgInfo;
+                                break;
+                            case FmgEntryTextType.TextBody:
+                                eGroup.TextBody = pair.Entry;
+                                eGroup.TextBodyInfo = pair.FmgInfo;
+                                break;
                         }
                     }
                 }

--- a/StudioCore/TextEditor/FMGBank.cs
+++ b/StudioCore/TextEditor/FMGBank.cs
@@ -1112,33 +1112,43 @@ namespace StudioCore.TextEditor
         }
 
         /// <summary>
-        /// Get patched FMG Entries for the specified category and text type.
+        /// Get patched FMG Entries for the specified category, with TextType Title or TextBody.
         /// </summary>
-        /// <returns>List of entries if found; empty list otherwise.</returns>
-        public static List<FMG.Entry> GetFmgEntriesByType(FmgEntryCategory category, FmgEntryTextType textType, bool sort = true)
+        /// <returns>List of patched entries if found; empty list otherwise.</returns>
+        public static List<FMG.Entry> GetFmgEntriesByCategory(FmgEntryCategory category, bool sort = true)
         {
             foreach (var info in _fmgInfoBank)
             {
-                if (info.EntryCategory == category && info.EntryType == textType)
-                {
+                if (info.EntryCategory == category && info.EntryType is FmgEntryTextType.Title or FmgEntryTextType.TextBody)
                     return info.GetPatchedEntries(sort);
-                }
             }
             return new List<FMG.Entry>();
         }
 
         /// <summary>
-        /// Get patched FMG Entries for the specified FMG ID.
+        /// Get patched FMG Entries for the specified category and text type.
         /// </summary>
-        /// <returns>List of entries if found; empty list otherwise.</returns>
-        public static List<FMG.Entry> GetFmgEntriesByID(FmgIDType fmgID, bool sort = true)
+        /// <returns>List of patched entries if found; empty list otherwise.</returns>
+        public static List<FMG.Entry> GetFmgEntriesByCategoryAndTextType(FmgEntryCategory category, FmgEntryTextType textType, bool sort = true)
+        {
+            foreach (var info in _fmgInfoBank)
+            {
+                if (info.EntryCategory == category && info.EntryType == textType)
+                    return info.GetPatchedEntries(sort);
+            }
+            return new List<FMG.Entry>();
+        }
+
+        /// <summary>
+        /// Get patched FMG Entries for the specified FmgIDType.
+        /// </summary>
+        /// <returns>List of patched entries if found; empty list otherwise.</returns>
+        public static List<FMG.Entry> GetFmgEntriesByFmgIDType(FmgIDType fmgID, bool sort = true)
         {
             foreach (var info in _fmgInfoBank)
             {
                 if (info.FmgID == fmgID)
-                {
                     return info.GetPatchedEntries(sort);
-                }
             }
             return new List<FMG.Entry>();
         }

--- a/StudioCore/TextEditor/FMGBank.cs
+++ b/StudioCore/TextEditor/FMGBank.cs
@@ -442,6 +442,7 @@ namespace StudioCore.TextEditor
             Title = 1,
             Summary = 2,
             Description = 3,
+            ExtraInfo = 4,
         }
 
         /// <summary>
@@ -609,25 +610,31 @@ namespace StudioCore.TextEditor
             //
             TalkMsg_FemalePC_Alt = 4,
             NetworkMessage = 31,
-            ActionButtonText = 32,
             EventTextForTalk = 33,
             EventTextForMap = 34,
             TutorialTitle = 207,
             TutorialBody = 208,
             TextEmbedImageName_win64 = 209,
 
-            // Multiple use cases
+            // Multiple use cases. Differences are applied in ApplyGameDifferences();
+            ReusedFMG_32 = 32,
+            // FMG 32
+            // BB:  GemExtraInfo
+            // DS3: ActionButtonText
+            // SDT: ActionButtonText
+            // ER:  ActionButtonText
             ReusedFMG_210 = 210,
-            // 210
+            // FMG 210
             // DS3: TitleGoods_DLC1
+            // SDT: ?
             // ER:  ToS_win64
             ReusedFMG_205 = 205,
-            // 205
+            // FMG 205
             // DS3: SystemMessage_PS4
             // SDT: TutorialText
             // ER:  LoadingTitle
             ReusedFMG_206 = 206,
-            // 206
+            // FMG 206
             // DS3: SystemMessage_XboxOne 
             // SDT: TutorialTitle
             // ER:  LoadingText
@@ -735,9 +742,6 @@ namespace StudioCore.TextEditor
                 case FmgIDType.TitleMessage:
                     return FmgEntryCategory.Message;
 
-                case FmgIDType.ActionButtonText:
-                    return FmgEntryCategory.ActionButtonText;
-
                 case FmgIDType.WeaponEffect:
                 default:
                     return FmgEntryCategory.None;
@@ -839,70 +843,8 @@ namespace StudioCore.TextEditor
             }
         }
 
-        /*
         /// <summary>
-        /// Checks if FMG is a patch FMG
-        /// </summary>
-        public static bool IsPatchFMG(FMGInfo info)
-        {
-            switch (info.FmgID)
-            {
-                case FmgIDType.ReusedFMG_210: // Changes per-game. Handled elsewhere.
-                    return false;
-                case FmgIDType.TitleGoods_Patch:
-                case FmgIDType.DescriptionGoods_Patch:
-                case FmgIDType.DescriptionGoods_DLC1:
-                case FmgIDType.DescriptionGoods_DLC2:
-                case FmgIDType.SummaryGoods_Patch:
-                case FmgIDType.SummaryGoods_DLC1:
-                case FmgIDType.SummaryGoods_DLC2:
-                case FmgIDType.TitleGoods:
-                case FmgIDType.TitleGoods_DLC2:
-                case FmgIDType.DescriptionWeapons_DLC1:
-                case FmgIDType.DescriptionWeapons_DLC2:
-                case FmgIDType.TitleWeapons_DLC1:
-                case FmgIDType.TitleWeapons_DLC2:
-                case FmgIDType.DescriptionWeapons_Patch:
-                case FmgIDType.SummaryWeapons_Patch:
-                case FmgIDType.TitleWeapons_Patch:
-                case FmgIDType.DescriptionArmor_DLC1:
-                case FmgIDType.DescriptionArmor_DLC2:
-                case FmgIDType.TitleArmor_DLC1:
-                case FmgIDType.TitleArmor_DLC2:
-                case FmgIDType.DescriptionArmor_Patch:
-                case FmgIDType.SummaryArmor_Patch:
-                case FmgIDType.TitleArmor_Patch:
-                case FmgIDType.DescriptionRings_DLC1:
-                case FmgIDType.DescriptionRings_DLC2:
-                case FmgIDType.SummaryRings_DLC1:
-                case FmgIDType.SummaryRings_DLC2:
-                case FmgIDType.TitleRings_DLC1:
-                case FmgIDType.TitleRings_DLC2:
-                case FmgIDType.DescriptionRings_Patch:
-                case FmgIDType.SummaryRings_Patch:
-                case FmgIDType.TitleRings_Patch:
-                case FmgIDType.DescriptionSpells_DLC1:
-                case FmgIDType.DescriptionSpells_DLC2:
-                case FmgIDType.SummarySpells_DLC1:
-                case FmgIDType.SummarySpells_DLC2:
-                case FmgIDType.TitleSpells_DLC1:
-                case FmgIDType.TitleSpells_DLC2:
-                case FmgIDType.DescriptionSpells_Patch:
-                case FmgIDType.TitleSpells_Patch:
-                case FmgIDType.TitleCharacters_DLC1:
-                case FmgIDType.TitleCharacters_DLC2:
-                case FmgIDType.TitleCharacters_Patch:
-                case FmgIDType.TitleLocations_DLC1:
-                case FmgIDType.TitleLocations_DLC2:
-                case FmgIDType.TitleLocations_Patch:
-                    return true;
-            }
-            return false;
-        }
-        */
-
-        /// <summary>
-        /// Dumb little list for comparing FMG type enum strings for patch FMGs
+        /// List of strings to compare with "FmgIDType" name to identify patch FMGs.
         /// </summary>
         private readonly static List<string> patchStrings = new()
         {
@@ -1111,12 +1053,24 @@ namespace StudioCore.TextEditor
             var gameType = AssetLocator.Type;
             switch (info.FmgID)
             {
-                case FmgIDType.Event:
-                case FmgIDType.Event_Patch:
-                    if (gameType is GameType.DemonsSouls or GameType.DarkSoulsPTDE or GameType.DarkSoulsRemastered)
+                case FmgIDType.ReusedFMG_32:
+                    if (gameType == GameType.Bloodborne)
                     {
+                        info.Name = "GemExtraInfo";
+                        info.UICategory = FmgUICategory.Item;
+                        info.EntryCategory = FmgEntryCategory.Gem;
+                        //info.EntryType = FmgEntryTextType.ExtraInfo; // TODO
+                    }
+                    else
+                    {
+                        info.Name = "ActionButtonText";
                         info.EntryCategory = FmgEntryCategory.ActionButtonText;
                     }
+                    break;
+                case FmgIDType.Event:
+                case FmgIDType.Event_Patch:
+                    if (gameType is GameType.DemonsSouls or GameType.DarkSoulsPTDE or GameType.DarkSoulsRemastered or GameType.Bloodborne)
+                        info.EntryCategory = FmgEntryCategory.ActionButtonText;
                     break;
                 case FmgIDType.ReusedFMG_205:
                     if (gameType == GameType.EldenRing)

--- a/StudioCore/TextEditor/TextEditorScreen.cs
+++ b/StudioCore/TextEditor/TextEditorScreen.cs
@@ -171,7 +171,7 @@ namespace StudioCore.TextEditor
                                     matches.Add(entry);
                             }
                         }
-                        foreach (var entry in FMGBank.GetFmgEntriesByType(_activeFmgInfo.EntryCategory, FMGBank.FmgEntryTextType.Description, false))
+                        foreach (var entry in FMGBank.GetFmgEntriesByCategoryAndTextType(_activeFmgInfo.EntryCategory, FMGBank.FmgEntryTextType.Description, false))
                         {
                             // Descriptions
                             if (entry.Text != null)
@@ -184,7 +184,7 @@ namespace StudioCore.TextEditor
                                 }
                             }
                         }
-                        foreach (var entry in FMGBank.GetFmgEntriesByType(_activeFmgInfo.EntryCategory, FMGBank.FmgEntryTextType.Summary, false))
+                        foreach (var entry in FMGBank.GetFmgEntriesByCategoryAndTextType(_activeFmgInfo.EntryCategory, FMGBank.FmgEntryTextType.Summary, false))
                         {
                             // Summaries
                             if (entry.Text != null)


### PR DESCRIPTION
Sets up stuff that will allow handling text better in future updates (especially by outside systems).
Fixes FMGs with multiple patch FMGs not always loading (and overriding) in the correct order.
Fixes a potential issue when trying to find the parent FMG for "TitleGoods_DLC1" due to per-game differences being checked before all FMGs were loaded.
Also cleans up a bit, and adds some additional per-game difference handling in ApplyGameDifferences(); (ReusedFMG_32).