### PR TITLE
MSB targeted dupe fixes

### DIFF
--- a/StudioCore/MsbEditor/Action.cs
+++ b/StudioCore/MsbEditor/Action.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using SoulsFormats;
+using StudioCore.Editor;
 
 namespace StudioCore.MsbEditor
 {
@@ -316,31 +317,40 @@ namespace StudioCore.MsbEditor
         private List<MapEntity> Clones = new List<MapEntity>();
         private List<ObjectContainer> CloneMaps = new List<ObjectContainer>();
         private bool SetSelection;
-        private Map MapTarget;
+        private Map TargetMap;
+        private Entity TargetBTL;
 
         private static Regex TrailIDRegex = new Regex(@"_(?<id>\d+)$");
 
-        public CloneMapObjectsAction(Universe univ, Scene.RenderScene scene, List<MapEntity> objects, bool setSelection, Map mapTarget = null)
+        public CloneMapObjectsAction(Universe univ, Scene.RenderScene scene, List<MapEntity> objects, bool setSelection, Map targetMap = null, Entity targetBTL = null)
         {
             Universe = univ;
             Scene = scene;
             Clonables.AddRange(objects);
             SetSelection = setSelection;
-            MapTarget = mapTarget;
+            TargetMap = targetMap;
+            TargetBTL = targetBTL;
         }
 
         public override ActionEvent Execute()
         {
             bool clonesCached = Clones.Count() > 0;
-            // foreach (var obj in Clonables)
 
             var objectnames = new Dictionary<string, HashSet<string>>();
             for (int i = 0; i < Clonables.Count(); i++)
             {
-                Map? m;
-                if (MapTarget != null)
+                if (Clonables[i].MapID == null)
                 {
-                    m = Universe.GetLoadedMap(MapTarget.Name);
+#if DEBUG
+                    TaskManager.warningList.TryAdd("FailedDupeNoMapID"+Clonables[i].Name, $"DEBUG Failed to dupe {Clonables[i].Name}, as it had no defined MapID");
+#endif
+                    continue;
+                }
+
+                Map? m;
+                if (TargetMap != null)
+                {
+                    m = Universe.GetLoadedMap(TargetMap.Name);
                 }
                 else
                 {
@@ -393,17 +403,20 @@ namespace StudioCore.MsbEditor
                     }
 
                     m.Objects.Insert(m.Objects.IndexOf(Clonables[i]) + 1, newobj);
-                    if (MapTarget != null)
+                    if (TargetBTL != null && newobj.WrappedObject is BTL.Light)
                     {
-                        // Duping to a targeted map.
-                        // This will cause issues for entities with non-root object parents (like BTL lights), and they should be forbidden from duping to targeted maps.
-                        if (MapTarget.MapOffsetNode != null)
+                        TargetBTL.AddChild(newobj);
+                    }
+                    else if (TargetMap != null)
+                    {
+                        // Duping to a targeted map, update parent.
+                        if (TargetMap.MapOffsetNode != null)
                         {
-                            MapTarget.MapOffsetNode.AddChild(newobj);
+                            TargetMap.MapOffsetNode.AddChild(newobj);
                         }
                         else
                         {
-                            MapTarget.RootObject.AddChild(newobj);
+                            TargetMap.RootObject.AddChild(newobj);
                         }
                     }
                     else if (Clonables[i].Parent != null)

--- a/StudioCore/MsbEditor/Action.cs
+++ b/StudioCore/MsbEditor/Action.cs
@@ -393,7 +393,20 @@ namespace StudioCore.MsbEditor
                     }
 
                     m.Objects.Insert(m.Objects.IndexOf(Clonables[i]) + 1, newobj);
-                    if (Clonables[i].Parent != null)
+                    if (MapTarget != null)
+                    {
+                        // Duping to a targeted map.
+                        // This will cause issues for entities with non-root object parents (like BTL lights), and they should be forbidden from duping to targeted maps.
+                        if (MapTarget.MapOffsetNode != null)
+                        {
+                            MapTarget.MapOffsetNode.AddChild(newobj);
+                        }
+                        else
+                        {
+                            MapTarget.RootObject.AddChild(newobj);
+                        }
+                    }
+                    else if (Clonables[i].Parent != null)
                     {
                         int idx = Clonables[i].Parent.ChildIndex(Clonables[i]);
                         Clonables[i].Parent.AddChild(newobj, idx + 1);

--- a/StudioCore/MsbEditor/MsbEditorScreen.cs
+++ b/StudioCore/MsbEditor/MsbEditorScreen.cs
@@ -306,17 +306,24 @@ namespace StudioCore.MsbEditor
                 ImGui.EndCombo();
             }
             var sel = _selection.GetFilteredSelection<MapEntity>().ToList();
-            if (_dupeSelectionTargetedMap == null)
-                ImGui.BeginDisabled();
-            if (ImGui.Button("Duplicate"))
+            if (sel.Any(e => e.WrappedObject.GetType() == typeof(BTL.Light)))
             {
-                var action = new CloneMapObjectsAction(Universe, RenderScene, sel, true, (Map)targetMap);
-                EditorActionManager.ExecuteAction(action);
-                // Closes popupo or menu bar
-                ImGui.CloseCurrentPopup();
+                ImGui.Text("Cannot duplicate BTL lights to other maps");
             }
-            if (_dupeSelectionTargetedMap == null)
-                ImGui.EndDisabled();
+            else
+            {
+                if (_dupeSelectionTargetedMap == null)
+                    ImGui.BeginDisabled();
+                if (ImGui.Button("Duplicate"))
+                {
+                    var action = new CloneMapObjectsAction(Universe, RenderScene, sel, true, (Map)targetMap);
+                    EditorActionManager.ExecuteAction(action);
+                    // Closes popupo or menu bar
+                    ImGui.CloseCurrentPopup();
+                }
+                if (_dupeSelectionTargetedMap == null)
+                    ImGui.EndDisabled();
+            }
         }
 
         public override void DrawEditorMenu()


### PR DESCRIPTION
Fix crash when trying to target dupe a root object.
Fix target dupe not changing entity's parent.
Fix BTL light target dupes not working, added functionality to target a BTL.