### PR TITLE
BTL improvements & cleanup. Add Create BTL Light option

### DIFF
--- a/StudioCore/MsbEditor/Action.cs
+++ b/StudioCore/MsbEditor/Action.cs
@@ -305,7 +305,7 @@ namespace StudioCore.MsbEditor
                     if (Clonables[i].Parent != null)
                     {
                         int idx = Clonables[i].Parent.ChildIndex(Clonables[i]);
-                        Clonables[i].Parent.AddChild(newobj, idx);
+                        Clonables[i].Parent.AddChild(newobj, idx + 1);
                     }
                     newobj.UpdateRenderModel();
                     if (newobj.RenderSceneMesh != null)

--- a/StudioCore/MsbEditor/Action.cs
+++ b/StudioCore/MsbEditor/Action.cs
@@ -375,16 +375,18 @@ namespace StudioCore.MsbEditor
         private List<MapEntity> Added = new List<MapEntity>();
         private List<ObjectContainer> AddedMaps = new List<ObjectContainer>();
         private bool SetSelection;
+        private Entity Parent;
 
         private static Regex TrailIDRegex = new Regex(@"_(?<id>\d+)$");
 
-        public AddMapObjectsAction(Universe univ, Map map, Scene.RenderScene scene, List<MapEntity> objects, bool setSelection)
+        public AddMapObjectsAction(Universe univ, Map map, Scene.RenderScene scene, List<MapEntity> objects, bool setSelection, Entity parent)
         {
             Universe = univ;
             Map = map;
             Scene = scene;
             Added.AddRange(objects);
             SetSelection = setSelection;
+            Parent = parent;
         }
 
         public override ActionEvent Execute()
@@ -394,7 +396,7 @@ namespace StudioCore.MsbEditor
                 if (Map != null)
                 {
                     Map.Objects.Add(Added[i]);
-                    Map.RootObject.AddChild(Added[i]);
+                    Parent.AddChild(Added[i]);
                     Added[i].UpdateRenderModel();
                     if (Added[i].RenderSceneMesh != null)
                     {

--- a/StudioCore/MsbEditor/Entity.cs
+++ b/StudioCore/MsbEditor/Entity.cs
@@ -24,8 +24,6 @@ namespace StudioCore.MsbEditor
 
         private string CachedName = null;
 
-        public string ExtraSaveInfo = null;
-
         [XmlIgnore]
         public ObjectContainer Container { get; set; } = null;
 
@@ -139,6 +137,8 @@ namespace StudioCore.MsbEditor
                 {
                     RenderSceneMesh.Visible = _EditorVisible;
                 }
+                foreach (var child in Children)
+                    child.EditorVisible = _EditorVisible;
             }
         }
 
@@ -184,7 +184,6 @@ namespace StudioCore.MsbEditor
             {
                 if (Children[i] == child)
                 {
-
                     return i;
                 }
             }
@@ -289,8 +288,6 @@ namespace StudioCore.MsbEditor
             var clone = DeepCopyObject(WrappedObject);
             var obj = DuplicateEntity(clone);
             CloneRenderable(obj);
-            obj.UseDrawGroups = UseDrawGroups;
-            obj.ExtraSaveInfo = ExtraSaveInfo;
             return obj;
         }
 
@@ -1179,7 +1176,7 @@ namespace StudioCore.MsbEditor
             WrappedObject = msbo;
         }
 
-        public MapEntity(ObjectContainer map, object msbo, MapEntityType type, string btlFile = null)
+        public MapEntity(ObjectContainer map, object msbo, MapEntityType type)
         {
             Container = map;
             WrappedObject = msbo;
@@ -1187,11 +1184,6 @@ namespace StudioCore.MsbEditor
             if (!(msbo is Param.Row) && !(msbo is MergedParamRow))
             {
                 CurrentModel = GetPropertyValue<string>("ModelName");
-            }
-            if (type is MapEntityType.Light)
-            {
-                ExtraSaveInfo = btlFile;
-                //OffsetBtlLight();
             }
         }
 

--- a/StudioCore/MsbEditor/SceneTree.cs
+++ b/StudioCore/MsbEditor/SceneTree.cs
@@ -511,13 +511,13 @@ namespace StudioCore.MsbEditor
                                 }
                                 else if (cats.Key == MapEntity.MapEntityType.Light)
                                 {
-                                    var btlFiles = typ.Value.DistinctBy(e => e.ExtraSaveInfo); // TODO2: cache this
-                                    foreach (var btlFile in btlFiles)
+                                    foreach (var parent in map.BTLParents)
                                     {
-                                        if (ImGui.TreeNodeEx($"{typ.Key.Name} {btlFile.ExtraSaveInfo}", ImGuiTreeNodeFlags.OpenOnArrow))
+                                        AssetDescription parentAD = (AssetDescription)parent.WrappedObject;
+                                        if (ImGui.TreeNodeEx($"{typ.Key.Name} {parentAD.AssetName}", ImGuiTreeNodeFlags.OpenOnArrow))
                                         {
                                             ImGui.SetItemAllowOverlap();
-                                            bool visible = btlFile.EditorVisible;
+                                            bool visible = parent.EditorVisible;
                                             ImGui.SameLine(ImGui.GetContentRegionAvail().X - 18.0f);
                                             ImGui.PushStyleColor(ImGuiCol.Text, visible ? new Vector4(1.0f, 1.0f, 1.0f, 1.0f)
                                                 : new Vector4(0.6f, 0.6f, 0.6f, 1.0f));
@@ -526,29 +526,18 @@ namespace StudioCore.MsbEditor
                                             if (ImGui.IsItemClicked(0))
                                             {
                                                 // Hide/Unhide all lights within this BTL.
-                                                btlFile.EditorVisible = !btlFile.EditorVisible;
-                                                foreach (var obj in typ.Value)
-                                                {
-                                                    if (obj.ExtraSaveInfo == btlFile.ExtraSaveInfo)
-                                                    {
-                                                        obj.EditorVisible = btlFile.EditorVisible;
-                                                    }
-                                                }
+                                                parent.EditorVisible = !parent.EditorVisible;
                                             }
-
-                                            foreach (var obj in typ.Value)
+                                            foreach (var obj in parent.Children)
                                             {
-                                                if (obj.ExtraSaveInfo == btlFile.ExtraSaveInfo)
-                                                {
-                                                    MapObjectSelectable(obj, true);
-                                                }
+                                                MapObjectSelectable(obj, true);
                                             }
                                             ImGui.TreePop();
                                         }
                                         else
                                         {
                                             ImGui.SetItemAllowOverlap();
-                                            bool visible = btlFile.EditorVisible;
+                                            bool visible = parent.EditorVisible;
                                             ImGui.SameLine(ImGui.GetContentRegionAvail().X - 39.0f);
                                             ImGui.PushStyleColor(ImGuiCol.Text, visible ? new Vector4(1.0f, 1.0f, 1.0f, 1.0f)
                                                 : new Vector4(0.6f, 0.6f, 0.6f, 1.0f));
@@ -557,14 +546,7 @@ namespace StudioCore.MsbEditor
                                             if (ImGui.IsItemClicked(0))
                                             {
                                                 // Hide/Unhide all lights within this BTL.
-                                                btlFile.EditorVisible = !btlFile.EditorVisible;
-                                                foreach (var obj in typ.Value)
-                                                {
-                                                    if (obj.ExtraSaveInfo == btlFile.ExtraSaveInfo)
-                                                    {
-                                                        obj.EditorVisible = btlFile.EditorVisible;
-                                                    }
-                                                }
+                                                parent.EditorVisible = !parent.EditorVisible;
                                             }
                                         }
                                     }


### PR DESCRIPTION
Adds create BTL Light option in create menu.

Makes BTL implementation a bit cleaner and (moderately) less stupid.
BTL lights now utilize entity parent/child system for organizing which lights belong to which BTL.
Adjusts CloneMapObjectsAction and AddMapObjectsAction to work better with parent/children (this shouldn't affect any pre-existing behavior).
Cleans up old/commented-out code.
Fixes a very minor bug with BTL Hide All/Unhide All UI element visually reflecting first light's hidden state.