### PR TITLE
DS2 map params in param editor

### DIFF
--- a/StudioCore/MsbEditor/Universe.cs
+++ b/StudioCore/MsbEditor/Universe.cs
@@ -380,7 +380,7 @@ namespace StudioCore.MsbEditor
             Dictionary<long, Param.Row> eventLocationParams = new Dictionary<long, Param.Row>();
             Dictionary<long, Param.Row> objectInstanceParams = new Dictionary<long, Param.Row>();
 
-            var regparam = ParamEditor.ParamBank.PrimaryBank.Params.GetValueOrDefault($"generatorregistparam_{mapid}");
+            var regparam = ParamEditor.ParamBank.PrimaryBank.Params[$"generatorregistparam_{mapid}"];
             foreach (var row in regparam.Rows)
             {
                 if (string.IsNullOrEmpty(row.Name))
@@ -393,7 +393,7 @@ namespace StudioCore.MsbEditor
                 map.AddObject(obj);
             }
 
-            var locparam = ParamEditor.ParamBank.PrimaryBank.Params.GetValueOrDefault($"generatorlocation_{mapid}");
+            var locparam = ParamEditor.ParamBank.PrimaryBank.Params[$"generatorlocation_{mapid}"];
             foreach (var row in locparam.Rows)
             {
                 if (string.IsNullOrEmpty(row.Name))
@@ -419,7 +419,7 @@ namespace StudioCore.MsbEditor
             }
 
             var chrsToLoad = new HashSet<AssetDescription>();
-            var genparam = ParamEditor.ParamBank.PrimaryBank.Params.GetValueOrDefault($"generatorparam_{mapid}");
+            var genparam = ParamEditor.ParamBank.PrimaryBank.Params[$"generatorparam_{mapid}"];
             foreach (var row in genparam.Rows)
             {
                 if (row.Name == null || row.Name == "")
@@ -460,7 +460,7 @@ namespace StudioCore.MsbEditor
                 }
             }
 
-            var evtparam = ParamEditor.ParamBank.PrimaryBank.Params.GetValueOrDefault($"eventparam_{mapid}");
+            var evtparam = ParamEditor.ParamBank.PrimaryBank.Params[$"eventparam_{mapid}"];
             foreach (var row in evtparam.Rows)
             {
                 if (string.IsNullOrEmpty(row.Name))
@@ -473,7 +473,7 @@ namespace StudioCore.MsbEditor
                 map.AddObject(obj);
             }
 
-            var evtlparam = ParamEditor.ParamBank.PrimaryBank.Params.GetValueOrDefault($"eventlocation_{mapid}");
+            var evtlparam = ParamEditor.ParamBank.PrimaryBank.Params[$"eventlocation_{mapid}"];
             foreach (var row in evtlparam.Rows)
             {
                 if (string.IsNullOrEmpty(row.Name))
@@ -500,7 +500,7 @@ namespace StudioCore.MsbEditor
                 mesh.SetSelectable(obj);
             }
 
-            var objparam = ParamEditor.ParamBank.PrimaryBank.Params.GetValueOrDefault($"mapobjectinstanceparam_{mapid}");
+            var objparam = ParamEditor.ParamBank.PrimaryBank.Params[$"mapobjectinstanceparam_{mapid}"];
             foreach (var row in objparam.Rows)
             {
                 if (string.IsNullOrEmpty(row.Name))
@@ -539,6 +539,14 @@ namespace StudioCore.MsbEditor
 
         public bool LoadMap(string mapid, bool selectOnLoad = false)
         {
+            if (_assetLocator.Type == GameType.DarkSoulsIISOTFS
+                && ParamEditor.ParamBank.VanillaBank.Params == null)
+            {
+                // ParamBank must be loaded for DS2 maps
+                TaskManager.warningList.TryAdd("ds2-mapload-noparams", "DS2 maps cannot be loaded until params are loaded.");
+                return false;
+            }
+
             var ad = _assetLocator.GetMapMSB(mapid);
             if (ad.AssetPath == null)
             {

--- a/StudioCore/MsbEditor/Universe.cs
+++ b/StudioCore/MsbEditor/Universe.cs
@@ -380,10 +380,7 @@ namespace StudioCore.MsbEditor
             Dictionary<long, Param.Row> eventLocationParams = new Dictionary<long, Param.Row>();
             Dictionary<long, Param.Row> objectInstanceParams = new Dictionary<long, Param.Row>();
 
-            var regparamad = _assetLocator.GetDS2GeneratorRegistParam(mapid);
-            var regparam = Param.Read(regparamad.AssetPath);
-            var reglayout = _assetLocator.GetParamdefForParam(regparam.ParamType);
-            regparam.ApplyParamdef(reglayout);
+            var regparam = ParamEditor.ParamBank.PrimaryBank.Params.GetValueOrDefault($"generatorregistparam_{mapid}");
             foreach (var row in regparam.Rows)
             {
                 if (string.IsNullOrEmpty(row.Name))
@@ -396,10 +393,7 @@ namespace StudioCore.MsbEditor
                 map.AddObject(obj);
             }
 
-            var locparamad = _assetLocator.GetDS2GeneratorLocationParam(mapid);
-            var locparam = Param.Read(locparamad.AssetPath);
-            var loclayout = _assetLocator.GetParamdefForParam(locparam.ParamType);
-            locparam.ApplyParamdef(loclayout);
+            var locparam = ParamEditor.ParamBank.PrimaryBank.Params.GetValueOrDefault($"generatorlocation_{mapid}");
             foreach (var row in locparam.Rows)
             {
                 if (string.IsNullOrEmpty(row.Name))
@@ -425,10 +419,7 @@ namespace StudioCore.MsbEditor
             }
 
             var chrsToLoad = new HashSet<AssetDescription>();
-            var genparamad = _assetLocator.GetDS2GeneratorParam(mapid);
-            var genparam = Param.Read(genparamad.AssetPath);
-            var genlayout = _assetLocator.GetParamdefForParam(genparam.ParamType);
-            genparam.ApplyParamdef(genlayout);
+            var genparam = ParamEditor.ParamBank.PrimaryBank.Params.GetValueOrDefault($"generatorparam_{mapid}");
             foreach (var row in genparam.Rows)
             {
                 if (row.Name == null || row.Name == "")
@@ -469,10 +460,7 @@ namespace StudioCore.MsbEditor
                 }
             }
 
-            var evtparamad = _assetLocator.GetDS2EventParam(mapid);
-            var evtparam = Param.Read(evtparamad.AssetPath);
-            var evtlayout = _assetLocator.GetParamdefForParam(evtparam.ParamType);
-            evtparam.ApplyParamdef(evtlayout);
+            var evtparam = ParamEditor.ParamBank.PrimaryBank.Params.GetValueOrDefault($"eventparam_{mapid}");
             foreach (var row in evtparam.Rows)
             {
                 if (string.IsNullOrEmpty(row.Name))
@@ -485,10 +473,7 @@ namespace StudioCore.MsbEditor
                 map.AddObject(obj);
             }
 
-            var evtlparamad = _assetLocator.GetDS2EventLocationParam(mapid);
-            var evtlparam = Param.Read(evtlparamad.AssetPath);
-            var evtllayout = _assetLocator.GetParamdefForParam(evtlparam.ParamType);
-            evtlparam.ApplyParamdef(evtllayout);
+            var evtlparam = ParamEditor.ParamBank.PrimaryBank.Params.GetValueOrDefault($"eventlocation_{mapid}");
             foreach (var row in evtlparam.Rows)
             {
                 if (string.IsNullOrEmpty(row.Name))
@@ -515,10 +500,7 @@ namespace StudioCore.MsbEditor
                 mesh.SetSelectable(obj);
             }
 
-            var objparamad = _assetLocator.GetDS2ObjInstanceParam(mapid);
-            var objparam = Param.Read(objparamad.AssetPath);
-            var objlayout = _assetLocator.GetParamdefForParam(objparam.ParamType);
-            objparam.ApplyParamdef(objlayout);
+            var objparam = ParamEditor.ParamBank.PrimaryBank.Params.GetValueOrDefault($"mapobjectinstanceparam_{mapid}");
             foreach (var row in objparam.Rows)
             {
                 if (string.IsNullOrEmpty(row.Name))
@@ -921,8 +903,12 @@ namespace StudioCore.MsbEditor
             catch(Exception e)
             {
                 // Store async exception so it can be caught by crash handler.
+#if DEBUG
+                throw;
+#else
                 LoadMapExceptions = e;
                 return;
+#endif
             }
         }
 

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -1076,11 +1076,17 @@ namespace StudioCore.ParamEditor
             // If params aren't loose, replace params with edited ones
             if (!loose)
             {
-                foreach (var p in paramBnd.Files)
+                // Replace params in paramBND, write remaining params loosely
+                foreach (var p in _params)
                 {
-                    if (_params.ContainsKey(Path.GetFileNameWithoutExtension(p.Name)))
+                    var bnd = paramBnd.Files.Find(e => Path.GetFileNameWithoutExtension(e.Name) == p.Key);
+                    if (bnd != null)
                     {
-                        p.Bytes = _params[Path.GetFileNameWithoutExtension(p.Name)].Write();
+                        bnd.Bytes = p.Value.Write();
+                    }
+                    else
+                    {
+                        Utils.WriteWithBackup(dir, mod, $@"Param\{p.Key}.param", p.Value);
                     }
                 }
             }

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -441,14 +441,18 @@ namespace StudioCore.ParamEditor
         }
 
         /// <summary>
-        /// Map related params that should not be in the param editor
+        /// Map related params.
         /// </summary>
-        private static List<string> _ds2ParamBlacklist = new List<string>()
+        public readonly static List<string> DS2MapParamlist = new List<string>()
         {
             "demopointlight",
             "demospotlight",
             "eventlocation",
             "eventparam",
+            "GeneralLocationEventParam",
+            "generatorparam",
+            "generatorregistparam",
+            "generatorlocation",
             "generatordbglocation",
             "hitgroupparam",
             "intrudepointparam",
@@ -519,28 +523,22 @@ namespace StudioCore.ParamEditor
                 var paramfiles = Directory.GetFileSystemEntries(d, @"*.param");
                 foreach (var p in paramfiles)
                 {
-                    bool blacklisted = false;
                     var name = Path.GetFileNameWithoutExtension(p);
-                    foreach (var bl in _ds2ParamBlacklist)
-                    {
-                        if (name.StartsWith(bl))
-                        {
-                            blacklisted = true;
-                            break;
-                        }
-                    }
-                    if (blacklisted)
-                    {
-                        continue;
-                    }
-
                     var lp = Param.Read(p);
                     var fname = lp.ParamType;
-                    PARAMDEF def = AssetLocator.GetParamdefForParam(fname);
-                    lp.ApplyParamdef(def);
-                    if (!_params.ContainsKey(name))
+
+                    try
                     {
-                        _params.Add(name, lp);
+                        PARAMDEF def = AssetLocator.GetParamdefForParam(fname);
+                        lp.ApplyParamdef(def);
+                        if (!_params.ContainsKey(name))
+                        {
+                            _params.Add(name, lp);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        TaskManager.warningList.TryAdd($"{fname} DefFail", $"Could not apply ParamDef for {fname}");
                     }
                 }
             }
@@ -569,7 +567,14 @@ namespace StudioCore.ParamEditor
             if (EnemyParam != null)
             {
                 PARAMDEF def = AssetLocator.GetParamdefForParam(EnemyParam.ParamType);
-                EnemyParam.ApplyParamdef(def);
+                try
+                {
+                    EnemyParam.ApplyParamdef(def);
+                }
+                catch (Exception e)
+                {
+                    TaskManager.warningList.TryAdd($"{EnemyParam.ParamType} DefFail", $"Could not apply ParamDef for {EnemyParam.ParamType}");
+                }
             }
             LoadParamFromBinder(paramBnd, ref _params, out _paramVersion);
         }

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -1371,7 +1371,7 @@ namespace StudioCore.ParamEditor
         private int _gotoParamRow = -1;
         private bool _arrowKeyPressed = false;
         private bool _focusRows = false;
-        private bool _drawParamView = false;
+        private bool _mapParamView = false;
 
         internal ParamEditorSelectionState _selection = new ParamEditorSelectionState();
 
@@ -1406,7 +1406,14 @@ namespace StudioCore.ParamEditor
                 or GameType.DarkSoulsRemastered)
             {
                 // This game has DrawParams, add UI element to toggle viewing DrawParam and GameParams.
-                if (ImGui.Checkbox("Edit Drawparams", ref _drawParamView))
+                if (ImGui.Checkbox("Edit Drawparams", ref _mapParamView))
+                    CacheBank.ClearCaches();
+                ImGui.Separator();
+            }
+            else if (ParamBank.PrimaryBank.AssetLocator.Type is GameType.DarkSoulsIISOTFS)
+            {
+                // DS2 has map params, add UI element to toggle viewing map params and GameParams.
+                if (ImGui.Checkbox("Edit Map Params", ref _mapParamView))
                     CacheBank.ClearCaches();
                 ImGui.Separator();
             }
@@ -1445,10 +1452,17 @@ namespace StudioCore.ParamEditor
                     or GameType.DarkSoulsPTDE
                     or GameType.DarkSoulsRemastered)
                 {
-                    if (_drawParamView)
+                    if (_mapParamView)
                         keyList = keyList.FindAll(p => p.EndsWith("Bank"));
                     else
                         keyList = keyList.FindAll(p => !p.EndsWith("Bank"));
+                }
+                else if (ParamBank.PrimaryBank.AssetLocator.Type is GameType.DarkSoulsIISOTFS)
+                {
+                    if (_mapParamView)
+                        keyList = keyList.FindAll(p => ParamBank.DS2MapParamlist.Contains(p.Split('_')[0]));
+                    else
+                        keyList = keyList.FindAll(p => !ParamBank.DS2MapParamlist.Contains(p.Split('_')[0]));
                 }
 
                 if (CFG.Current.Param_AlphabeticalParams)


### PR DESCRIPTION
Base solution to just get everything exposed and open to useful param editor features. Uses same filter system as DrawParams.
* Exposes the previously-culled DS2 map params to param editor in toggleable filter (note: some were not culled and were double exposed in MSB and param anyway).
* Try/Catch DS2 ApplyParamDef, like other games do.
* Map Editor now uses ParamBank's params, so changes are now immediately shared between the two editors. DS2 maps now require a loaded ParamBank.