### PR TITLE
Add key distinction to cachebank

### DIFF
--- a/StudioCore/Editor/CacheBank.cs
+++ b/StudioCore/Editor/CacheBank.cs
@@ -4,19 +4,28 @@ using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using System.Linq;
 
 namespace StudioCore.Editor
 {
     public class CacheBank
     {
-        private static Dictionary<object, object> caches = new Dictionary<object, object>();
+        private static Dictionary<(EditorScreen, object, string), object> caches = new Dictionary<(EditorScreen, object, string), object>();
+        
+        /// <summary>
+        /// Gets/Sets a cache. The cached data is intended to have a lifetime until the contextual object is modified, or the UIScreen object is refreshed.
+        /// </summary>
+        public static T GetCached<T>(EditorScreen UIScreen, object context, Func<T> getValue)
+        {
+            return GetCached<T>(UIScreen, context, "", getValue);
+        }
 
         /// <summary>
-        /// Gets/Sets a cache
+        /// Gets/Sets a cache with a specific key, avoiding any case where there would be conflict over the context-giving object
         /// </summary>
-        public static T GetCached<T>(object UIScreen, object key, Func<T> getValue)
+        public static T GetCached<T>(EditorScreen UIScreen, object context, string key, Func<T> getValue)
         {
-            var trueKey = (UIScreen, key);
+            var trueKey = (UIScreen, context, key);
             if (!caches.ContainsKey(trueKey))
             {
                 caches[trueKey] = getValue();
@@ -25,12 +34,23 @@ namespace StudioCore.Editor
         }
 
         /// <summary>
-        /// Removes a targeted cache
+        /// Removes cached data related to the context object
         /// </summary>
-        public static void RemoveCache(object UIScreen, object key)
+        public static void RemoveCache(EditorScreen UIScreen, object context)
         {
-            var trueKey = (UIScreen, key);
-            caches.Remove(trueKey);
+            var toRemove = caches.Where((keypair) => keypair.Key.Item1 == UIScreen && keypair.Key.Item2 == context);
+            foreach (var kp in toRemove)
+                caches.Remove(kp.Key);
+        }
+        
+        /// <summary>
+        /// Removes cached data within the UIScreen's domain
+        /// </summary>
+        public static void RemoveCache(EditorScreen UIScreen)
+        {
+            var toRemove = caches.Where((keypair) => keypair.Key.Item1 == UIScreen);
+            foreach (var kp in toRemove)
+                caches.Remove(kp.Key);
         }
 
         /// <summary>

--- a/StudioCore/ParamEditor/ParamRowEditor.cs
+++ b/StudioCore/ParamEditor/ParamRowEditor.cs
@@ -336,9 +336,9 @@ namespace StudioCore.ParamEditor
             ImGui.Separator();
 
             string search = propSearchString;
-            List<(PseudoColumn, Param.Column)> cols = CacheBank.GetCached(_paramEditor, row, () => CellSearchEngine.cse.Search((activeParam, row), search, true, true));
-            List<(PseudoColumn, Param.Column)> vcols = CacheBank.GetCached(_paramEditor, vrow, () => cols.Select((x, i) => x.GetAs(ParamBank.VanillaBank.GetParamFromName(activeParam))).ToList());
-            List<List<(PseudoColumn, Param.Column)>> auxCols = CacheBank.GetCached(_paramEditor, auxRows, () => auxRows.Select((r, i) => cols.Select((c, j) => c.GetAs(ParamBank.AuxBanks[r.Item1].GetParamFromName(activeParam))).ToList()).ToList());
+            List<(PseudoColumn, Param.Column)> cols = CacheBank.GetCached(_paramEditor, row, "fieldFilter", () => CellSearchEngine.cse.Search((activeParam, row), search, true, true));
+            List<(PseudoColumn, Param.Column)> vcols = CacheBank.GetCached(_paramEditor, vrow, "vFieldFilter", () => cols.Select((x, i) => x.GetAs(ParamBank.VanillaBank.GetParamFromName(activeParam))).ToList());
+            List<List<(PseudoColumn, Param.Column)>> auxCols = CacheBank.GetCached(_paramEditor, auxRows, "auxFieldFilter", () => auxRows.Select((r, i) => cols.Select((c, j) => c.GetAs(ParamBank.AuxBanks[r.Item1].GetParamFromName(activeParam))).ToList()).ToList());
 
             List<string> pinnedFields = new List<string>(_paramEditor._projectSettings.PinnedFields.GetValueOrDefault(activeParam, new List<string>()));
             if (pinnedFields.Count > 0)
@@ -413,7 +413,7 @@ namespace StudioCore.ParamEditor
                 ImGui.Separator();
                 ImGui.NewLine();
                 var ccd = meta.CalcCorrectDef;
-                (float[] values, int xOffset, float minY, float maxY) = CacheBank.GetCached(_paramEditor, row, () => getCalcCorrectedData(ccd, row));
+                (float[] values, int xOffset, float minY, float maxY) = CacheBank.GetCached(_paramEditor, row, "calcCorrectData", () => getCalcCorrectedData(ccd, row));
                 ImGui.PlotLines("##graph", ref values[0], values.Length, 0, xOffset == 0 ? "" : $@"Note: add {xOffset} to x coordinate", minY, maxY, new Vector2(ImGui.GetColumnWidth(-1), ImGui.GetColumnWidth(-1)*0.5625f));
             }
             catch (Exception e)


### PR DESCRIPTION
Also fixes calccorrectgraph graph, which was using a shared context object (the row)