### PR TITLE
Crash handling fixes and improvements

### DIFF
--- a/DSMapStudio/DSMapStudio.csproj
+++ b/DSMapStudio/DSMapStudio.csproj
@@ -5,10 +5,10 @@
     <TargetFramework>net7.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Authors>Katalash</Authors>
-    <Version>1.03.0</Version>
+    <Version>1.07.0</Version>
     <ApplicationIcon>icon.ico</ApplicationIcon>
-    <PackageVersion>1.03.1</PackageVersion>
-    <AssemblyVersion>1.03.1</AssemblyVersion>
+    <PackageVersion>1.07.0</PackageVersion>
+    <AssemblyVersion>1.07.0</AssemblyVersion>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <LangVersion>11</LangVersion>
   </PropertyGroup>

--- a/DSMapStudio/Program.cs
+++ b/DSMapStudio/Program.cs
@@ -33,17 +33,17 @@ namespace DSMapStudio
             Directory.SetCurrentDirectory(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location));
 
             var mapStudio = new MapStudioNew();
-#if !DEBUG
+#if DEBUG
             try
             {
+                File.Copy("sdsad", "sdasd");
                 mapStudio.Run();
             }
-            catch (Exception e)
+            catch
             {
-                List<string> log = LogExceptions(e);
-                ExportCrashLog(log);
                 mapStudio.AttemptSaveOnCrash();
                 mapStudio.CrashShutdown();
+                // Throw to trigger CrashHandler
                 throw;
             }
 #else

--- a/DSMapStudio/Program.cs
+++ b/DSMapStudio/Program.cs
@@ -36,7 +36,6 @@ namespace DSMapStudio
 #if DEBUG
             try
             {
-                File.Copy("sdsad", "sdasd");
                 mapStudio.Run();
             }
             catch

--- a/DSMapStudio/Program.cs
+++ b/DSMapStudio/Program.cs
@@ -33,7 +33,7 @@ namespace DSMapStudio
             Directory.SetCurrentDirectory(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location));
 
             var mapStudio = new MapStudioNew();
-#if DEBUG
+#if !DEBUG
             try
             {
                 mapStudio.Run();

--- a/DSMapStudio/Program.cs
+++ b/DSMapStudio/Program.cs
@@ -14,7 +14,8 @@ namespace DSMapStudio
     public static class Program
     {
         public static string[] ARGS;
-        //public static MapStudio MainInstance;
+
+        private static string _version = Application.ProductVersion;
 
         /// <summary>
         /// The main entry point for the application.
@@ -40,7 +41,7 @@ namespace DSMapStudio
             catch (Exception e)
             {
                 List<string> log = LogExceptions(e);
-                mapStudio.ExportCrashLog(log);
+                ExportCrashLog(log);
                 mapStudio.AttemptSaveOnCrash();
                 mapStudio.CrashShutdown();
                 throw;
@@ -69,12 +70,34 @@ namespace DSMapStudio
             return log;
         }
 
+
+        static string CrashLogPath = $"{Directory.GetCurrentDirectory()}\\Crash Logs";
+        static void ExportCrashLog(List<string> exceptionInfo)
+        {
+            var time = $"{DateTime.Now:yyyy-M-dd--HH-mm-ss}";
+            exceptionInfo.Insert(0, $"DSMapStudio Version {_version}");
+            Directory.CreateDirectory($"{CrashLogPath}");
+            var crashLogPath = $"{CrashLogPath}\\Log {time}.txt";
+            File.WriteAllLines(crashLogPath, exceptionInfo);
+
+            if (exceptionInfo.Count > 10)
+                MessageBox.Show($"DSMapStudio has run into an issue.\nCrash log has been generated at \"{crashLogPath}\".",
+                    $"DSMapStudio Unhandled Error - {_version}", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            else
+                MessageBox.Show($"DSMapStudio has run into an issue.\nCrash log has been generated at \"{crashLogPath}\".\n\nCrash Log:\n{string.Join("\n", exceptionInfo)}",
+                    $"DSMapStudio Unhandled Error - {_version}", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+
+
         static void CrashHandler(object sender, UnhandledExceptionEventArgs args)
         {
             Exception e = (Exception)args.ExceptionObject;
             Console.WriteLine("Crash caught : " + e.Message);
             Console.WriteLine("Stack Trace : " + e.StackTrace);
             Console.WriteLine("Runtime terminating: {0}", args.IsTerminating);
+
+            List<string> log = LogExceptions(e);
+            ExportCrashLog(log);
         }
     }
 }

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -25,7 +25,7 @@ namespace StudioCore
 {
     public class MapStudioNew
     {
-        private static string _version = "1.07";
+        private static string _version = Application.ProductVersion;
         private static string _programTitle = $"Dark Souls Map Studio version {_version}";
 
         private Sdl2Window _window;
@@ -372,23 +372,6 @@ namespace StudioCore
             System.Windows.Forms.Application.Exit();
         }
 
-        private string CrashLogPath = $"{Directory.GetCurrentDirectory()}\\Crash Logs";
-        public void ExportCrashLog(List<string> exceptionInfo)
-        {
-            var time = $"{DateTime.Now:yyyy-M-dd--HH-mm-ss}";
-            exceptionInfo.Insert(0, $"DSMapStudio Version {_version}");
-            Directory.CreateDirectory($"{CrashLogPath}");
-            var crashLogPath = $"{CrashLogPath}\\Log {time}.txt";
-            File.WriteAllLines(crashLogPath, exceptionInfo);
-
-            if (exceptionInfo.Count > 10)
-                MessageBox.Show($"DSMapStudio has run into an issue.\nCrash log has been generated at \"{crashLogPath}\".",
-                    $"DSMapStudio Unhandled Error - {_version}", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            else
-                MessageBox.Show($"DSMapStudio has run into an issue.\nCrash log has been generated at \"{crashLogPath}\".\n\nCrash Log:\n{string.Join("\n", exceptionInfo)}",
-                    $"DSMapStudio Unhandled Error - {_version}", MessageBoxButtons.OK, MessageBoxIcon.Error);
-        }
-
         private void ChangeProjectSettings(Editor.ProjectSettings newsettings, string moddir, NewProjectOptions options)
         {
             _projectSettings = newsettings;
@@ -505,84 +488,96 @@ namespace StudioCore
         private bool AttemptLoadProject(Editor.ProjectSettings settings, string filename, bool updateRecents = true, NewProjectOptions options = null)
         {
             bool success = true;
-
-            // Check if game exe exists
-            if (!Directory.Exists(settings.GameRoot))
+            try
             {
-                success = false;
-                System.Windows.Forms.MessageBox.Show($@"Could not find game data directory for {settings.GameType}. Please select the game executable.", "Error",
-                    System.Windows.Forms.MessageBoxButtons.OK,
-                    System.Windows.Forms.MessageBoxIcon.None);
-
-                var rbrowseDlg = new System.Windows.Forms.OpenFileDialog()
+                // Check if game exe exists
+                if (!Directory.Exists(settings.GameRoot))
                 {
-                    Filter = AssetLocator.GameExecutatbleFilter,
-                    ValidateNames = true,
-                    CheckFileExists = true,
-                    CheckPathExists = true,
-                    //ShowReadOnly = true,
-                };
+                    success = false;
+                    System.Windows.Forms.MessageBox.Show($@"Could not find game data directory for {settings.GameType}. Please select the game executable.", "Error",
+                        System.Windows.Forms.MessageBoxButtons.OK,
+                        System.Windows.Forms.MessageBoxIcon.None);
 
-                var gametype = GameType.Undefined;
-                while (gametype != settings.GameType)
-                {
-                    if (rbrowseDlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                    var rbrowseDlg = new System.Windows.Forms.OpenFileDialog()
                     {
-                        settings.GameRoot = rbrowseDlg.FileName;
-                        gametype = _assetLocator.GetGameTypeForExePath(settings.GameRoot);
-                        if (gametype != settings.GameType)
+                        Filter = AssetLocator.GameExecutatbleFilter,
+                        ValidateNames = true,
+                        CheckFileExists = true,
+                        CheckPathExists = true,
+                        //ShowReadOnly = true,
+                    };
+
+                    var gametype = GameType.Undefined;
+                    while (gametype != settings.GameType)
+                    {
+                        if (rbrowseDlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
                         {
-                            System.Windows.Forms.MessageBox.Show($@"Selected executable was not for {settings.GameType}. Please select the correct game executable.", "Error",
-                                System.Windows.Forms.MessageBoxButtons.OK,
-                                System.Windows.Forms.MessageBoxIcon.None);
+                            settings.GameRoot = rbrowseDlg.FileName;
+                            gametype = _assetLocator.GetGameTypeForExePath(settings.GameRoot);
+                            if (gametype != settings.GameType)
+                            {
+                                System.Windows.Forms.MessageBox.Show($@"Selected executable was not for {settings.GameType}. Please select the correct game executable.", "Error",
+                                    System.Windows.Forms.MessageBoxButtons.OK,
+                                    System.Windows.Forms.MessageBoxIcon.None);
+                            }
+                            else
+                            {
+                                success = true;
+                                settings.GameRoot = Path.GetDirectoryName(settings.GameRoot);
+                                if (settings.GameType == GameType.Bloodborne)
+                                {
+                                    settings.GameRoot = settings.GameRoot + @"\dvdroot_ps4";
+                                }
+                                settings.Serialize(filename);
+                            }
                         }
                         else
                         {
-                            success = true;
-                            settings.GameRoot = Path.GetDirectoryName(settings.GameRoot);
-                            if (settings.GameType == GameType.Bloodborne)
-                            {
-                                settings.GameRoot = settings.GameRoot + @"\dvdroot_ps4";
-                            }
-                            settings.Serialize(filename);
+                            break;
                         }
                     }
-                    else
+                }
+
+                if (success)
+                {
+                    if (!_assetLocator.CheckFilesExpanded(settings.GameRoot, settings.GameType))
                     {
-                        break;
+                        if (!GameNotUnpackedWarning(settings.GameType))
+                            return false;
+                    }
+                    if ((settings.GameType == GameType.Sekiro || settings.GameType == GameType.EldenRing) && !File.Exists(Path.Join(Path.GetFullPath("."), "oo2core_6_win64.dll")))
+                    {
+                        if (!File.Exists(Path.Join(settings.GameRoot, "oo2core_6_win64.dll")))
+                        {
+                            throw new FileNotFoundException($"Could not find file \"oo2core_6_win64.dll\" in \"{settings.GameRoot}\" folder, which should be included by default. Try reinstalling the game.");
+                        }
+                        File.Copy(Path.Join(settings.GameRoot, "oo2core_6_win64.dll"), Path.Join(Path.GetFullPath("."), "oo2core_6_win64.dll"));
+                    }
+                    _projectSettings = settings;
+                    ChangeProjectSettings(_projectSettings, Path.GetDirectoryName(filename), options);
+                    CFG.Current.LastProjectFile = filename;
+                    _window.Title = $"{_programTitle}  -  {_projectSettings.ProjectName}";
+
+                    if (updateRecents)
+                    {
+                        var recent = new CFG.RecentProject();
+                        recent.Name = _projectSettings.ProjectName;
+                        recent.GameType = _projectSettings.GameType;
+                        recent.ProjectFile = filename;
+                        CFG.Current.RecentProjects.Insert(0, recent);
+                        if (CFG.Current.RecentProjects.Count > CFG.MAX_RECENT_PROJECTS)
+                        {
+                            CFG.Current.RecentProjects.RemoveAt(CFG.Current.RecentProjects.Count - 1);
+                        }
                     }
                 }
             }
-
-            if (success)
+            catch
             {
-                if (!_assetLocator.CheckFilesExpanded(settings.GameRoot, settings.GameType))
-                {
-                    if (!GameNotUnpackedWarning(settings.GameType))
-                        return false;
-                }
-                if ((settings.GameType == GameType.Sekiro || settings.GameType == GameType.EldenRing) && !File.Exists(Path.Join(Path.GetFullPath("."), "oo2core_6_win64.dll")))
-                {
-                    //Technically we're not checking it exists, but the same can be said for many things we assume from CheckFilesExpanded
-                    File.Copy(Path.Join(settings.GameRoot, "oo2core_6_win64.dll"), Path.Join(Path.GetFullPath("."), "oo2core_6_win64.dll"));
-                }
-                _projectSettings = settings;
-                ChangeProjectSettings(_projectSettings, Path.GetDirectoryName(filename), options);
-                CFG.Current.LastProjectFile = filename;
-                _window.Title = $"{_programTitle}  -  {_projectSettings.ProjectName}";
-
-                if (updateRecents)
-                {
-                    var recent = new CFG.RecentProject();
-                    recent.Name = _projectSettings.ProjectName;
-                    recent.GameType = _projectSettings.GameType;
-                    recent.ProjectFile = filename;
-                    CFG.Current.RecentProjects.Insert(0, recent);
-                    if (CFG.Current.RecentProjects.Count > CFG.MAX_RECENT_PROJECTS)
-                    {
-                        CFG.Current.RecentProjects.RemoveAt(CFG.Current.RecentProjects.Count - 1);
-                    }
-                }
+                // Error loading project, clear recent project to let the user launch the program next time without issue.
+                CFG.Current.LastProjectFile = "";
+                CFG.Save();
+                throw;
             }
             return success;
         }

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -549,7 +549,10 @@ namespace StudioCore
                     {
                         if (!File.Exists(Path.Join(settings.GameRoot, "oo2core_6_win64.dll")))
                         {
-                            throw new FileNotFoundException($"Could not find file \"oo2core_6_win64.dll\" in \"{settings.GameRoot}\" folder, which should be included by default. Try reinstalling the game.");
+                            MessageBox.Show($"Could not find file \"oo2core_6_win64.dll\" in \"{settings.GameRoot}\", which should be included by default.\n\nTry reinstalling the game.", "Error",
+                                MessageBoxButtons.OK,
+                                MessageBoxIcon.None);
+                            return false;
                         }
                         File.Copy(Path.Join(settings.GameRoot, "oo2core_6_win64.dll"), Path.Join(Path.GetFullPath("."), "oo2core_6_win64.dll"));
                     }


### PR DESCRIPTION
Make Crash Handler handle UnhandledException properly.
Use Assembly version for program version.
Clear recent project in CFG if an exception occurred while trying to load project.
Handle missing oodle dll in game folder.