### PR TITLE
Recent project list improvements

### DIFF
--- a/StudioCore/CFG.cs
+++ b/StudioCore/CFG.cs
@@ -30,7 +30,7 @@ namespace StudioCore
         private IDictionary<string, JToken> _additionalData;
 #pragma warning restore IDE0051
 
-        public const int MAX_RECENT_PROJECTS = 10;
+        public const int MAX_RECENT_PROJECTS = 20;
 
         public static string GetConfigFilePath()
         {

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -768,9 +768,10 @@ namespace StudioCore
                     if (ImGui.BeginMenu("Recent Projects", Editor.TaskManager.GetLiveThreads().Count == 0 && CFG.Current.RecentProjects.Count > 0))
                     {
                         CFG.RecentProject recent = null;
-                        foreach (var p in CFG.Current.RecentProjects)
+                        int id = 0;
+                        foreach (var p in CFG.Current.RecentProjects.ToArray())
                         {
-                            if (ImGui.MenuItem($@"{p.GameType.ToString()}:{p.Name}"))
+                            if (ImGui.MenuItem($@"{p.GameType}: {p.Name}##{id}"))
                             {
                                 if (File.Exists(p.ProjectFile))
                                 {
@@ -781,6 +782,16 @@ namespace StudioCore
                                     }
                                 }
                             }
+                            if (ImGui.BeginPopupContextItem())
+                            {
+                                if (ImGui.Selectable("Remove from list"))
+                                {
+                                    CFG.Current.RecentProjects.Remove(p);
+                                    CFG.Save();
+                                }
+                                ImGui.EndPopup();
+                            }
+                            id++;
                         }
                         if (recent != null)
                         {


### PR DESCRIPTION
Fix recent projects selectables with identical names.
Add right-click context option to remove project from recent projects list.

Increases the recent project limit from 10 to 20.