### PR TITLE
Fix for Debug EXE

### DIFF
--- a/StudioCore/Assets/GameOffsets/DS1/CoreOffsets.txt
+++ b/StudioCore/Assets/GameOffsets/DS1/CoreOffsets.txt
@@ -1,8 +1,10 @@
 ﻿exeName:DARKSOULS.exe
 paramBase:0xF785B4
+paramBaseDebug:0xF7C774
 paramInnerPath:0x20
 paramCountOffset:0xA
 paramDataOffset:0x30
 rowPointerOffset:0x4
 rowHeaderSize:0xC
 throwParamBase:0xF785C4
+throwParamBaseDebug:0xF7C784


### PR DESCRIPTION
Checks exe dos header for offset of new header, as the dosstub is bigger in the debug exe. Will eventually switch out for AoBs