### PR TITLE
Add FMG editor separate options (+ improvements)

### DIFF
--- a/StudioCore/AssetLocator.cs
+++ b/StudioCore/AssetLocator.cs
@@ -628,39 +628,20 @@ namespace StudioCore
         /// <summary>
         /// Get path of item.msgbnd (english by default)
         /// </summary>
-        public AssetDescription GetItemMsgbnd(ref string langFolder, bool writemode = false)
+        public AssetDescription GetItemMsgbnd(string langFolder, bool writemode = false)
         {
-            return GetMsgbnd("item", ref langFolder, writemode);
+            return GetMsgbnd("item", langFolder, writemode);
         }
         /// <summary>
         /// Get path of menu.msgbnd (english by default)
         /// </summary>
-        public AssetDescription GetMenuMsgbnd(ref string langFolder, bool writemode = false)
+        public AssetDescription GetMenuMsgbnd(string langFolder, bool writemode = false)
         {
-            return GetMsgbnd("menu", ref langFolder, writemode);
+            return GetMsgbnd("menu", langFolder, writemode);
         }
-        public AssetDescription GetMsgbnd(string msgBndType, ref string langFolder, bool writemode = false)
+        public AssetDescription GetMsgbnd(string msgBndType, string langFolder, bool writemode = false)
         {
             AssetDescription ad = new();
-            if (langFolder == "")
-            {
-                //pick default (english) path
-                foreach (var lang in GetMsgLanguages())
-                {
-                    string folder = lang.Value.Split("\\").Last();
-                    if (folder.Contains("eng", StringComparison.CurrentCultureIgnoreCase)) //I believe this is good enough.
-                    {
-                        langFolder = folder;
-                        break;
-                    }
-                }
-                if (langFolder == "")
-                {
-                    // Could not find default [english] text msgbnd.
-                    return ad;
-                }
-            }
-
             string path = $@"msg\{langFolder}\{msgBndType}.msgbnd.dcx";
             if (Type == GameType.DemonsSouls)
             {

--- a/StudioCore/CFG.cs
+++ b/StudioCore/CFG.cs
@@ -208,6 +208,8 @@ namespace StudioCore
 
         // FMG Editor settings
         public bool FMG_ShowOriginalNames = false;
+        public bool FMG_NoGroupedFmgEntries = false;
+        public bool FMG_NoFmgPatching = false;
 
         // Param settings
         public bool Param_ShowAltNames = true;

--- a/StudioCore/Editor/ProjectSettings.cs
+++ b/StudioCore/Editor/ProjectSettings.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.IO;
+using Newtonsoft.Json.Linq;
 
 namespace StudioCore.Editor
 {
@@ -16,6 +17,13 @@ namespace StudioCore.Editor
         public string GameRoot { get; set; } = "";
         public GameType GameType { get; set; } = GameType.Undefined;
 
+        // JsonExtensionData stores info in config file not present in class in order to retain settings between versions.
+#pragma warning disable IDE0051
+        [JsonExtensionData]
+        private IDictionary<string, JToken> _additionalData;
+#pragma warning restore IDE0051
+
+        // Params
         public List<string> PinnedParams { get; set; } = new List<string>();
         public Dictionary<string, List<int>> PinnedRows { get; set; } = new Dictionary<string, List<int>>();
         public Dictionary<string, List<string>> PinnedFields { get; set; } = new Dictionary<string, List<string>>();
@@ -27,6 +35,9 @@ namespace StudioCore.Editor
         /// </summary>
         public bool UseLooseParams { get; set; } = false;
         public bool PartialParams { get; set; } = false;
+
+        // FMG editor
+        public string LastFmgLanguageUsed { get; set; } = "";
 
         public void Serialize(string path)
         {

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -1516,6 +1516,21 @@ namespace StudioCore
                 }
 
                 //
+                if (ImGui.BeginTabItem("FMG Text Settings"))
+                {
+                    ImGui.Indent();
+
+                    ImGui.Checkbox("Show Original FMG Names", ref CFG.Current.FMG_ShowOriginalNames);
+                    if (ImGui.Checkbox("Separate Related FMGs and Entries", ref CFG.Current.FMG_NoGroupedFmgEntries))
+                        _textEditor.OnProjectChanged(_projectSettings);
+                    if (ImGui.Checkbox("Separate Patch FMGs", ref CFG.Current.FMG_NoFmgPatching))
+                        _textEditor.OnProjectChanged(_projectSettings);
+
+                    ImGui.Unindent();
+                    ImGui.EndTabItem();
+                }
+
+                //
                 if (ImGui.BeginTabItem("Misc Settings"))
                 {
                     ImGui.Indent();
@@ -1577,17 +1592,6 @@ namespace StudioCore
                         {
                             _needsRebuildFont = true;
                         }
-
-                        ImGui.Unindent();
-                    }
-
-                    ImGui.Separator();
-
-                    if (ImGui.CollapsingHeader("FMG Text Editor"))
-                    {
-                        ImGui.Indent();
-
-                        ImGui.Checkbox("Show Original FMG Names", ref CFG.Current.FMG_ShowOriginalNames);
 
                         ImGui.Unindent();
                     }

--- a/StudioCore/TextEditor/FMGBank.cs
+++ b/StudioCore/TextEditor/FMGBank.cs
@@ -918,15 +918,16 @@ namespace StudioCore.TextEditor
         {
             if (path == null)
             {
-                if (_languageFolder == "")
+                if (_languageFolder != "")
                 {
-                    // Default language folder could not be found.
+                    TaskManager.warningList.TryAdd("FmgPathLoadError" + msgBndType + _languageFolder,
+                        $"Could not find text data files when looking for [{msgBndType}] in [{_languageFolder}] folder.\nText data will not be loaded.");
                 }
                 else
                 {
-                    MessageBox.Show($"Could not find {msgBndType} in language folder \"{_languageFolder}\".\nText data will not be loaded.", "Error");
+                    TaskManager.warningList.TryAdd("FmgDefaultPathLoadError" + msgBndType + _languageFolder,
+                        $"Could not find text data files when looking for [{msgBndType}] in [Default Eng] folder.\nText data will not be loaded. Make sure entire game is unpacked.");
                 }
-                
                 IsLoaded = false;
                 IsLoading = false;
                 return false;

--- a/StudioCore/TextEditor/FMGBank.cs
+++ b/StudioCore/TextEditor/FMGBank.cs
@@ -952,43 +952,47 @@ namespace StudioCore.TextEditor
         {
             try
             {
-                _languageFolder = languageFolder;
-                IsLoaded = false;
-                IsLoading = true;
-
-                ActiveUITypes.Clear();
-                foreach (var e in Enum.GetValues(typeof(FmgUICategory)))
+                TaskManager.Run("FB:Reload", true, false, true, () =>
                 {
-                    ActiveUITypes.Add((FmgUICategory)e, false);
-                }
-
-                //TaskManager.Run("FB:Reload", true, false, true, () =>
-                if (AssetLocator.Type == GameType.Undefined)
-                {
-                    return;
-                }
-
-                if (AssetLocator.Type == GameType.DarkSoulsIISOTFS)
-                {
-                    ReloadDS2FMGs(ref _languageFolder);
-                    IsLoading = false;
-                    IsLoaded = true;
-                    return;
-                }
-
-                var itemMsgPath = AssetLocator.GetItemMsgbnd(ref _languageFolder);
-                var menuMsgPath = AssetLocator.GetMenuMsgbnd(ref _languageFolder);
-
-                _fmgInfoBank.Clear();
-                if (!LoadItemMenuMsgBnds(itemMsgPath, menuMsgPath))
-                {
-                    _fmgInfoBank.Clear();
                     IsLoaded = false;
+                    IsLoading = true;
+                    while (true && !languageFolder.Contains("eng"))
+                    {
+                        _languageFolder = languageFolder;
+                        ActiveUITypes.Clear();
+                        foreach (var e in Enum.GetValues(typeof(FmgUICategory)))
+                        {
+                            ActiveUITypes.Add((FmgUICategory)e, false);
+                        }
+
+                        if (AssetLocator.Type == GameType.Undefined)
+                        {
+                            return;
+                        }
+
+                        if (AssetLocator.Type == GameType.DarkSoulsIISOTFS)
+                        {
+                            ReloadDS2FMGs(ref _languageFolder);
+                            IsLoading = false;
+                            IsLoaded = true;
+                            return;
+                        }
+
+                        var itemMsgPath = AssetLocator.GetItemMsgbnd(ref _languageFolder);
+                        var menuMsgPath = AssetLocator.GetMenuMsgbnd(ref _languageFolder);
+
+                        _fmgInfoBank.Clear();
+                        if (!LoadItemMenuMsgBnds(itemMsgPath, menuMsgPath))
+                        {
+                            _fmgInfoBank.Clear();
+                            IsLoaded = false;
+                            IsLoading = false;
+                            return;
+                        }
+                    }
+                    IsLoaded = true;
                     IsLoading = false;
-                    return;
-                }
-                IsLoaded = true;
-                IsLoading = false;
+                });
             }
             catch (Exception e) when (e is DirectoryNotFoundException or FileNotFoundException)
             {

--- a/StudioCore/TextEditor/FMGEditor.cs
+++ b/StudioCore/TextEditor/FMGEditor.cs
@@ -272,6 +272,7 @@ namespace StudioCore.TextEditor
         }
 
         private int _idCache = 0;
+        private FMGBank.EntryGroup _eGroupCache;
         public void PropIDFMG(FMGBank.EntryGroup eGroup, List<FMG.Entry> entryCache)
         {
             var oldID = eGroup.ID;
@@ -279,6 +280,7 @@ namespace StudioCore.TextEditor
             if (ImGui.InputInt("##id", ref id))
             {
                 _idCache = id;
+                _eGroupCache = eGroup;
             }
             bool committed = ImGui.IsItemDeactivatedAfterEdit();
             if (committed)
@@ -286,9 +288,9 @@ namespace StudioCore.TextEditor
                 if (_idCache != oldID)
                 {
                     // Forbid duplicate IDs
-                    if (entryCache.Find(e => e.ID == id) == null)
+                    if (entryCache.Find(e => e.ID == _idCache) == null)
                     {
-                        UpdateProperty(eGroup.GetType().GetProperty("ID"), eGroup, _idCache);
+                        UpdateProperty(_eGroupCache.GetType().GetProperty("ID"), _eGroupCache, _idCache);
                     }
                 }
             }

--- a/StudioCore/TextEditor/TextEditorScreen.cs
+++ b/StudioCore/TextEditor/TextEditorScreen.cs
@@ -140,94 +140,63 @@ namespace StudioCore.TextEditor
 
         private void FMGSearchLogic(ref bool doFocus)
         {
-            // Todo: This could be cleaned up.
             if (_entryLabelCache != null)
             {
                 if (_searchFilter != _searchFilterCached)
                 {
-                    _EntryLabelCacheFiltered = _entryLabelCache;
                     List<FMG.Entry> matches = new();
+                    _EntryLabelCacheFiltered = _entryLabelCache;
 
-                    if (_activeFmgInfo.GroupedEntry)
-                    {
-                        // Grouped entries
-                        List<FMG.Entry> searchEntries;
-                        if (_searchFilter.Length > _searchFilterCached.Length)
-                            searchEntries = _EntryLabelCacheFiltered;
-                        else
-                            searchEntries = _entryLabelCache;
-
-                        foreach (var entry in searchEntries)
-                        {
-                            // Titles
-                            if (entry.ID.ToString().Contains(_searchFilter, StringComparison.CurrentCultureIgnoreCase))
-                            {
-                                // ID search
-                                matches.Add(entry);
-                            }
-                            else if (entry.Text != null)
-                            {
-                                // Text search
-                                if (entry.Text.Contains(_searchFilter, StringComparison.CurrentCultureIgnoreCase))
-                                    matches.Add(entry);
-                            }
-                        }
-                        foreach (var entry in FMGBank.GetFmgEntriesByCategoryAndTextType(_activeFmgInfo.EntryCategory, FMGBank.FmgEntryTextType.Description, false))
-                        {
-                            // Descriptions
-                            if (entry.Text != null)
-                            {
-                                if (entry.Text.Contains(_searchFilter, StringComparison.CurrentCultureIgnoreCase))
-                                {
-                                    var search = _entryLabelCache.Find(e => e.ID == entry.ID && !matches.Contains(e));
-                                    if (search != null)
-                                        matches.Add(search);
-                                }
-                            }
-                        }
-                        foreach (var entry in FMGBank.GetFmgEntriesByCategoryAndTextType(_activeFmgInfo.EntryCategory, FMGBank.FmgEntryTextType.Summary, false))
-                        {
-                            // Summaries
-                            if (entry.Text != null)
-                            {
-                                if (entry.Text.Contains(_searchFilter, StringComparison.CurrentCultureIgnoreCase))
-                                {
-                                    var search = _entryLabelCache.Find(e => e.ID == entry.ID && !matches.Contains(e));
-                                    if (search != null)
-                                        matches.Add(search);
-                                }
-                            }
-                        }
-                    }
+                    List<FMG.Entry> mainEntries;
+                    if (_searchFilter.Length > _searchFilterCached.Length)
+                        mainEntries = _EntryLabelCacheFiltered;
                     else
-                    {
-                        // Non-grouped entries
-                        List<FMG.Entry> searchEntries;
-                        if (_searchFilter.Length > _searchFilterCached.Length)
-                            searchEntries = _EntryLabelCacheFiltered;
-                        else
-                            searchEntries = _entryLabelCache;
+                        mainEntries = _entryLabelCache;
 
-                        foreach (var entry in searchEntries)
+                    // Title/Textbody
+                    foreach (var entry in mainEntries)
+                    {
+                        if (entry.ID.ToString().Contains(_searchFilter, StringComparison.CurrentCultureIgnoreCase))
                         {
-                            if (entry.ID.ToString().Contains(_searchFilter, StringComparison.CurrentCultureIgnoreCase))
-                            {
-                                // ID search
+                            // ID search
+                            matches.Add(entry);
+                        }
+                        else if (entry.Text != null)
+                        {
+                            // Text search
+                            if (entry.Text.Contains(_searchFilter, StringComparison.CurrentCultureIgnoreCase))
                                 matches.Add(entry);
-                            }
-                            else if (entry.Text != null)
+                        }
+                    }
+
+                    // Descriptions
+                    foreach (var entry in FMGBank.GetFmgEntriesByCategoryAndTextType(_activeFmgInfo.EntryCategory, FMGBank.FmgEntryTextType.Description, false))
+                    {
+                        if (entry.Text != null)
+                        {
+                            if (entry.Text.Contains(_searchFilter, StringComparison.CurrentCultureIgnoreCase))
                             {
-                                // Text search
-                                if (entry.Text.Contains(_searchFilter, StringComparison.CurrentCultureIgnoreCase))
-                                {
-                                    var search = _entryLabelCache.Find(e => e.ID == entry.ID && !matches.Contains(e));
-                                    if (search != null)
-                                        matches.Add(search);
-                                }
+                                var search = _entryLabelCache.Find(e => e.ID == entry.ID && !matches.Contains(e));
+                                if (search != null)
+                                    matches.Add(search);
                             }
                         }
                     }
 
+                    // Summaries
+                    foreach (var entry in FMGBank.GetFmgEntriesByCategoryAndTextType(_activeFmgInfo.EntryCategory, FMGBank.FmgEntryTextType.Summary, false))
+                    {
+                        if (entry.Text != null)
+                        {
+                            if (entry.Text.Contains(_searchFilter, StringComparison.CurrentCultureIgnoreCase))
+                            {
+                                var search = _entryLabelCache.Find(e => e.ID == entry.ID && !matches.Contains(e));
+                                if (search != null)
+                                    matches.Add(search);
+                            }
+                        }
+                    }
+                   
                     _EntryLabelCacheFiltered = matches;
                     _searchFilterCached = _searchFilter;
                     doFocus = true;
@@ -247,14 +216,18 @@ namespace StudioCore.TextEditor
                     && info.UICategory == uiType 
                     && info.EntryType is FMGBank.FmgEntryTextType.Title or FMGBank.FmgEntryTextType.TextBody)
                 {
-                    string displayName;
+                    string displayName = "";
                     if (CFG.Current.FMG_ShowOriginalNames)
                     {
                         displayName = info.FileName;
                     }
                     else
                     {
-                        displayName = info.Name.Replace("Title", "");
+                        if (!CFG.Current.FMG_NoGroupedFmgEntries)
+                            displayName = info.Name.Replace("Title", "");
+                        else
+                            displayName = info.Name;
+
                         displayName = displayName.Replace("Modern_", "");
                     }
                     if (ImGui.Selectable($@" {displayName}", info == _activeFmgInfo))

--- a/StudioCore/TextEditor/TextEditorScreen.cs
+++ b/StudioCore/TextEditor/TextEditorScreen.cs
@@ -18,6 +18,7 @@ namespace StudioCore.TextEditor
     {
         public ActionManager EditorActionManager = new ActionManager();
         private readonly PropertyEditor _propEditor = null;
+        private ProjectSettings _projectSettings;
 
         private FMGBank.EntryGroup _activeEntryGroup;
         private FMGBank.FMGInfo _activeFmgInfo;
@@ -101,7 +102,7 @@ namespace StudioCore.TextEditor
                 }
                 ImGui.EndMenu();
             }
-            if (ImGui.BeginMenu("Text Language"))
+            if (ImGui.BeginMenu("Text Language", FMGBank.IsLoaded))
             {
                 var folders = FMGBank.AssetLocator.GetMsgLanguages();
                 if (folders.Count == 0)
@@ -533,6 +534,7 @@ namespace StudioCore.TextEditor
 
         private void ChangeLanguage(string path)
         {
+            _projectSettings.LastFmgLanguageUsed = path;
             ClearTextEditorCache();
             ResetActionManager();
             FMGBank.ReloadFMGs(path);
@@ -540,9 +542,10 @@ namespace StudioCore.TextEditor
 
         public override void OnProjectChanged(ProjectSettings newSettings)
         {
+            _projectSettings = newSettings;
             ClearTextEditorCache();
             ResetActionManager();
-            FMGBank.ReloadFMGs();
+            FMGBank.ReloadFMGs(_projectSettings.LastFmgLanguageUsed);
         }
 
         public override void Save()

--- a/StudioCore/TextEditor/TextEditorScreen.cs
+++ b/StudioCore/TextEditor/TextEditorScreen.cs
@@ -102,7 +102,7 @@ namespace StudioCore.TextEditor
                 }
                 ImGui.EndMenu();
             }
-            if (ImGui.BeginMenu("Text Language", FMGBank.IsLoaded))
+            if (ImGui.BeginMenu("Text Language", !FMGBank.IsLoading))
             {
                 var folders = FMGBank.AssetLocator.GetMsgLanguages();
                 if (folders.Count == 0)


### PR DESCRIPTION
Adds option in settings menu to separate grouped FMGs in the editor (I.E. title, description, summary).
Adds option in settings menu to separate patch FMGs (I.E. DLC).
Adds "Previously used FMG language" to project settings file, which is used to remember which FMG language to load on project load.
FMG reload is a task (once again).
Misc cleanup, improvements, and minor fixes.