### PR TITLE
Transform Font scale to UI scale.

### DIFF
--- a/StudioCore/CFG.cs
+++ b/StudioCore/CFG.cs
@@ -183,7 +183,7 @@ namespace StudioCore
         public bool FontThai = false;
         public bool FontVietnamese = false;
         public bool FontCyrillic = false;
-        public float FontSizeScale = 1.0f;
+        public float UIScale = 1.0f;
 
         // FMG Editor settings
         public bool FMG_ShowOriginalNames = false;

--- a/StudioCore/Editor/UIHints.cs
+++ b/StudioCore/Editor/UIHints.cs
@@ -124,6 +124,7 @@ Some common tools for mapstudio include:
 
         public static bool AddImGuiHintButton(string id, ref string hint, bool canEdit = false, bool isRowHint = false)
         {
+            float scale = ImGuiRenderer.GetUIScale();
             bool ret = false;
             ImGui.SameLine();
             /*
@@ -150,7 +151,7 @@ Some common tools for mapstudio include:
                 {
                     if (ParamEditor.ParamEditorScreen.EditorMode && canEdit) //remove this, editor mode should be called earlier
                     {
-                        ImGui.InputTextMultiline("", ref hint, 8196, new Vector2(720, 480));
+                        ImGui.InputTextMultiline("", ref hint, 8196, new Vector2(720, 480) * scale);
                         if (ImGui.IsItemDeactivatedAfterEdit())
                             ret = true;
                     }
@@ -171,7 +172,7 @@ Some common tools for mapstudio include:
 
                     if (ParamEditor.ParamEditorScreen.EditorMode && canEdit) //remove this, editor mode should be called earlier
                     {
-                        ImGui.InputTextMultiline("", ref hint, 8196, new Vector2(720, 480));
+                        ImGui.InputTextMultiline("", ref hint, 8196, new Vector2(720, 480) * scale);
                         if (ImGui.IsItemDeactivatedAfterEdit())
                             ret = true;
                     }

--- a/StudioCore/ImGuiRenderer.cs
+++ b/StudioCore/ImGuiRenderer.cs
@@ -658,6 +658,12 @@ namespace StudioCore
                 resource.Dispose();
             }
         }
+        
+        public static float GetUIScale()
+        {
+            // TODO: Multiply with DPI. Seems to always return 1.0
+            return CFG.Current.UIScale * ImGui.GetWindowDpiScale();
+        }
 
         private struct ResourceSetInfo
         {

--- a/StudioCore/ImGuiRenderer.cs
+++ b/StudioCore/ImGuiRenderer.cs
@@ -661,8 +661,8 @@ namespace StudioCore
         
         public static float GetUIScale()
         {
-            // TODO: Multiply with DPI. Seems to always return 1.0
-            return CFG.Current.UIScale * ImGui.GetWindowDpiScale();
+            // TODO: Multiply by monitor DPI when available.
+            return CFG.Current.UIScale;
         }
 
         private struct ResourceSetInfo

--- a/StudioCore/MsbEditor/DisplayGroupsEditor.cs
+++ b/StudioCore/MsbEditor/DisplayGroupsEditor.cs
@@ -20,6 +20,8 @@ namespace StudioCore.MsbEditor
 
         public void OnGui(int dispCount)
         {
+            float scale = ImGuiRenderer.GetUIScale();
+
             uint[] sdrawgroups = null;
             uint[] sdispgroups = null;
             var sel = _selection.GetSingleFilteredSelection<Entity>();
@@ -34,7 +36,7 @@ namespace StudioCore.MsbEditor
             }
 
 
-            ImGui.SetNextWindowSize(new Vector2(100, 100));
+            ImGui.SetNextWindowSize(new Vector2(100, 100) * scale);
 
             if (InputTracker.GetKeyDown(KeyBindings.Current.Map_RenderGroup_GetDisp)
             || InputTracker.GetKeyDown(KeyBindings.Current.Map_RenderGroup_GetDraw)

--- a/StudioCore/MsbEditor/ModelEditorScreen.cs
+++ b/StudioCore/MsbEditor/ModelEditorScreen.cs
@@ -156,12 +156,13 @@ namespace StudioCore.MsbEditor
 
         public void OnGUI()
         {
+            float scale = ImGuiRenderer.GetUIScale();
             // Docking setup
             //var vp = ImGui.GetMainViewport();
             var wins = ImGui.GetWindowSize();
             var winp = ImGui.GetWindowPos();
-            winp.Y += 20.0f;
-            wins.Y -= 20.0f;
+            winp.Y += 20.0f * scale;
+            wins.Y -= 20.0f * scale;
             ImGui.SetNextWindowPos(winp);
             ImGui.SetNextWindowSize(wins);
             var dsid = ImGui.GetID("DockSpace_ModelEdit");
@@ -242,8 +243,8 @@ namespace StudioCore.MsbEditor
                 }
             }
 
-            ImGui.SetNextWindowSize(new Vector2(300, 500), ImGuiCond.FirstUseEver);
-            ImGui.SetNextWindowPos(new Vector2(20, 20), ImGuiCond.FirstUseEver);
+            ImGui.SetNextWindowSize(new Vector2(300, 500) * scale, ImGuiCond.FirstUseEver);
+            ImGui.SetNextWindowPos(new Vector2(20, 20) * scale, ImGuiCond.FirstUseEver);
 
             System.Numerics.Vector3 clear_color = new System.Numerics.Vector3(114f / 255f, 144f / 255f, 154f / 255f);
             //ImGui.Text($@"Viewport size: {Viewport.Width}x{Viewport.Height}");

--- a/StudioCore/MsbEditor/MsbEditorScreen.cs
+++ b/StudioCore/MsbEditor/MsbEditorScreen.cs
@@ -541,12 +541,14 @@ namespace StudioCore.MsbEditor
 
         public void OnGUI(string[] initcmd)
         {
+            float scale = ImGuiRenderer.GetUIScale();
+
             // Docking setup
             //var vp = ImGui.GetMainViewport();
             var wins = ImGui.GetWindowSize();
             var winp = ImGui.GetWindowPos();
-            winp.Y += 20.0f;
-            wins.Y -= 20.0f;
+            winp.Y += 20.0f * scale;
+            wins.Y -= 20.0f * scale;
             ImGui.SetNextWindowPos(winp);
             ImGui.SetNextWindowSize(wins);
             ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, 0.0f);
@@ -720,8 +722,8 @@ namespace StudioCore.MsbEditor
                 }
             }
 
-            ImGui.SetNextWindowSize(new Vector2(300, 500), ImGuiCond.FirstUseEver);
-            ImGui.SetNextWindowPos(new Vector2(20, 20), ImGuiCond.FirstUseEver);
+            ImGui.SetNextWindowSize(new Vector2(300, 500) * scale, ImGuiCond.FirstUseEver);
+            ImGui.SetNextWindowPos(new Vector2(20, 20) * scale, ImGuiCond.FirstUseEver);
 
             System.Numerics.Vector3 clear_color = new System.Numerics.Vector3(114f / 255f, 144f / 255f, 154f / 255f);
             //ImGui.Text($@"Viewport size: {Viewport.Width}x{Viewport.Height}");

--- a/StudioCore/MsbEditor/PropertyEditor.cs
+++ b/StudioCore/MsbEditor/PropertyEditor.cs
@@ -587,6 +587,7 @@ namespace StudioCore.MsbEditor
 
         private void PropEditorGeneric(Selection selection, HashSet<Entity> entSelection, object target = null, bool decorate = true)
         {
+            float scale = ImGuiRenderer.GetUIScale();
             var firstEnt = entSelection.First();
             var obj = (target == null) ? firstEnt.WrappedObject : target;
             var type = obj.GetType();
@@ -906,7 +907,7 @@ namespace StudioCore.MsbEditor
                 {
                     ImGui.NewLine();
                     ImGui.Text("References: ");
-                    ImGui.Indent(10);
+                    ImGui.Indent(10 * scale);
                     foreach (var m in firstEnt.References)
                     {
                         foreach (var n in m.Value)
@@ -966,10 +967,10 @@ namespace StudioCore.MsbEditor
                         }
                     }
                 }
-                ImGui.Unindent(10);
+                ImGui.Unindent(10 * scale);
                 ImGui.NewLine();
                 ImGui.Text("Objects referencing this object:");
-                ImGui.Indent(10);
+                ImGui.Indent(10 * scale);
                 foreach (var m in firstEnt.GetReferencingObjects())
                 {
                     var nameWithType = m.PrettyName.Insert(2, m.WrappedObject.GetType().Name + " - ");
@@ -980,17 +981,18 @@ namespace StudioCore.MsbEditor
                     }
                     refID++;
                 }
-                ImGui.Unindent(10);
+                ImGui.Unindent(10 * scale);
             }
         }
 
         public void OnGui(Selection selection, string id, float w, float h)
         {
+            float scale = ImGuiRenderer.GetUIScale();
             var entSelection = selection.GetFilteredSelection<Entity>();
 
             ImGui.PushStyleColor(ImGuiCol.ChildBg, new Vector4(0.145f, 0.145f, 0.149f, 1.0f));
-            ImGui.SetNextWindowSize(new Vector2(350, h - 80), ImGuiCond.FirstUseEver);
-            ImGui.SetNextWindowPos(new Vector2(w - 370, 20), ImGuiCond.FirstUseEver);
+            ImGui.SetNextWindowSize(new Vector2(350, h - 80) * scale, ImGuiCond.FirstUseEver);
+            ImGui.SetNextWindowPos(new Vector2(w - 370, 20) * scale, ImGuiCond.FirstUseEver);
             ImGui.Begin($@"Properties##{id}");
             ImGui.BeginChild("propedit");
             if (entSelection.Count > 1)

--- a/StudioCore/MsbEditor/SceneTree.cs
+++ b/StudioCore/MsbEditor/SceneTree.cs
@@ -192,6 +192,8 @@ namespace StudioCore.MsbEditor
         private ulong _mapEnt_ImGuiID = 0; // Needed to avoid issue with identical IDs during keyboard navigation. May be unecessary when ImGUI is updated.
         unsafe private void MapObjectSelectable(Entity e, bool visicon, bool hierarchial=false)
         {
+            float scale = ImGuiRenderer.GetUIScale();
+            
             // Main selectable
             if (e is MapEntity me)
             {
@@ -413,12 +415,12 @@ namespace StudioCore.MsbEditor
                 if (e is MapEntity me2)
                 {
                     ImGui.SetItemAllowOverlap();
-                    ImGui.InvisibleButton(me2.Type.ToString() + e.Name, new Vector2(-1, 3.0f));
+                    ImGui.InvisibleButton(me2.Type.ToString() + e.Name, new Vector2(-1, 3.0f) * scale);
                 }
                 else
                 {
                     ImGui.SetItemAllowOverlap();
-                    ImGui.InvisibleButton(e.Name, new Vector2(-1, 3.0f));
+                    ImGui.InvisibleButton(e.Name, new Vector2(-1, 3.0f) * scale);
                 }
                 if (ImGui.IsItemFocused())
                 {
@@ -598,6 +600,8 @@ namespace StudioCore.MsbEditor
 
         public void OnGui()
         {
+            float scale = ImGuiRenderer.GetUIScale();
+
             ImGui.PushStyleColor(ImGuiCol.ChildBg, new Vector4(0.145f, 0.145f, 0.149f, 1.0f));
             if (_configuration == Configuration.MapEditor)
             {
@@ -605,7 +609,7 @@ namespace StudioCore.MsbEditor
             }
             else
             {
-                ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(0.0f, 2.0f));
+                ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(0.0f, 2.0f) * scale);
             }
             string titleString = _configuration == Configuration.MapEditor ? $@"Map Object List##{_id}" : $@"Model Hierarchy##{_id}";
             if (ImGui.Begin(titleString))
@@ -624,7 +628,7 @@ namespace StudioCore.MsbEditor
                 if (_configuration == Configuration.MapEditor)
                 {
                     ImGui.Spacing();
-                    ImGui.Indent(30);
+                    ImGui.Indent(30 * scale);
                     ImGui.AlignTextToFramePadding();
                     ImGui.Text("List Sorting Style:");
                     ImGui.SameLine();
@@ -642,7 +646,7 @@ namespace StudioCore.MsbEditor
                     ImGui.SetNextItemWidth(-1);
                     ImGui.InputText("##treeSearch", ref _mapNameSearchStr, 99);
 
-                    ImGui.Unindent(30);
+                    ImGui.Unindent(30 * scale);
                 }
 
                 ImGui.BeginChild("listtree");
@@ -806,11 +810,11 @@ namespace StudioCore.MsbEditor
                     {
                         if (_pendingDragDrop)
                         {
-                            ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(8.0f, 0.0f));
+                            ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(8.0f, 0.0f) * scale);
                         }
                         else
                         {
-                            ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(8.0f, 3.0f));
+                            ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(8.0f, 3.0f) * scale);
                         }
                         if (_viewMode == ViewMode.Hierarchy)
                         {

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -732,12 +732,14 @@ namespace StudioCore.ParamEditor
 
         public void MassEditPopups()
         {
+            float scale = ImGuiRenderer.GetUIScale();
+            
             // Popup size relies on magic numbers. Multiline maxlength is also arbitrary.
             if (ImGui.BeginPopup("massEditMenuRegex"))
             {
                 ImGui.Text("param PARAM: id VALUE: FIELD: = VALUE;");
                 UIHints.AddImGuiHintButton("MassEditHint", ref UIHints.MassEditHint);
-                ImGui.InputTextMultiline("##MEditRegexInput", ref _currentMEditRegexInput, 65536, new Vector2(1024, ImGui.GetTextLineHeightWithSpacing() * 4));
+                ImGui.InputTextMultiline("##MEditRegexInput", ref _currentMEditRegexInput, 65536, new Vector2(1024, ImGui.GetTextLineHeightWithSpacing() * 4) * scale);
 
                 if (ImGui.Selectable("Submit", false, ImGuiSelectableFlags.DontClosePopups))
                 {
@@ -754,23 +756,23 @@ namespace StudioCore.ParamEditor
                     _mEditRegexResult = r.Information;
                 }
                 ImGui.Text(_mEditRegexResult);
-                ImGui.InputTextMultiline("##MEditRegexOutput", ref _lastMEditRegexInput, 65536, new Vector2(1024, ImGui.GetTextLineHeightWithSpacing() * 4), ImGuiInputTextFlags.ReadOnly);
+                ImGui.InputTextMultiline("##MEditRegexOutput", ref _lastMEditRegexInput, 65536, new Vector2(1024, ImGui.GetTextLineHeightWithSpacing() * 4) * scale, ImGuiInputTextFlags.ReadOnly);
                 ImGui.EndPopup();
             }
             else if (ImGui.BeginPopup("massEditMenuCSVExport"))
             {
-                ImGui.InputTextMultiline("##MEditOutput", ref _currentMEditCSVOutput, 65536, new Vector2(1024, ImGui.GetTextLineHeightWithSpacing() * 4), ImGuiInputTextFlags.ReadOnly);
+                ImGui.InputTextMultiline("##MEditOutput", ref _currentMEditCSVOutput, 65536, new Vector2(1024, ImGui.GetTextLineHeightWithSpacing() * 4) * scale, ImGuiInputTextFlags.ReadOnly);
                 ImGui.EndPopup();
             }
             else if (ImGui.BeginPopup("massEditMenuSingleCSVExport"))
             {
                 ImGui.Text(_currentMEditSingleCSVField);
-                ImGui.InputTextMultiline("##MEditOutput", ref _currentMEditCSVOutput, 65536, new Vector2(1024, ImGui.GetTextLineHeightWithSpacing() * 4), ImGuiInputTextFlags.ReadOnly);
+                ImGui.InputTextMultiline("##MEditOutput", ref _currentMEditCSVOutput, 65536, new Vector2(1024, ImGui.GetTextLineHeightWithSpacing() * 4) * scale, ImGuiInputTextFlags.ReadOnly);
                 ImGui.EndPopup();
             }
             else if (ImGui.BeginPopup("massEditMenuCSVImport"))
             {
-                ImGui.InputTextMultiline("##MEditRegexInput", ref _currentMEditCSVInput, 256 * 65536, new Vector2(1024, ImGui.GetTextLineHeightWithSpacing() * 4));
+                ImGui.InputTextMultiline("##MEditRegexInput", ref _currentMEditCSVInput, 256 * 65536, new Vector2(1024, ImGui.GetTextLineHeightWithSpacing() * 4) * scale);
                 ImGui.Checkbox("Append new rows instead of ID based insertion (this will create out-of-order IDs)", ref _mEditCSVAppendOnly);
                 if (_mEditCSVAppendOnly)
                     ImGui.Checkbox("Replace existing rows instead of updating them (they will be moved to the end)", ref _mEditCSVReplaceRows);
@@ -790,7 +792,7 @@ namespace StudioCore.ParamEditor
             else if (ImGui.BeginPopup("massEditMenuSingleCSVImport"))
             {
                 ImGui.Text(_currentMEditSingleCSVField);
-                ImGui.InputTextMultiline("##MEditRegexInput", ref _currentMEditCSVInput, 256 * 65536, new Vector2(1024, ImGui.GetTextLineHeightWithSpacing() * 4));
+                ImGui.InputTextMultiline("##MEditRegexInput", ref _currentMEditCSVInput, 256 * 65536, new Vector2(1024, ImGui.GetTextLineHeightWithSpacing() * 4) * scale);
                 DelimiterInputText();
                 if (ImGui.Selectable("Submit", false, ImGuiSelectableFlags.DontClosePopups))
                 {
@@ -811,6 +813,8 @@ namespace StudioCore.ParamEditor
 
         public void OnGUI(string[] initcmd)
         {
+            float scale = ImGuiRenderer.GetUIScale();
+
             if (!_isMEditPopupOpen && !_isShortcutPopupOpen && !_isSearchBarActive)// Are shortcuts active? Presently just checks for massEdit popup.
             {
                 // Keyboard shortcuts
@@ -989,7 +993,7 @@ namespace StudioCore.ParamEditor
                         continue;
                     string name = view._selection.getActiveRow() != null ? view._selection.getActiveRow().Name : null;
                     string toDisplay = (view == _activeView ? "**" : "") + (name == null || name.Trim().Equals("") ? "Param Editor View" : Utils.ImGuiEscape(name, "null")) + (view == _activeView ? "**" : "");
-                    ImGui.SetNextWindowSize(new Vector2(1280.0f, 720.0f), ImGuiCond.Once);
+                    ImGui.SetNextWindowSize(new Vector2(1280.0f, 720.0f) * scale, ImGuiCond.Once);
                     ImGui.SetNextWindowDockID(ImGui.GetID("DockSpace_ParamEditorViews"), ImGuiCond.Once);
                     ImGui.Begin($@"{toDisplay}###ParamEditorView##{view._viewIndex}");
                     if (ImGui.IsItemClicked(ImGuiMouseButton.Left))

--- a/StudioCore/ParamEditor/ParamRowEditor.cs
+++ b/StudioCore/ParamEditor/ParamRowEditor.cs
@@ -604,7 +604,9 @@ namespace StudioCore.ParamEditor
 
         private void PropertyRowNameContextMenu(ParamBank bank, string originalName, FieldMetaData cellMeta, string activeParam, bool showPinOptions, bool isPinned)
         {
-            ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(0f, 10f));
+            float scale = ImGuiRenderer.GetUIScale();
+
+            ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(0f, 10f) * scale);
             if (ImGui.BeginPopupContextItem("rowName"))
             {
                 if (CFG.Current.Param_ShowAltNames == true && CFG.Current.Param_AlwaysShowOriginalName == false)

--- a/StudioCore/Resource/ResourceManager.cs
+++ b/StudioCore/Resource/ResourceManager.cs
@@ -790,10 +790,12 @@ namespace StudioCore.Resource
         private static bool ResourceListWindowOpen = true;
         public static void OnGuiDrawTasks(float w, float h)
         {
+            float scale = ImGuiRenderer.GetUIScale();
+            
             if (ActiveJobProgress.Count() > 0)
             {
-                ImGui.SetNextWindowSize(new Vector2(400, 310));
-                ImGui.SetNextWindowPos(new Vector2(w - 100, h - 300));
+                ImGui.SetNextWindowSize(new Vector2(400, 310) * scale);
+                ImGui.SetNextWindowPos(new Vector2(w - (100 * scale), h - (300 * scale)));
                 if (!ImGui.Begin("Resource Loading Tasks", ref TaskWindowOpen, ImGuiWindowFlags.NoDecoration))
                 {
                     ImGui.End();
@@ -812,7 +814,7 @@ namespace StudioCore.Resource
                         }
                         else
                         {
-                            ImGui.ProgressBar((float)completed / (float)size, new Vector2(386.0f, 20.0f));
+                            ImGui.ProgressBar((float)completed / (float)size, new Vector2(386.0f, 20.0f) * scale);
                         }
                     }
                 }

--- a/StudioCore/Scene/CreatePrefabModal.cs
+++ b/StudioCore/Scene/CreatePrefabModal.cs
@@ -33,9 +33,11 @@ namespace StudioCore.Scene
 
         public void OnGui()
         {
-            ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, 7.0f);
+            float scale = ImGuiRenderer.GetUIScale();
+
+            ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, 7.0f * scale);
             ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 1.0f);
-            ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(14.0f, 8.0f));
+            ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(14.0f, 8.0f) * scale);
             if (ImGui.BeginPopupModal("Create Prefab", ref _open, ImGuiWindowFlags.AlwaysAutoResize))
             {
                 ImGui.AlignTextToFramePadding();
@@ -48,7 +50,7 @@ namespace StudioCore.Scene
                 }
                 ImGui.NewLine();
 
-                if (ImGui.Button("Create", new Vector2(120, 0)))
+                if (ImGui.Button("Create", new Vector2(120, 0) * scale))
                 {
                     bool validated = true;
 
@@ -59,7 +61,7 @@ namespace StudioCore.Scene
                     }
                 }
                 ImGui.SameLine();
-                if (ImGui.Button("Cancel", new Vector2(120, 0)))
+                if (ImGui.Button("Cancel", new Vector2(120, 0) * scale))
                 {
                     ImGui.CloseCurrentPopup();
                 }

--- a/StudioCore/TextEditor/TextEditorScreen.cs
+++ b/StudioCore/TextEditor/TextEditorScreen.cs
@@ -448,11 +448,13 @@ namespace StudioCore.TextEditor
                 return;
             }
 
+            var scale = ImGuiRenderer.GetUIScale();
+
             // Docking setup
             var wins = ImGui.GetWindowSize();
             var winp = ImGui.GetWindowPos();
-            winp.Y += 20.0f;
-            wins.Y -= 20.0f;
+            winp.Y += 20.0f * scale;
+            wins.Y -= 20.0f * scale;
             ImGui.SetNextWindowPos(winp);
             ImGui.SetNextWindowSize(wins);
 


### PR DESCRIPTION
Renamed font scale to UI scale and added it as a multiplier to various sizes in the program. This is to make the program appear uniform at different monitor sizes where one might choose to scale it up.

Also, changed the UI scale slider to only perform scaling when let go of, and lowered its rounding to steps of 0.05.

Note that this is not a comprehensive solution. Dear ImGui says the following about DPI awareness:

> ### Q: How should I handle DPI in my application?
> 
> The short answer is: obtain the desired DPI scale, load your fonts resized with that scale (always round down fonts size to the nearest integer), and scale your Style structure accordingly using `style.ScaleAllSizes()`.
> 
> Your application may want to detect DPI change and reload the fonts and reset style between frames.
> 
> Your ui code  should avoid using hardcoded constants for size and positioning. Prefer to express values as multiple of reference values such as `ImGui::GetFontSize()` or `ImGui::GetFrameHeight()`. So e.g. instead of seeing a hardcoded height of 500 for a given item/window, you may want to use `30*ImGui::GetFontSize()` instead.
> 
> Down the line Dear ImGui will provide a variety of standardized reference values to facilitate using this.

So, down the line, instead of the changes I made to StyleVars, `style.ScaleAllSizes()` should be used instead.

The various hardcoded plain numbers used for sizes should be transformed into references to Font Size according to the instructions above.

Also, the DPI of the monitor should be read, and ideally changed as the program is moved from monitor to monitor. Currently, this is not the case.

Fonts, of course, should also be refreshed when the slider is changed, rather than requiring a restart.

However, this early solution will at least make the program usable again on larger monitors with DPI scaled up.

##  Comparisons:

These are at 4K with 225% DPI.

### Current 1.04 (no DPI awareness) (1.00 Font Scale)

![2022-11-20_19-42-56__DSMapStudio](https://user-images.githubusercontent.com/1077140/202920804-0dc35c39-cdcb-498a-a63a-41c85d9d7965.png)

### Current master branch (DPI aware) (2.25 Font Scale)

![2022-11-20_19-43-35__DSMapStudio](https://user-images.githubusercontent.com/1077140/202920817-2833efa1-d897-4d6d-8da4-aefa4a7b5608.png)

### My branch (DPI aware) (2.25 UI Scale)

![2022-11-20_19-52-17__DSMapStudio](https://user-images.githubusercontent.com/1077140/202920846-6fbe16d8-8ab7-46e9-ac97-5efc79277654.png)
