### PR TITLE
Param "Paste after selection" improvements

### DIFF
--- a/StudioCore/CFG.cs
+++ b/StudioCore/CFG.cs
@@ -196,6 +196,7 @@ namespace StudioCore
         public bool Param_AllowFieldReorder = true;
         public bool Param_AlphabeticalParams = true;
         public bool Param_ShowVanillaParams = true;
+        public bool Param_PasteAfterSelection = false;
 
         //private string _Param_Export_Array_Delimiter = "|";
         private string _Param_Export_Delimiter = ",";

--- a/StudioCore/Editor/Action.cs
+++ b/StudioCore/Editor/Action.cs
@@ -149,16 +149,16 @@ namespace StudioCore.Editor
         private List<Param.Row> Removed = new List<Param.Row>();
         private bool appOnly = false;
         private bool replParams = false;
-        private bool useIDAsIndex = false;
+        private int InsertIndex;
 
-        public AddParamsAction(Param param, string pstring, List<Param.Row> rows, bool appendOnly, bool replaceParams, bool useIDasIndex)
+        public AddParamsAction(Param param, string pstring, List<Param.Row> rows, bool appendOnly, bool replaceParams, int index = -1)
         {
             Param = param;
             Clonables.AddRange(rows);
             ParamString = pstring;
             appOnly = appendOnly;
             replParams = replaceParams;
-            useIDAsIndex = useIDasIndex;
+            InsertIndex = index;
         }
 
         public override ActionEvent Execute()
@@ -166,9 +166,10 @@ namespace StudioCore.Editor
             foreach (var row in Clonables)
             {
                 var newrow = new Param.Row(row);
-                if (useIDAsIndex)
+                if (InsertIndex > -1)
                 {
-                    Param.InsertRow(newrow.ID, newrow);
+                    newrow.Name = row.Name != null ? row.Name + "_1" : "";
+                    Param.InsertRow(InsertIndex, newrow);
                 }
                 else
                 {

--- a/StudioCore/ParamEditor/MassParamEdit.cs
+++ b/StudioCore/ParamEditor/MassParamEdit.cs
@@ -402,7 +402,7 @@ namespace StudioCore.ParamEditor
                 }
                 changeCount = actions.Count;
                 addedCount = addedParams.Count;
-                actions.Add(new AddParamsAction(p, "legacystring", addedParams, appendOnly, replaceParams, false));
+                actions.Add(new AddParamsAction(p, "legacystring", addedParams, appendOnly, replaceParams));
                 if (changeCount != 0 || addedCount != 0)
                     actionManager.ExecuteAction(new CompoundAction(actions));
                 return new MassEditResult(MassEditResultType.SUCCESS, $@"{changeCount} cells affected, {addedCount} rows added");
@@ -486,7 +486,7 @@ namespace StudioCore.ParamEditor
             Param param = bank.Params[paramName];
             List<Param.Row> newRows = new List<Param.Row>(param.Rows);
             newRows.Sort((Param.Row a, Param.Row b)=>{return a.ID - b.ID;});
-            return new AddParamsAction(param, paramName, newRows, true, true, false); //appending same params and allowing overwrite
+            return new AddParamsAction(param, paramName, newRows, true, true); //appending same params and allowing overwrite
         }
     }
 

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -109,7 +109,6 @@ namespace StudioCore.ParamEditor
         private string _clipboardParam = null;
         private List<Param.Row> _clipboardRows = new List<Param.Row>();
         private long _clipboardBaseRow = 0;
-        private bool _ctrlVuseIndex = false;
         private string _currentCtrlVValue = "0";
         private string _currentCtrlVOffset = "0";
 
@@ -1018,11 +1017,11 @@ namespace StudioCore.ParamEditor
                 try
                 {
                     long offset = 0;
-                    ImGui.Checkbox("Paste after selection", ref _ctrlVuseIndex);
+                    ImGui.Checkbox("Paste after selection", ref CFG.Current.Param_PasteAfterSelection);
                     var insertIndex = -1;
-                    if (_ctrlVuseIndex)
+                    if (CFG.Current.Param_PasteAfterSelection)
                     {
-                        ImGui.Text("Note: You may produce out-of-order or duplicate rows. These may confuse later ID-based row additions.");
+                        //ImGui.Text("Note: Allows out-of-order rows, which may confuse later ID-based row additions.");
                     }
                     else
                     {
@@ -1042,10 +1041,10 @@ namespace StudioCore.ParamEditor
                         offset = long.Parse(_currentCtrlVValue);
                         offset = long.Parse(_currentCtrlVOffset);
                     }
-                    if (ImGui.Selectable("Submit"))
+                    if (ImGui.Button("Submit"))
                     {
                         List<Param.Row> rowsToInsert = new List<Param.Row>();
-                        if (!_ctrlVuseIndex)
+                        if (!CFG.Current.Param_PasteAfterSelection)
                         {
                             foreach (Param.Row r in _clipboardRows)
                             {

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -721,7 +721,7 @@ namespace StudioCore.ParamEditor
                 Param.Row newrow = new(r);
                 rowsToInsert.Add(newrow);
             }
-            EditorActionManager.ExecuteAction(new AddParamsAction(param, "legacystring", rowsToInsert, false, false, false));
+            EditorActionManager.ExecuteAction(new AddParamsAction(param, "legacystring", rowsToInsert, false, false));
         }
 
         public void OpenMassEditPopup(string popup)
@@ -1017,18 +1017,12 @@ namespace StudioCore.ParamEditor
                 _isShortcutPopupOpen = true;
                 try
                 {
-                    int max = -1;
                     long offset = 0;
                     ImGui.Checkbox("Paste after selection", ref _ctrlVuseIndex);
+                    var insertIndex = -1;
                     if (_ctrlVuseIndex)
                     {
                         ImGui.Text("Note: You may produce out-of-order or duplicate rows. These may confuse later ID-based row additions.");
-                        List<Param.Row> rows = _activeView._selection.getSelectedRows();
-                        Param param = ParamBank.PrimaryBank.Params[_activeView._selection.getActiveParam()];
-                        foreach (Param.Row r in rows)
-                        {
-                            max = param.IndexOfRow(r) > max ? param.IndexOfRow(r) : max;
-                        }
                     }
                     else
                     {
@@ -1048,21 +1042,39 @@ namespace StudioCore.ParamEditor
                         offset = long.Parse(_currentCtrlVValue);
                         offset = long.Parse(_currentCtrlVOffset);
                     }
-                    int index = 1;
                     if (ImGui.Selectable("Submit"))
                     {
                         List<Param.Row> rowsToInsert = new List<Param.Row>();
-                        foreach (Param.Row r in _clipboardRows)
+                        if (!_ctrlVuseIndex)
                         {
-                            Param.Row newrow = new Param.Row(r);// more cloning
-                            if (_ctrlVuseIndex)
-                                newrow.ID = (int) (max+index);
-                            else
-                                newrow.ID = (int) (r.ID + offset);
-                            rowsToInsert.Add(newrow);
-                            index++;
+                            foreach (Param.Row r in _clipboardRows)
+                            {
+                                Param.Row newrow = new Param.Row(r);// more cloning
+                                newrow.ID = (int)(r.ID + offset);
+                                rowsToInsert.Add(newrow);
+                            }
                         }
-                        EditorActionManager.ExecuteAction(new AddParamsAction(ParamBank.PrimaryBank.Params[_clipboardParam], "legacystring", rowsToInsert, false, false, _ctrlVuseIndex));
+                        else
+                        {
+                            List<Param.Row> rows = _activeView._selection.getSelectedRows();
+                            Param param = ParamBank.PrimaryBank.Params[_activeView._selection.getActiveParam()];
+                            insertIndex = param.IndexOfRow(rows.Last()) + 1;
+                            foreach (Param.Row r in _clipboardRows)
+                            {
+                                // Determine new ID based on paste target. Increment ID until a free ID is found.
+                                Param.Row newrow = new Param.Row(r);
+                                newrow.ID = _activeView._selection.getSelectedRows().Last().ID;
+                                do
+                                {
+                                    newrow.ID++;
+                                }
+                                while (ParamBank.PrimaryBank.Params[_activeView._selection.getActiveParam()][newrow.ID] != null || rowsToInsert.Exists(e => e.ID == newrow.ID));
+                                rowsToInsert.Add(newrow);
+                            }
+                            // Do a clever thing by reversing order, making ID order incremental and resulting in row insertion being in the correct order because of the static index.
+                            rowsToInsert.Reverse();
+                        }
+                        EditorActionManager.ExecuteAction(new AddParamsAction(ParamBank.PrimaryBank.Params[_clipboardParam], "legacystring", rowsToInsert, false, false, insertIndex));
                     }
                 }
                 catch


### PR DESCRIPTION
Use paste target's ID as a base and increment it until next unused ID is found (then repeat for all copied rows as).
Store Paste after Selection preference in CFG.
Remove note about out-of-order IDs considering vanilla does that already and we really just need to work around it.
Append "_1" to duped row names, matching offset paste behavior.
Replace Submit selectable with button.