### PR TITLE
Add Arbitrary Rotation X/Y action, Reset Rotation action

### DIFF
--- a/StudioCore/CFG.cs
+++ b/StudioCore/CFG.cs
@@ -197,6 +197,9 @@ namespace StudioCore
 
         // Map Editor settings
         public bool Map_AlwaysListLoadedMaps = true;
+        public float Map_ArbitraryRotation_X_Shift { get; set; } = 90.0f;
+        public float Map_ArbitraryRotation_Y_Shift { get; set; } = 90.0f;
+
 
         // Font settings
         public bool FontChinese = false;

--- a/StudioCore/KeyBindings.cs
+++ b/StudioCore/KeyBindings.cs
@@ -101,6 +101,9 @@ namespace StudioCore
             public KeyBind Map_HideToggle = new(Key.H, true);
             public KeyBind Map_UnhideAll = new(Key.H, false, true);
             public KeyBind Map_GotoSelectionInObjectList = new(Key.G);
+            public KeyBind Map_ResetRotation = new(Key.L);
+            public KeyBind Map_ArbitraryRotationX = new(Key.J);
+            public KeyBind Map_ArbitraryRotationY = new(Key.K);
             public KeyBind Map_Dummify = new(Key.Comma, false, false, true);
             public KeyBind Map_UnDummify = new(Key.Period, false, false, true);
 

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -672,6 +672,7 @@ namespace StudioCore
             ctx = Tracy.TracyCZoneN(1, "Menu");
             bool newProject = false;
             ImGui.PushStyleVar(ImGuiStyleVar.FrameBorderSize, 0.0f);
+
             if (ImGui.BeginMainMenuBar())
             {
                 if (ImGui.BeginMenu("File"))
@@ -899,7 +900,8 @@ namespace StudioCore
                 }
                 if (TaskManager.GetLiveThreads().Count > 0 && ImGui.BeginMenu("Tasks"))
                 {
-                    foreach (String task in TaskManager.GetLiveThreads()) {
+                    foreach (String task in TaskManager.GetLiveThreads())
+                    {
                         ImGui.Text(task);
                     }
                     ImGui.EndMenu();
@@ -1354,6 +1356,27 @@ namespace StudioCore
                         ImGui.Indent();
                         ImGui.Checkbox("Enable Texturing (alpha)", ref CFG.Current.EnableTexturing);
                         ImGui.Checkbox("Exclude loaded maps from search filter", ref CFG.Current.Map_AlwaysListLoadedMaps);
+                        ImGui.Unindent();
+                    }
+
+                    ImGui.Separator();
+
+                    if (ImGui.CollapsingHeader("Selection"))
+                    {
+                        ImGui.Indent();
+
+                        float arbitrary_rotation_x = CFG.Current.Map_ArbitraryRotation_X_Shift;
+                        float arbitrary_rotation_y = CFG.Current.Map_ArbitraryRotation_Y_Shift;
+
+                        if (ImGui.SliderFloat("Arbitrary Rotation: X", ref arbitrary_rotation_x, 1.0f, 180.0f))
+                        {
+                            CFG.Current.Map_ArbitraryRotation_X_Shift = arbitrary_rotation_x;
+                        }
+                        if (ImGui.SliderFloat("Arbitrary Rotation: Y", ref arbitrary_rotation_y, 1.0f, 180.0f))
+                        {
+                            CFG.Current.Map_ArbitraryRotation_Y_Shift = arbitrary_rotation_y;
+                        }
+
                         ImGui.Unindent();
                     }
 

--- a/StudioCore/MsbEditor/MsbEditorScreen.cs
+++ b/StudioCore/MsbEditor/MsbEditorScreen.cs
@@ -170,6 +170,67 @@ namespace StudioCore.MsbEditor
         }
 
         /// <summary>
+        /// Reset the rotation of the selected object to 0, 0, 0
+        /// </summary>
+        private void ResetRotationSelection()
+        {
+            var actlist = new List<Action>();
+
+            var selected = _selection.GetFilteredSelection<Entity>();
+            foreach (var s in selected)
+            {
+                var pos = s.GetLocalTransform().Position;
+                var rot_x = 0;
+                var rot_y = 0;
+                var rot_z = 0;
+
+                Transform newRot = new Transform(pos, new Vector3(rot_x, rot_y, rot_z));
+
+                actlist.Add(s.GetUpdateTransformAction(newRot));
+            }
+
+            var action = new CompoundAction(actlist);
+            EditorActionManager.ExecuteAction(action);
+        }
+
+        /// <summary>
+        /// Rotate the selected objects by a fixed amount on the specified axis
+        /// </summary>
+        private void ArbitraryRotation_Selection(int axis_type)
+        {
+            var actlist = new List<Action>();
+
+            var selected = _selection.GetFilteredSelection<Entity>();
+            foreach (var s in selected)
+            {
+
+                var pos = s.GetLocalTransform().Position;
+
+                var rot_x = s.GetLocalTransform().EulerRotation.X;
+                var rot_y = s.GetLocalTransform().EulerRotation.Y;
+                var rot_z = s.GetLocalTransform().EulerRotation.Z;
+
+                if (axis_type == 0)
+                {
+                    float rad = ((float)Math.PI / 180) * CFG.Current.Map_ArbitraryRotation_X_Shift;
+                    rot_x = s.GetLocalTransform().EulerRotation.X + rad;
+                }
+                if (axis_type == 1)
+                {
+                    float rad = ((float)Math.PI / 180) * CFG.Current.Map_ArbitraryRotation_Y_Shift;
+                    rot_y = s.GetLocalTransform().EulerRotation.Y + rad;
+                }
+
+                Transform newRot = new Transform(pos, new Vector3(rot_x, rot_y, rot_z));
+
+                actlist.Add(s.GetUpdateTransformAction(newRot));
+            }
+
+            var action = new CompoundAction(actlist);
+            EditorActionManager.ExecuteAction(action);
+        }
+
+        /// <summary>
         /// Hides all the selected objects, unless all of them are hidden in which
         /// they will be unhidden
         /// </summary>
@@ -398,6 +459,21 @@ namespace StudioCore.MsbEditor
                 if (ImGui.MenuItem("Goto in Object List", KeyBindings.Current.Map_GotoSelectionInObjectList.HintText, false, _selection.IsSelection()))
                 {
                     GotoSelection();
+                }
+
+                ImGui.Separator(); // Selection options goes below here
+
+                if (ImGui.MenuItem("Reset Rotation", KeyBindings.Current.Map_ResetRotation.HintText, false, _selection.IsSelection()))
+                {
+                    ResetRotationSelection();
+                }
+                if (ImGui.MenuItem("Arbitrary Rotation: X", KeyBindings.Current.Map_ArbitraryRotationX.HintText, false, _selection.IsSelection()))
+                {
+                    ArbitraryRotation_Selection(0);
+                }
+                if (ImGui.MenuItem("Arbitrary Rotation: Y", KeyBindings.Current.Map_ArbitraryRotationY.HintText, false, _selection.IsSelection()))
+                {
+                    ArbitraryRotation_Selection(1);
                 }
 
                 ImGui.EndMenu();
@@ -736,6 +812,14 @@ namespace StudioCore.MsbEditor
                 if (InputTracker.GetKeyDown(KeyBindings.Current.Map_GotoSelectionInObjectList))
                 {
                     GotoSelection();
+                }
+                if (InputTracker.GetKeyDown(KeyBindings.Current.Map_ArbitraryRotationX))
+                {
+                    ArbitraryRotation_Selection(0);
+                }
+                if (InputTracker.GetKeyDown(KeyBindings.Current.Map_ArbitraryRotationY))
+                {
+                    ArbitraryRotation_Selection(1);
                 }
                 if (InputTracker.GetKeyDown(KeyBindings.Current.Map_Dummify) && _selection.IsSelection())
                 {


### PR DESCRIPTION
Adds an action to rotate an object around the X and Y axis by a fixed amount with the press of a keybind (J for X axis, K for Y axis). The fixed amount for both can be changed in the Map Settings menu.

Adds an action to reset the current rotation of an object to 0, 0, 0 with the press of a keybind (L).
