### PR TITLE
Add the ability to change Gizmo color

### DIFF
--- a/StudioCore/CFG.cs
+++ b/StudioCore/CFG.cs
@@ -2,8 +2,10 @@
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -194,6 +196,15 @@ namespace StudioCore
         public float GFX_Camera_MoveSpeed_Normal { get; set; } = 20.0f;
         public float GFX_Camera_MoveSpeed_Fast { get; set; } = 200.0f;
         public float GFX_RenderDistance_Max { get; set; } = 50000.0f;
+
+        public Vector3 GFX_Gizmo_X_BaseColor = new Vector3(0.952f, 0.211f, 0.325f);
+        public Vector3 GFX_Gizmo_X_HighlightColor = new Vector3(1.0f, 0.4f, 0.513f);
+
+        public Vector3 GFX_Gizmo_Y_BaseColor = new Vector3(0.525f, 0.784f, 0.082f);
+        public Vector3 GFX_Gizmo_Y_HighlightColor = new Vector3(0.713f, 0.972f, 0.270f);
+
+        public Vector3 GFX_Gizmo_Z_BaseColor = new Vector3(0.219f, 0.564f, 0.929f);
+        public Vector3 GFX_Gizmo_Z_HighlightColor = new Vector3(0.407f, 0.690f, 1.0f);
 
         // Map Editor settings
         public bool Map_AlwaysListLoadedMaps = true;

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -18,6 +18,8 @@ using Veldrid;
 using Veldrid.Sdl2;
 using Veldrid.StartupUtilities;
 using System.Windows.Forms;
+using StudioCore.MsbEditor;
+using System.Drawing;
 
 namespace StudioCore
 {
@@ -1399,6 +1401,36 @@ namespace StudioCore
                             _msbEditor.Viewport._worldView.CameraMoveSpeed_Fast = CFG.Default.GFX_Camera_MoveSpeed_Fast;
                             CFG.Current.GFX_Camera_MoveSpeed_Fast = _msbEditor.Viewport._worldView.CameraMoveSpeed_Fast;
                         }
+                        ImGui.Unindent();
+                    }
+
+                    ImGui.Separator();
+
+                    if (ImGui.CollapsingHeader("Gizmos"))
+                    {
+                        ImGui.Indent();
+
+                        ImGui.ColorEdit3("X Axis - Base Color", ref CFG.Current.GFX_Gizmo_X_BaseColor);
+                        ImGui.ColorEdit3("X Axis - Highlight Color", ref CFG.Current.GFX_Gizmo_X_HighlightColor);
+
+                        ImGui.ColorEdit3("Y Axis - Base Color", ref CFG.Current.GFX_Gizmo_Y_BaseColor);
+                        ImGui.ColorEdit3("Y Axis - Highlight Color", ref CFG.Current.GFX_Gizmo_Y_HighlightColor);
+
+                        ImGui.ColorEdit3("Z Axis - Base Color", ref CFG.Current.GFX_Gizmo_Z_BaseColor);
+                        ImGui.ColorEdit3("Z Axis - Highlight Color", ref CFG.Current.GFX_Gizmo_Z_HighlightColor);
+
+                        if (ImGui.Button("Reset Colors to Default"))
+                        {
+                            CFG.Current.GFX_Gizmo_X_BaseColor = new Vector3(0.952f, 0.211f, 0.325f);
+                            CFG.Current.GFX_Gizmo_X_HighlightColor = new Vector3(1.0f, 0.4f, 0.513f);
+
+                            CFG.Current.GFX_Gizmo_Y_BaseColor = new Vector3(0.525f, 0.784f, 0.082f);
+                            CFG.Current.GFX_Gizmo_Y_HighlightColor = new Vector3(0.713f, 0.972f, 0.270f);
+
+                            CFG.Current.GFX_Gizmo_Z_BaseColor = new Vector3(0.219f, 0.564f, 0.929f);
+                            CFG.Current.GFX_Gizmo_Z_HighlightColor = new Vector3(0.407f, 0.690f, 1.0f);
+                        }
+
                         ImGui.Unindent();
                     }
 

--- a/StudioCore/MsbEditor/Gizmos.cs
+++ b/StudioCore/MsbEditor/Gizmos.cs
@@ -114,39 +114,51 @@ namespace StudioCore.MsbEditor
             TranslateSquareGizmoZ = new DebugPrimitives.DbgPrimGizmoTranslateSquare(Axis.PosZ);
 
             TranslateGizmoXProxy = new DebugPrimitiveRenderableProxy(renderlist, TranslateGizmoX);
-            TranslateGizmoXProxy.BaseColor = Color.FromArgb(0xF3, 0x36, 0x53);
-            TranslateGizmoXProxy.HighlightedColor = Color.FromArgb(0xFF, 0x66, 0x83);
+            TranslateGizmoXProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_X_BaseColor);
+            TranslateGizmoXProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_X_HighlightColor);
+
             TranslateGizmoYProxy = new DebugPrimitiveRenderableProxy(renderlist, TranslateGizmoY);
-            TranslateGizmoYProxy.BaseColor = Color.FromArgb(0x86, 0xC8, 0x15);
-            TranslateGizmoYProxy.HighlightedColor = Color.FromArgb(0xB6, 0xF8, 0x45);
+            TranslateGizmoYProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Y_BaseColor);
+            TranslateGizmoYProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Y_HighlightColor);
+
             TranslateGizmoZProxy = new DebugPrimitiveRenderableProxy(renderlist, TranslateGizmoZ);
-            TranslateGizmoZProxy.BaseColor = Color.FromArgb(0x38, 0x90, 0xED);
-            TranslateGizmoZProxy.HighlightedColor = Color.FromArgb(0x68, 0xB0, 0xFF);
+            TranslateGizmoZProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Z_BaseColor);
+            TranslateGizmoZProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Z_HighlightColor);
+
             TranslateSquareGizmoXProxy = new DebugPrimitiveRenderableProxy(renderlist, TranslateSquareGizmoX);
-            TranslateSquareGizmoXProxy.BaseColor = Color.FromArgb(0xF3, 0x36, 0x53);
-            TranslateSquareGizmoXProxy.HighlightedColor = Color.FromArgb(0xFF, 0x66, 0x83);
+            TranslateSquareGizmoXProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_X_BaseColor);
+            TranslateSquareGizmoXProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_X_HighlightColor);
+
             TranslateSquareGizmoYProxy = new DebugPrimitiveRenderableProxy(renderlist, TranslateSquareGizmoY);
-            TranslateSquareGizmoYProxy.BaseColor = Color.FromArgb(0x86, 0xC8, 0x15);
-            TranslateSquareGizmoYProxy.HighlightedColor = Color.FromArgb(0xB6, 0xF8, 0x45);
+            TranslateSquareGizmoYProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Y_BaseColor);
+            TranslateSquareGizmoYProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Y_HighlightColor);
+
             TranslateSquareGizmoZProxy = new DebugPrimitiveRenderableProxy(renderlist, TranslateSquareGizmoZ);
-            TranslateSquareGizmoZProxy.BaseColor = Color.FromArgb(0x38, 0x90, 0xED);
-            TranslateSquareGizmoZProxy.HighlightedColor = Color.FromArgb(0x68, 0xB0, 0xFF);
+            TranslateSquareGizmoZProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Z_BaseColor);
+            TranslateSquareGizmoZProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Z_HighlightColor);
 
             RotateGizmoX = new DebugPrimitives.DbgPrimGizmoRotateRing(Axis.PosX);
             RotateGizmoY = new DebugPrimitives.DbgPrimGizmoRotateRing(Axis.PosY);
             RotateGizmoZ = new DebugPrimitives.DbgPrimGizmoRotateRing(Axis.PosZ);
 
             RotateGizmoXProxy = new DebugPrimitiveRenderableProxy(renderlist, RotateGizmoX);
-            RotateGizmoXProxy.BaseColor = Color.FromArgb(0xF3, 0x36, 0x53);
-            RotateGizmoXProxy.HighlightedColor = Color.FromArgb(0xFF, 0x66, 0x83);
+            RotateGizmoXProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_X_BaseColor);
+            RotateGizmoXProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_X_HighlightColor);
+
             RotateGizmoYProxy = new DebugPrimitiveRenderableProxy(renderlist, RotateGizmoY);
-            RotateGizmoYProxy.BaseColor = Color.FromArgb(0x86, 0xC8, 0x15);
-            RotateGizmoYProxy.HighlightedColor = Color.FromArgb(0xB6, 0xF8, 0x45);
+            RotateGizmoYProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Y_BaseColor);
+            RotateGizmoYProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Y_HighlightColor);
+
             RotateGizmoZProxy = new DebugPrimitiveRenderableProxy(renderlist, RotateGizmoZ);
-            RotateGizmoZProxy.BaseColor = Color.FromArgb(0x38, 0x90, 0xED);
-            RotateGizmoZProxy.HighlightedColor = Color.FromArgb(0x68, 0xB0, 0xFF);
+            RotateGizmoZProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Z_BaseColor);
+            RotateGizmoZProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Z_HighlightColor);
 
             _selection = selection;
+        }
+
+        Color GetGizmoColor(Vector3 color)
+        {
+            return Color.FromArgb((int)(color.X * 255), (int)(color.Y * 255), (int)(color.Z * 255));
         }
 
         // Code referenced from
@@ -258,6 +270,27 @@ namespace StudioCore.MsbEditor
         public void Update(Ray ray, bool canCaptureMouse)
         {
             bool canTransform = true;
+
+            // Update gizmo color
+            TranslateGizmoXProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_X_BaseColor);
+            TranslateGizmoXProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_X_HighlightColor);
+            TranslateGizmoYProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Y_BaseColor);
+            TranslateGizmoYProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Y_HighlightColor);
+            TranslateGizmoZProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Z_BaseColor);
+            TranslateGizmoZProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Z_HighlightColor);
+            TranslateSquareGizmoXProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_X_BaseColor);
+            TranslateSquareGizmoXProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_X_HighlightColor);
+            TranslateSquareGizmoYProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Y_BaseColor);
+            TranslateSquareGizmoYProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Y_HighlightColor);
+            TranslateSquareGizmoZProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Z_BaseColor);
+            TranslateSquareGizmoZProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Z_HighlightColor);
+            RotateGizmoXProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_X_BaseColor);
+            RotateGizmoXProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_X_HighlightColor);
+            RotateGizmoYProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Y_BaseColor);
+            RotateGizmoYProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Y_HighlightColor);
+            RotateGizmoZProxy.BaseColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Z_BaseColor);
+            RotateGizmoZProxy.HighlightedColor = GetGizmoColor(CFG.Current.GFX_Gizmo_Z_HighlightColor);
+
             if (IsTransforming)
             {
                 if (!InputTracker.GetMouseButton(MouseButton.Left))


### PR DESCRIPTION
- Added gizmo color settings, allowing the user to configure the colors used by the gizmo tool for the X, Y and Z axis.
- Added a button in the Gizmo section that resets the gizmo colors to the 'default' colors.