### PR TITLE
Fix ds2 def, prevent crash when diffing with undef'd vanilla

### DIFF
--- a/StudioCore/Assets/Paramdex/DS2S/Defs/ITEM_LOT_PARAM2.xml
+++ b/StudioCore/Assets/Paramdex/DS2S/Defs/ITEM_LOT_PARAM2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PARAMDEF XmlVersion="0">
-  <ParamType>ITEM_lot__PARAM2</ParamType>
+  <ParamType>ITEM_LOT_PARAM2</ParamType>
   <Unk06>0</Unk06>
   <BigEndian>False</BigEndian>
   <Unicode>True</Unicode>

--- a/StudioCore/ParamEditor/ParamUtils.cs
+++ b/StudioCore/ParamEditor/ParamUtils.cs
@@ -85,7 +85,7 @@ namespace StudioCore.ParamEditor
 
         public static (PseudoColumn, Param.Column) GetAs(this (PseudoColumn, Param.Column) col, Param newParam)
         {
-            return (col.Item1, col.Item2 == null? null : newParam.Cells.FirstOrDefault((x) => x.Def.InternalName == col.Item2.Def.InternalName));
+            return (col.Item1, col.Item2 == null || newParam == null ? null : newParam.Cells.FirstOrDefault((x) => x.Def.InternalName == col.Item2.Def.InternalName));
         }
         public static bool IsColumnValid(this (PseudoColumn, Param.Column) col)
         {


### PR DESCRIPTION
This crash only became relevant because DS2 loose params were able to load in without proper paramdef checks - should look into this more later.
Fixing it because a similar issue might crop up later anyway.