### PR TITLE
Default renderable proxy v2 + Add setting to display model markers for all map entities.

### DIFF
--- a/StudioCore/CFG.cs
+++ b/StudioCore/CFG.cs
@@ -214,6 +214,7 @@ namespace StudioCore
         public float Map_ArbitraryRotation_X_Shift { get; set; } = 90.0f;
         public float Map_ArbitraryRotation_Y_Shift { get; set; } = 90.0f;
         public float Map_MoveSelectionToCamera_Radius = 3.0f;
+        public bool Map_ShowModelMarkersForEverything = true;
 
         // Font settings
         public bool FontChinese = false;

--- a/StudioCore/CFG.cs
+++ b/StudioCore/CFG.cs
@@ -214,7 +214,7 @@ namespace StudioCore
         public float Map_ArbitraryRotation_X_Shift { get; set; } = 90.0f;
         public float Map_ArbitraryRotation_Y_Shift { get; set; } = 90.0f;
         public float Map_MoveSelectionToCamera_Radius = 3.0f;
-        public bool Map_ShowModelMarkersForEverything = true;
+        public bool Map_ShowModelMarkersForEverything = false;
 
         // Font settings
         public bool FontChinese = false;

--- a/StudioCore/FeatureFlags.cs
+++ b/StudioCore/FeatureFlags.cs
@@ -25,5 +25,7 @@ namespace StudioCore
 #endif
 
         public static bool EnablePartialParam = false;
+
+        public static bool GiveAllRenderablesModelMarkers = true;
     }
 }

--- a/StudioCore/FeatureFlags.cs
+++ b/StudioCore/FeatureFlags.cs
@@ -25,7 +25,5 @@ namespace StudioCore
 #endif
 
         public static bool EnablePartialParam = false;
-
-        public static bool GiveAllRenderablesModelMarkers = true;
     }
 }

--- a/StudioCore/KeyBindings.cs
+++ b/StudioCore/KeyBindings.cs
@@ -107,6 +107,7 @@ namespace StudioCore
             public KeyBind Map_Dummify = new(Key.Comma, false, false, true);
             public KeyBind Map_UnDummify = new(Key.Period, false, false, true);
             public KeyBind Map_MoveSelectionToCamera = new(Key.X);
+            public KeyBind Map_ShowModelMarkersForEverything = new(Key.M, true);
 
             // Parameters
             public KeyBind Param_SelectAll = new(Key.A, true);

--- a/StudioCore/MsbEditor/MsbEditorScreen.cs
+++ b/StudioCore/MsbEditor/MsbEditorScreen.cs
@@ -720,6 +720,10 @@ namespace StudioCore.MsbEditor
                     Viewport.SceneParamsGui();
                     ImGui.EndMenu();
                 }
+                if (ImGui.MenuItem("Show model markers for everything", KeyBindings.Current.Map_ShowModelMarkersForEverything.HintText, CFG.Current.Map_ShowModelMarkersForEverything))
+                {
+                    ToggleShowModelMarkersForEverything();
+                }
                 CFG.Current.LastSceneFilter = RenderScene.DrawFilter;
                 ImGui.EndMenu();
             }
@@ -760,10 +764,6 @@ namespace StudioCore.MsbEditor
                         Gizmos.Origin = Gizmos.GizmosOrigin.BoundingBox;
                     }
                     ImGui.EndMenu();
-                }
-                if (ImGui.MenuItem("Show model markers for everything", KeyBindings.Current.Map_ShowModelMarkersForEverything.HintText, CFG.Current.Map_ShowModelMarkersForEverything))
-                {
-                    ToggleShowModelMarkersForEverything();
                 }
                 ImGui.EndMenu();
             }

--- a/StudioCore/MsbEditor/MsbEditorScreen.cs
+++ b/StudioCore/MsbEditor/MsbEditorScreen.cs
@@ -254,7 +254,23 @@ namespace StudioCore.MsbEditor
             var action = new CompoundAction(actlist);
             EditorActionManager.ExecuteAction(action);
         }
-        
+
+        public void ToggleShowModelMarkersForEverything()
+        {
+            CFG.Current.Map_ShowModelMarkersForEverything = !CFG.Current.Map_ShowModelMarkersForEverything;
+
+            foreach (var map in Universe.LoadedObjectContainers)
+            {
+                if (map.Value != null)
+                {
+                    foreach (var ent in map.Value.Objects)
+                    {
+                        ent.UpdateRenderModel();
+                    }
+                }
+            }
+        }
+
         /// <summary>
         /// Hides all the selected objects, unless all of them are hidden in which
         /// they will be unhidden
@@ -745,6 +761,10 @@ namespace StudioCore.MsbEditor
                     }
                     ImGui.EndMenu();
                 }
+                if (ImGui.MenuItem("Show model markers for everything", KeyBindings.Current.Map_ShowModelMarkersForEverything.HintText, CFG.Current.Map_ShowModelMarkersForEverything))
+                {
+                    ToggleShowModelMarkersForEverything();
+                }
                 ImGui.EndMenu();
             }
         }
@@ -861,6 +881,10 @@ namespace StudioCore.MsbEditor
                 if (InputTracker.GetKeyDown(KeyBindings.Current.Map_MoveSelectionToCamera) && _selection.IsSelection())
                 {
                     MoveSelectionToCamera();
+                }
+                if (InputTracker.GetKeyDown(KeyBindings.Current.Map_ShowModelMarkersForEverything))
+                {
+                    ToggleShowModelMarkersForEverything();
                 }
 
                 // Render settings

--- a/StudioCore/Scene/RenderableProxy.cs
+++ b/StudioCore/Scene/RenderableProxy.cs
@@ -376,7 +376,7 @@ namespace StudioCore.Scene
             _placeholderProxy =
                 DebugPrimitiveRenderableProxy.GetModelMarkerProxy(_renderablesSet, _placeholderType);
             _placeholderProxy.World = World;
-            //_placeholderProxy.Visible = false;
+            _placeholderProxy.Visible = _visible;
             _placeholderProxy.DrawFilter = _drawfilter;
             _placeholderProxy.DrawGroups = _drawgroups;
             if (_selectable != null)
@@ -392,6 +392,7 @@ namespace StudioCore.Scene
             {
                 _placeholderProxy.Register();
             }
+            //
 
         }
 
@@ -444,7 +445,6 @@ namespace StudioCore.Scene
             if (_placeholderProxy != null)
             {
                 _placeholderProxy.UnregisterAndRelease();
-                _placeholderProxy.Dispose();
                 _placeholderProxy = null;
             }
 

--- a/StudioCore/Scene/RenderableProxy.cs
+++ b/StudioCore/Scene/RenderableProxy.cs
@@ -247,8 +247,7 @@ namespace StudioCore.Scene
 
                 if (_placeholderProxy != null)
                 {
-                    if (_showPlaceholderProxy ||
-                        (CFG.Current.Map_ShowModelMarkersForEverything && FeatureFlags.GiveAllRenderablesModelMarkers))
+                    if (_showPlaceholderProxy || CFG.Current.Map_ShowModelMarkersForEverything)
                     {
                         _placeholderProxy.Visible = _visible;
                     }

--- a/StudioCore/Scene/RenderableProxy.cs
+++ b/StudioCore/Scene/RenderableProxy.cs
@@ -244,13 +244,17 @@ namespace StudioCore.Scene
                     sm.Visible = _visible;
                 }
 
-                if (VisibleModelMarker)
+                if (_placeholderProxy != null)
                 {
-                    _placeholderProxy.Visible = _visible;
-                }
-                else
-                {
-                    _placeholderProxy.Visible = false;
+                    if (VisibleModelMarker ||
+                        FeatureFlags.GiveAllRenderablesModelMarkers && true)
+                    {
+                        _placeholderProxy.Visible = _visible;
+                    }
+                    else
+                    {
+                        _placeholderProxy.Visible = false;
+                    }
                 }
             }
         }
@@ -373,24 +377,27 @@ namespace StudioCore.Scene
             }
 
             // George addition
-            _placeholderProxy =
-                DebugPrimitiveRenderableProxy.GetModelMarkerProxy(_renderablesSet, _placeholderType);
-            _placeholderProxy.World = World;
-            _placeholderProxy.Visible = _visible;
-            _placeholderProxy.DrawFilter = _drawfilter;
-            _placeholderProxy.DrawGroups = _drawgroups;
-            if (_selectable != null)
+            if (_placeholderType != ModelMarkerType.None)
             {
-                _selectable.TryGetTarget(out var sel);
-                if (sel != null)
+                _placeholderProxy =
+                    DebugPrimitiveRenderableProxy.GetModelMarkerProxy(_renderablesSet, _placeholderType);
+                _placeholderProxy.World = World;
+                _placeholderProxy.Visible = _visible;
+                _placeholderProxy.DrawFilter = _drawfilter;
+                _placeholderProxy.DrawGroups = _drawgroups;
+                if (_selectable != null)
                 {
-                    _placeholderProxy.SetSelectable(sel);
+                    _selectable.TryGetTarget(out var sel);
+                    if (sel != null)
+                    {
+                        _placeholderProxy.SetSelectable(sel);
+                    }
                 }
-            }
 
-            if (_registered)
-            {
-                _placeholderProxy.Register();
+                if (_registered)
+                {
+                    _placeholderProxy.Register();
+                }
             }
             //
 

--- a/StudioCore/Scene/RenderableProxy.cs
+++ b/StudioCore/Scene/RenderableProxy.cs
@@ -374,7 +374,7 @@ namespace StudioCore.Scene
                 ScheduleRenderableConstruction();
             }
 
-            // George addition
+            // Default placeholderProxy
             if (_placeholderType != ModelMarkerType.None)
             {
                 _placeholderProxy =
@@ -397,8 +397,6 @@ namespace StudioCore.Scene
                     _placeholderProxy.Register();
                 }
             }
-            //
-
         }
 
         public MeshRenderableProxy(MeshRenderableProxy clone) :

--- a/StudioCore/Scene/RenderableProxy.cs
+++ b/StudioCore/Scene/RenderableProxy.cs
@@ -164,6 +164,7 @@ namespace StudioCore.Scene
 
         private ModelMarkerType _placeholderType;
         private RenderableProxy? _placeholderProxy = null;
+        private bool _showPlaceholderProxy;
 
         private int _renderable = -1;
         private int _selectionOutlineRenderable = -1;
@@ -246,8 +247,8 @@ namespace StudioCore.Scene
 
                 if (_placeholderProxy != null)
                 {
-                    if (VisibleModelMarker ||
-                        FeatureFlags.GiveAllRenderablesModelMarkers && true)
+                    if (_showPlaceholderProxy ||
+                        (CFG.Current.Map_ShowModelMarkersForEverything && FeatureFlags.GiveAllRenderablesModelMarkers))
                     {
                         _placeholderProxy.Visible = _visible;
                     }
@@ -355,8 +356,6 @@ namespace StudioCore.Scene
             return b;
         }
 
-        public bool VisibleModelMarker;
-
         public MeshRenderableProxy(
             MeshRenderables renderables,
             MeshProvider provider,
@@ -368,7 +367,7 @@ namespace StudioCore.Scene
             _renderablesSet = renderables;
             _meshProvider = provider;
             _placeholderType = placeholderType;
-            VisibleModelMarker = _placeholderType != ModelMarkerType.None;
+            _showPlaceholderProxy = _placeholderType != ModelMarkerType.None;
             _meshProvider.AddEventListener(this);
             _meshProvider.Acquire();
             if (autoregister)
@@ -764,7 +763,7 @@ namespace StudioCore.Scene
 
         public void OnProviderAvailable()
         {
-            VisibleModelMarker = _placeholderType != ModelMarkerType.None;
+            _showPlaceholderProxy = _placeholderType != ModelMarkerType.None;
             for (int i = 0; i < _meshProvider.ChildCount; i++)
             {
                 var child = new MeshRenderableProxy(_renderablesSet, _meshProvider.GetChildProvider(i),
@@ -786,7 +785,7 @@ namespace StudioCore.Scene
 
                 if (child._meshProvider != null && child._meshProvider.IsAvailable() && child._meshProvider.IndexCount > 0)
                 {
-                    VisibleModelMarker = false;
+                    _showPlaceholderProxy = false;
                 }
             }
 
@@ -795,11 +794,11 @@ namespace StudioCore.Scene
                 ScheduleRenderableConstruction();
                 if (_meshProvider != null && _meshProvider.IndexCount > 0)
                 {
-                    VisibleModelMarker = false;
+                    _showPlaceholderProxy = false;
                 }
             }
 
-            if (!VisibleModelMarker && _placeholderProxy != null)
+            if (!_showPlaceholderProxy && _placeholderProxy != null)
             {
                 _placeholderProxy.Visible = false;
             }


### PR DESCRIPTION
### Known issues:
- Harsher on render system limits since many things will have a new renderable, seemingly nothing adjusted limits settings can't handle though.
- Some model markers aren't appearing for an unknown reason during map load. This is inconsistent and seems to differ from computer to computer (I would bet it's affected by map load speed or something, and that post-map-load "refresh all entity models" isn't behaving as I expected. Needs more research.


### Add default renderable proxy
This is for the purposes of making MSB entities with non-existent model references have a model marker instead of not rendering at all (example: an enemy with model name c6969).

_Feedback on everything in RenderableProxy.cs please! This is one of my classic "well it technically works" goofs!_

### Add setting + hotkey to display model markers for all map entities
Utilizes above system to display model markers for every map entity, in spite of whether they have a renderable model or not.
Useful in several scenarios, including ER speedtree flvers.