### PR TITLE
Small tweaks to editors.

### DIFF
--- a/StudioCore/MsbEditor/AssetBrowser.cs
+++ b/StudioCore/MsbEditor/AssetBrowser.cs
@@ -87,13 +87,17 @@ namespace StudioCore.MsbEditor
                 }
                 ImGui.EndChild();
                 ImGui.NextColumn();
-                ImGui.BeginChild("AssetList");
+                ImGui.BeginChild("AssetListSearch");
 
                 if (InputTracker.GetKeyDown(KeyBindings.Current.Map_PropSearch))
                     ImGui.SetKeyboardFocusHere();
                 ImGui.InputText($"Search <{KeyBindings.Current.Map_PropSearch.HintText}>", ref _searchStr, 255);
 
+                ImGui.Spacing();
                 ImGui.Separator();
+                ImGui.Spacing();
+
+                ImGui.BeginChild("AssetList");
 
                 if (_selected == "Chr")
                 {

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -1422,7 +1422,7 @@ namespace StudioCore.ParamEditor
                     int gotorow = 0;
                     ImGui.SetKeyboardFocusHere();
                     ImGui.InputInt("Goto Row ID", ref gotorow);
-                    if (ImGui.IsItemDeactivated())
+                    if (ImGui.IsItemDeactivatedAfterEdit())
                     {
                         _gotoParamRow = gotorow;
                         ImGui.CloseCurrentPopup();
@@ -1447,6 +1447,10 @@ namespace StudioCore.ParamEditor
                     _paramEditor._isSearchBarActive = false;
                 UIHints.AddImGuiHintButton("MassEditHint", ref UIHints.SearchBarHint);
 
+                ImGui.Spacing();
+                ImGui.Separator();
+                ImGui.Spacing();
+                
                 ImGui.BeginChild("pinnedRows");
 
                 List<int> pinnedRowList = new List<int>(_paramEditor._projectSettings.PinnedRows.GetValueOrDefault(activeParam, new List<int>()));
@@ -1540,7 +1544,7 @@ namespace StudioCore.ParamEditor
             }
 
             var selected = _selection.getSelectedRows().Contains(r);
-            if (_gotoParamRow != -1)
+            if (_gotoParamRow != -1 && !isPinned)
             {
                 // Goto row was activated. As soon as a corresponding ID is found, change selection to it.
                 if (r.ID == _gotoParamRow)


### PR DESCRIPTION
* "Goto ID" no longer goes to a pinned ID, but the actual ID in the list.
* "Goto ID" no longer goes to 0 if you did not enter anything and just click out of the popup.
* Search bar in Model Editor Asset Browser no longer scrolls along with the list.