### PR TITLE
Fix offset on Move Selection to Camera

### DIFF
--- a/StudioCore/MsbEditor/Entity.cs
+++ b/StudioCore/MsbEditor/Entity.cs
@@ -163,6 +163,13 @@ namespace StudioCore.MsbEditor
                 Parent.Children.Remove(child);
             }
             child.Parent = this;
+
+            // Update the containing map for map entities.
+            if (Container.GetType() == typeof(Map) && child.Container.GetType() == typeof(Map))
+            {
+                child.Container = Container;
+            }
+
             Children.Add(child);
             child.UpdateRenderModel();
         }

--- a/StudioCore/MsbEditor/MsbEditorScreen.cs
+++ b/StudioCore/MsbEditor/MsbEditorScreen.cs
@@ -246,6 +246,10 @@ namespace StudioCore.MsbEditor
             {
                 var rot = s.GetRootTransform().EulerRotation;
 
+                // Offset the new position by the map's offset from the origin.
+                TransformNode node = (TransformNode) s.Container.RootObject.WrappedObject;
+                new_pos -= node.Position;
+
                 Transform newPos = new Transform(new_pos, rot);
 
                 actlist.Add(s.GetUpdateTransformAction(newPos));


### PR DESCRIPTION
**Please review in detail, I'm not sure about the consequences of my AddChild change**

Poked around in the debugger until I found a place which stored the currently relevant map and its relevant transform offset, then applied that to the selection blindly. Sure hope that makes sense!

The Container change is secondary and doesn't really seem to be relevant, but it seems like good practice. Duplicated map entities did not have their Container (ContainingMap) changed correctly.