### PR TITLE
WIP: Make robust CSV import and export using CsvHelper lib

### DIFF
--- a/StudioCore/CFG.cs
+++ b/StudioCore/CFG.cs
@@ -247,12 +247,31 @@ namespace StudioCore
             get
             {
                 if (_Param_Export_Delimiter.Length == 0)
-                    _Param_Export_Delimiter = CFG.Default.Param_Export_Delimiter;
-                else if (_Param_Export_Delimiter == "|")
-                    _Param_Export_Delimiter = CFG.Default.Param_Export_Delimiter; // Temporary measure to prevent conflicts with byte array delimiters. Will be removed later.
+                    _Param_Export_Delimiter = Default.Param_Export_Delimiter;
+                else if (!_Param_Export_Escape && _Param_Export_Delimiter == "|")
+                {
+                    // If not using escape characters, | in byte array values will interfere and cannot be a valid delimiter.
+                    System.Windows.Forms.MessageBox.Show("| as a delimiter would clash with byte array export values, returning to default delimiter.", "Warning", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.None);
+                    _Param_Export_Delimiter = Default.Param_Export_Delimiter;
+                }
                 return _Param_Export_Delimiter;
             }
-            set { _Param_Export_Delimiter = value; }
+            set => _Param_Export_Delimiter = value;
+        }
+        private bool _Param_Export_Escape = true;
+        public bool Param_Export_Escape
+        {
+            get => _Param_Export_Escape;
+            set
+            {
+                if (value == false && _Param_Export_Delimiter == "|")
+                {
+                    // If not using escape characters, | in byte array values will interfere and cannot be a valid delimiter.
+                    System.Windows.Forms.MessageBox.Show("| as a delimiter would clash with byte array export values, returning to default delimiter.", "Warning", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.None);
+                    _Param_Export_Delimiter = Default.Param_Export_Delimiter;
+                }
+                _Param_Export_Escape = value;
+            }
         }
 
         public bool EnableEldenRingAutoMapOffset = true;

--- a/StudioCore/ParamEditor/MassParamEdit.cs
+++ b/StudioCore/ParamEditor/MassParamEdit.cs
@@ -433,7 +433,7 @@ namespace StudioCore.ParamEditor
                     {
                         string[]? line = parser.ReadFields();
                         // Skip empty or header row
-                        if (line == null || line.Length == 0 || (line[0] == "ID" && (line.Length == 1 || line[1] == "Name")))
+                        if (line == null || line.Length < 2 || (line[0] == "ID" && line[1] == "Name"))
                         {
                             continue;
                         }

--- a/StudioCore/ParamEditor/MassParamEdit.cs
+++ b/StudioCore/ParamEditor/MassParamEdit.cs
@@ -356,6 +356,7 @@ namespace StudioCore.ParamEditor
                                 }
                             }
                         }
+
                     }
                 }
             }

--- a/StudioCore/ParamEditor/MassParamEdit.cs
+++ b/StudioCore/ParamEditor/MassParamEdit.cs
@@ -433,7 +433,13 @@ namespace StudioCore.ParamEditor
                     {
                         string[]? line = parser.ReadFields();
                         // Skip empty or header row
-                        if (line == null || line.Length < 2 || (line[0] == "ID" && line[1] == "Name"))
+
+                        if (line.Length != csvLength && !(line.Length==csvLength+1 && line[csvLength].Trim().Equals("")))
+                        {
+                            return new MassEditResult(MassEditResultType.PARSEERROR, $"CSV line {csvLines.Count} has wrong number of values (is {line.Length}, should be {csvLength}");
+                        }
+
+                        if (line == null || (line[0] == "ID" && line[1] == "Name"))
                         {
                             continue;
                         }
@@ -442,7 +448,7 @@ namespace StudioCore.ParamEditor
                     }
                     catch (MalformedLineException e)
                     {
-                        return new MassEditResult(MassEditResultType.PARSEERROR, $"CSV contains malformed line {csvLines.Count}, {e.Message}");
+                        return new MassEditResult(MassEditResultType.PARSEERROR, $"CSV line {csvLines.Count} is malformed, {e.Message}");
                     }
 
                 }
@@ -453,10 +459,6 @@ namespace StudioCore.ParamEditor
                 List<Param.Row> addedParams = new List<Param.Row>();
                 foreach (string[] csvs in csvLines)
                 {
-                    if (csvs.Length != csvLength && !(csvs.Length==csvLength+1 && csvs[csvLength].Trim().Equals("")))
-                    {
-                        return new MassEditResult(MassEditResultType.PARSEERROR, "CSV has wrong number of values");
-                    }
                     int id = int.Parse(csvs[0]);
                     string name = csvs[1];
                     var row = p[id];

--- a/StudioCore/ParamEditor/MassParamEdit.cs
+++ b/StudioCore/ParamEditor/MassParamEdit.cs
@@ -432,13 +432,14 @@ namespace StudioCore.ParamEditor
                     try
                     {
                         string[]? line = parser.ReadFields();
-                        // Skip empty or header row
 
+                        // Sanity check for amount of fields
                         if (line.Length != csvLength && !(line.Length==csvLength+1 && line[csvLength].Trim().Equals("")))
                         {
                             return new MassEditResult(MassEditResultType.PARSEERROR, $"CSV line {csvLines.Count} has wrong number of values (is {line.Length}, should be {csvLength}");
                         }
 
+                        // Skip empty or header row
                         if (line == null || (line[0] == "ID" && line[1] == "Name"))
                         {
                             continue;

--- a/StudioCore/ParamEditor/MassParamEdit.cs
+++ b/StudioCore/ParamEditor/MassParamEdit.cs
@@ -427,16 +427,18 @@ namespace StudioCore.ParamEditor
                 parser.SetDelimiters(separator.ToString());
 
                 List<string[]> csvLines = new();
+                int lineBeingParsed = 0;
                 while (!parser.EndOfData)
                 {
                     try
                     {
+                        lineBeingParsed++;
                         string[]? line = parser.ReadFields();
 
                         // Sanity check for amount of fields
                         if (line.Length != csvLength && !(line.Length==csvLength+1 && line[csvLength].Trim().Equals("")))
                         {
-                            return new MassEditResult(MassEditResultType.PARSEERROR, $"CSV line {csvLines.Count} has wrong number of values (is {line.Length}, should be {csvLength}");
+                            return new MassEditResult(MassEditResultType.PARSEERROR, $"CSV line {lineBeingParsed} has wrong number of values (is {line.Length}, should be {csvLength}");
                         }
 
                         // Skip empty or header row
@@ -449,7 +451,7 @@ namespace StudioCore.ParamEditor
                     }
                     catch (MalformedLineException e)
                     {
-                        return new MassEditResult(MassEditResultType.PARSEERROR, $"CSV line {csvLines.Count} is malformed, {e.Message}");
+                        return new MassEditResult(MassEditResultType.PARSEERROR, $"CSV line {lineBeingParsed} is malformed, {e.Message}");
                     }
 
                 }

--- a/StudioCore/ParamEditor/MassParamEdit.cs
+++ b/StudioCore/ParamEditor/MassParamEdit.cs
@@ -432,15 +432,13 @@ namespace StudioCore.ParamEditor
                     try
                     {
                         string[]? line = parser.ReadFields();
-                        if (line[0] == "ID" && line[1] == "Name")
+                        // Skip empty or header row
+                        if (line == null || line.Length == 0 || (line[0] == "ID" && (line.Length == 1 || line[1] == "Name")))
                         {
-                            // skip column label row;
                             continue;
                         }
-                        if (line != null)
-                        {
-                            csvLines.Add(line);
-                        }
+
+                        csvLines.Add(line);
                     }
                     catch (MalformedLineException e)
                     {

--- a/StudioCore/ParamEditor/MassParamEdit.cs
+++ b/StudioCore/ParamEditor/MassParamEdit.cs
@@ -429,16 +429,24 @@ namespace StudioCore.ParamEditor
                 List<string[]> csvLines = new();
                 while (!parser.EndOfData)
                 {
-                    string[]? line = parser.ReadFields();
-                    if (line[0] == "ID" && line[1] == "Name")
+                    try
                     {
-                        // skip column label row;
-                        continue;
+                        string[]? line = parser.ReadFields();
+                        if (line[0] == "ID" && line[1] == "Name")
+                        {
+                            // skip column label row;
+                            continue;
+                        }
+                        if (line != null)
+                        {
+                            csvLines.Add(line);
+                        }
                     }
-                    if (line != null)
+                    catch (MalformedLineException e)
                     {
-                        csvLines.Add(line);
+                        return new MassEditResult(MassEditResultType.PARSEERROR, $"CSV contains malformed line {csvLines.Count}, {e.Message}");
                     }
+
                 }
                 parser.Close();
                 int changeCount = 0;

--- a/StudioCore/StudioCore.csproj
+++ b/StudioCore/StudioCore.csproj
@@ -422,6 +422,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="NativeLibraryLoader" Version="1.0.12" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Octokit" Version="4.0.4" />


### PR DESCRIPTION
The simplistic "split string by separator" workflow has issues when processing CSV with commas in double quotes, such as those compliant with the RFC 4180 standard. The C# TextFieldParser class seems to perform better at this with some basic configuration. Tested with a 2MB param CSV import containing double quoted commas.