### PR TITLE
DrawParam editing

### DIFF
--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -258,6 +258,27 @@ namespace StudioCore.ParamEditor
                 param = $@"{dir}\param\gameparam\{paramBinderName}";
             }
             LoadParamsDESFromFile(param);
+
+            //DrawParam
+            Dictionary<string, string> drawparams = new();
+            if (Directory.Exists($@"{dir}\param\DrawParam"))
+            {
+                foreach (var p in Directory.GetFiles($@"{dir}\param\DrawParam", "*.parambnd.dcx"))
+                {
+                    drawparams[Path.GetFileNameWithoutExtension(p)] = p;
+                }
+            }
+            if (Directory.Exists($@"{mod}\param\DrawParam"))
+            {
+                foreach (var p in Directory.GetFiles($@"{mod}\param\DrawParam", "*.parambnd.dcx"))
+                {
+                    drawparams[Path.GetFileNameWithoutExtension(p)] = p;
+                }
+            }
+            foreach (var drawparam in drawparams)
+            {
+                LoadParamsDESFromFile(drawparam.Value);
+            }
         }
         private void LoadVParamsDES()
         {
@@ -267,6 +288,13 @@ namespace StudioCore.ParamEditor
                 paramBinderName = "gameparamna.parambnd.dcx";
             }
             LoadParamsDESFromFile($@"{AssetLocator.GameRootDirectory}\param\gameparam\{paramBinderName}");
+            if (Directory.Exists($@"{AssetLocator.GameRootDirectory}\param\DrawParam"))
+            {
+                foreach (var p in Directory.GetFiles($@"{AssetLocator.GameRootDirectory}\param\DrawParam", "*.parambnd.dcx"))
+                {
+                    LoadParamsDS1FromFile(p);
+                }
+            }
         }
         private void LoadParamsDESFromFile(string path)
         {
@@ -290,10 +318,38 @@ namespace StudioCore.ParamEditor
                 param = $@"{dir}\param\GameParam\GameParam.parambnd";
             }
             LoadParamsDS1FromFile(param);
+
+            //DrawParam
+            Dictionary<string, string> drawparams = new();
+            if (Directory.Exists($@"{dir}\param\DrawParam"))
+            {
+                foreach (var p in Directory.GetFiles($@"{dir}\param\DrawParam", "*.parambnd"))
+                {
+                    drawparams[Path.GetFileNameWithoutExtension(p)] = p;
+                }
+            }
+            if (Directory.Exists($@"{mod}\param\DrawParam"))
+            {
+                foreach (var p in Directory.GetFiles($@"{mod}\param\DrawParam", "*.parambnd"))
+                {
+                    drawparams[Path.GetFileNameWithoutExtension(p)] = p;
+                }
+            }
+            foreach (var drawparam in drawparams)
+            {
+                LoadParamsDS1FromFile(drawparam.Value);
+            }
         }
         private void LoadVParamsDS1()
         {
             LoadParamsDS1FromFile($@"{AssetLocator.GameRootDirectory}\param\GameParam\GameParam.parambnd");
+            if (Directory.Exists($@"{AssetLocator.GameRootDirectory}\param\DrawParam"))
+            {
+                foreach (var p in Directory.GetFiles($@"{AssetLocator.GameRootDirectory}\param\DrawParam", "*.parambnd"))
+                {
+                    LoadParamsDS1FromFile(p);
+                }
+            }
         }
         private void LoadParamsDS1FromFile(string path)
         {
@@ -318,10 +374,38 @@ namespace StudioCore.ParamEditor
                 param = $@"{dir}\param\GameParam\GameParam.parambnd.dcx";
             }
             LoadParamsDS1RFromFile(param);
+
+            //DrawParam
+            Dictionary<string, string> drawparams = new();
+            if (Directory.Exists($@"{dir}\param\DrawParam"))
+            {
+                foreach (var p in Directory.GetFiles($@"{dir}\param\DrawParam", "*.parambnd.dcx"))
+                {
+                    drawparams[Path.GetFileNameWithoutExtension(p)] = p;
+                }
+            }
+            if (Directory.Exists($@"{mod}\param\DrawParam"))
+            {
+                foreach (var p in Directory.GetFiles($@"{mod}\param\DrawParam", "*.parambnd.dcx"))
+                {
+                    drawparams[Path.GetFileNameWithoutExtension(p)] = p;
+                }
+            }
+            foreach (var drawparam in drawparams)
+            {
+                LoadParamsDS1RFromFile(drawparam.Value);
+            }
         }
         private void LoadVParamsDS1R()
         {
             LoadParamsDS1RFromFile($@"{AssetLocator.GameRootDirectory}\param\GameParam\GameParam.parambnd.dcx");
+            if (Directory.Exists($@"{AssetLocator.GameRootDirectory}\param\DrawParam"))
+            {
+                foreach (var p in Directory.GetFiles($@"{AssetLocator.GameRootDirectory}\param\DrawParam", "*.parambnd.dcx"))
+                {
+                    LoadParamsDS1FromFile(p);
+                }
+            }
         }
         private void LoadParamsDS1RFromFile(string path)
         {
@@ -816,6 +900,9 @@ namespace StudioCore.ParamEditor
         // In theory this should be called twice for both Vanilla and PrimaryBank. However, as primarybank is the only one to ever change, this is unnecessary.
         public static void RefreshParamRowDiffCache(Param.Row row, Param otherBankParam, HashSet<int> cache)
         {
+            if (otherBankParam == null)
+                return;
+
             var otherBankRows = otherBankParam.Rows.Where(cell => cell.ID == row.ID).ToArray();
             if (IsChanged(row, otherBankRows))
                 cache.Add(row.ID);
@@ -870,8 +957,24 @@ namespace StudioCore.ParamEditor
                     p.Bytes = _params[Path.GetFileNameWithoutExtension(p.Name)].Write();
                 }
             }
-            // Don't write to mod dir for now
             Utils.WriteWithBackup(dir, mod, @"param\GameParam\GameParam.parambnd", paramBnd);
+
+            // Drawparam
+            if (Directory.Exists($@"{AssetLocator.GameRootDirectory}\param\DrawParam"))
+            {
+                foreach (var bnd in Directory.GetFiles($@"{AssetLocator.GameRootDirectory}\param\DrawParam", "*.parambnd"))
+                {
+                    paramBnd = BND3.Read(bnd);
+                    foreach (var p in paramBnd.Files)
+                    {
+                        if (_params.ContainsKey(Path.GetFileNameWithoutExtension(p.Name)))
+                        {
+                            p.Bytes = _params[Path.GetFileNameWithoutExtension(p.Name)].Write();
+                        }
+                    }
+                    Utils.WriteWithBackup(dir, mod, @$"param\DrawParam\{Path.GetFileNameWithoutExtension(bnd)}", paramBnd);
+                }
+            }
         }
         private void SaveParamsDS1R()
         {
@@ -900,6 +1003,23 @@ namespace StudioCore.ParamEditor
                 }
             }
             Utils.WriteWithBackup(dir, mod, @"param\GameParam\GameParam.parambnd.dcx", paramBnd);
+
+            // Drawparam
+            if (Directory.Exists($@"{AssetLocator.GameRootDirectory}\param\DrawParam"))
+            {
+                foreach (var bnd in Directory.GetFiles($@"{AssetLocator.GameRootDirectory}\param\DrawParam", "*.parambnd.dcx"))
+                {
+                    paramBnd = BND3.Read(bnd);
+                    foreach (var p in paramBnd.Files)
+                    {
+                        if (_params.ContainsKey(Path.GetFileNameWithoutExtension(p.Name)))
+                        {
+                            p.Bytes = _params[Path.GetFileNameWithoutExtension(p.Name)].Write();
+                        }
+                    }
+                    Utils.WriteWithBackup(dir, mod, @$"param\DrawParam\{Path.GetFileNameWithoutExtension(bnd)}.dcx", paramBnd);
+                }
+            }
         }
 
         private void SaveParamsDS2(bool loose)
@@ -1107,6 +1227,23 @@ namespace StudioCore.ParamEditor
                 }
             }
             Utils.WriteWithBackup(dir, mod, $@"param\gameparam\{paramBinderName}", paramBnd);
+
+            // Drawparam
+            if (Directory.Exists($@"{AssetLocator.GameRootDirectory}\param\DrawParam"))
+            {
+                foreach (var bnd in Directory.GetFiles($@"{AssetLocator.GameRootDirectory}\param\DrawParam", "*.parambnd.dcx"))
+                {
+                    paramBnd = BND3.Read(bnd);
+                    foreach (var p in paramBnd.Files)
+                    {
+                        if (_params.ContainsKey(Path.GetFileNameWithoutExtension(p.Name)))
+                        {
+                            p.Bytes = _params[Path.GetFileNameWithoutExtension(p.Name)].Write();
+                        }
+                    }
+                    Utils.WriteWithBackup(dir, mod, @$"param\DrawParam\{Path.GetFileNameWithoutExtension(bnd)}.dcx", paramBnd);
+                }
+            }
         }
         private void SaveParamsER(bool partial)
         {

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -173,7 +173,7 @@ namespace StudioCore.ParamEditor
             // _params = new Dictionary<string, PARAM>();
             foreach (var f in parambnd.Files)
             {
-                if (!f.Name.ToUpper().EndsWith(".PARAM") || Path.GetFileNameWithoutExtension(f.Name).StartsWith("default_"))
+                if (!f.Name.ToUpper().EndsWith(".PARAM"))
                 {
                     continue;
                 }

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -883,9 +883,9 @@ namespace StudioCore.ParamEditor
                     {
                         doFocus = initcmd[0] == "select";
                         if (_activeView._selection.getActiveRow() != null && !ParamBank.VanillaBank.IsLoadingParams)
-                            ParamBank.RefreshParamRowDiffCache(_activeView._selection.getActiveRow(), 
-                                ParamBank.VanillaBank.Params[_activeView._selection.getActiveParam()],
-                                ParamBank.PrimaryBank.VanillaDiffCache[_activeView._selection.getActiveParam()]);
+                            ParamBank.RefreshParamRowDiffCache(_activeView._selection.getActiveRow(),
+                                ParamBank.VanillaBank.Params.GetValueOrDefault(_activeView._selection.getActiveParam()),
+                                ParamBank.PrimaryBank.VanillaDiffCache.GetValueOrDefault(_activeView._selection.getActiveParam()));
 
                         ParamEditorView viewToMofidy = _activeView;
                         if (initcmd[1].Equals("new"))
@@ -916,8 +916,8 @@ namespace StudioCore.ParamEditor
                         }
                         if (_activeView._selection.getActiveRow() != null && !ParamBank.VanillaBank.IsLoadingParams)
                             ParamBank.RefreshParamRowDiffCache(_activeView._selection.getActiveRow(),
-                                ParamBank.VanillaBank.Params[_activeView._selection.getActiveParam()],
-                                ParamBank.PrimaryBank.VanillaDiffCache[_activeView._selection.getActiveParam()]);
+                                ParamBank.VanillaBank.Params.GetValueOrDefault(_activeView._selection.getActiveParam()),
+                                ParamBank.PrimaryBank.VanillaDiffCache.GetValueOrDefault(_activeView._selection.getActiveParam()));
 
                     }
                 }
@@ -1316,6 +1316,7 @@ namespace StudioCore.ParamEditor
         private int _gotoParamRow = -1;
         private bool _arrowKeyPressed = false;
         private bool _focusRows = false;
+        private bool _drawParamView = false;
 
         internal ParamEditorSelectionState _selection = new ParamEditorSelectionState();
 
@@ -1335,6 +1336,16 @@ namespace StudioCore.ParamEditor
         {
             ImGui.Columns(3);
             ImGui.BeginChild("params");
+
+            if (ParamBank.PrimaryBank.AssetLocator.Type is GameType.DemonsSouls
+                or GameType.DarkSoulsPTDE
+                or GameType.DarkSoulsRemastered)
+            {
+                // This game has DrawParams, add UI element to toggle viewing DrawParam and GameParams.
+                if (ImGui.Checkbox("Edit Drawparams", ref _drawParamView))
+                    CacheBank.ClearCaches();
+            }
+
             if (isActiveView && InputTracker.GetKeyDown(KeyBindings.Current.Param_SearchParam))
                 ImGui.SetKeyboardFocusHere();
             ImGui.InputText($"Search <{KeyBindings.Current.Param_SearchParam.HintText}>", ref _selection.currentParamSearchString, 256);
@@ -1373,6 +1384,17 @@ namespace StudioCore.ParamEditor
             List<string> paramKeyList = CacheBank.GetCached(this._paramEditor, _viewIndex, () => {
                 var list = ParamSearchEngine.pse.Search(true, _selection.currentParamSearchString, true, true);
                 var keyList = list.Select((param) => ParamBank.PrimaryBank.GetKeyForParam(param)).ToList();
+
+                if (ParamBank.PrimaryBank.AssetLocator.Type is GameType.DemonsSouls
+                    or GameType.DarkSoulsPTDE
+                    or GameType.DarkSoulsRemastered)
+                {
+                    if (_drawParamView)
+                        keyList = keyList.FindAll(p => p.EndsWith("Bank"));
+                    else
+                        keyList = keyList.FindAll(p => !p.EndsWith("Bank"));
+                }
+
                 if (CFG.Current.Param_AlphabeticalParams)
                     keyList.Sort();
                 return keyList;
@@ -1553,10 +1575,11 @@ namespace StudioCore.ParamEditor
             else
             {
                 ImGui.BeginChild("columns" + activeParam);
+                Param vanillaParam = ParamBank.VanillaBank.Params?.GetValueOrDefault(activeParam);
                 _propEditor.PropEditorParamRow(
                     ParamBank.PrimaryBank,
                     activeRow,
-                    ParamBank.VanillaBank.Params?[activeParam][activeRow.ID],
+                    vanillaParam?[activeRow.ID],
                     ParamBank.AuxBanks.Select((bank, i) => (bank.Key, bank.Value.Params?[activeParam][activeRow.ID])).ToList(),
                     _selection.getCompareRow(),
                     ref _selection.getCurrentPropSearchString(),

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -1337,15 +1337,6 @@ namespace StudioCore.ParamEditor
             ImGui.Columns(3);
             ImGui.BeginChild("params");
 
-            if (ParamBank.PrimaryBank.AssetLocator.Type is GameType.DemonsSouls
-                or GameType.DarkSoulsPTDE
-                or GameType.DarkSoulsRemastered)
-            {
-                // This game has DrawParams, add UI element to toggle viewing DrawParam and GameParams.
-                if (ImGui.Checkbox("Edit Drawparams", ref _drawParamView))
-                    CacheBank.ClearCaches();
-            }
-
             if (isActiveView && InputTracker.GetKeyDown(KeyBindings.Current.Param_SearchParam))
                 ImGui.SetKeyboardFocusHere();
             ImGui.InputText($"Search <{KeyBindings.Current.Param_SearchParam.HintText}>", ref _selection.currentParamSearchString, 256);
@@ -1353,6 +1344,16 @@ namespace StudioCore.ParamEditor
             {
                 CacheBank.ClearCaches();
                 lastParamSearch = _selection.currentParamSearchString;
+            }
+
+            if (ParamBank.PrimaryBank.AssetLocator.Type is GameType.DemonsSouls
+                or GameType.DarkSoulsPTDE
+                or GameType.DarkSoulsRemastered)
+            {
+                // This game has DrawParams, add UI element to toggle viewing DrawParam and GameParams.
+                if (ImGui.Checkbox("Edit Drawparams", ref _drawParamView))
+                    CacheBank.ClearCaches();
+                ImGui.Separator();
             }
 
             List<string> pinnedParamKeyList = new List<string>(_paramEditor._projectSettings.PinnedParams);


### PR DESCRIPTION
Allows editing DrawParams in the param editor.
Currently, you toggle between viewing GameParam and DrawParam via UI checkbox. This isn't _super_ great, but it's enough for base functionality.

Incidentally fixes a crash when VanillaBank is missing a key, which also prevents crashing in other situations (notably, when a paramdef cannot be applied to VanillaBank due to paramdef updates.