### PR TITLE
Make game executable browser file name filter include EBOOT.BIN

### DIFF
--- a/StudioCore/AssetLocator.cs
+++ b/StudioCore/AssetLocator.cs
@@ -75,7 +75,8 @@ namespace StudioCore
     public class AssetLocator
     {
 
-        public static readonly string GameExecutatbleFilter =
+        public static readonly string GameExecutableFilter =
+            "Game Executable (.EXE, EBOOT.BIN) |*.EXE*;*EBOOT.BIN*|" +
             "Windows executable (*.EXE) |*.EXE*|" +
             "Playstation executable (*.BIN) |*.BIN*|" +
             "All Files|*.*";

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -544,7 +544,7 @@ namespace StudioCore
 
                     var rbrowseDlg = new System.Windows.Forms.OpenFileDialog()
                     {
-                        Filter = AssetLocator.GameExecutatbleFilter,
+                        Filter = AssetLocator.GameExecutableFilter,
                         ValidateNames = true,
                         CheckFileExists = true,
                         CheckPathExists = true,
@@ -1097,7 +1097,7 @@ namespace StudioCore
                 ImGui.Text("Game Executable:   ");
                 ImGui.SameLine();
                 Utils.ImGuiGenericHelpPopup("?", "##Help_GameExecutable",
-                    "The location of the game's .EXE file.\nThe folder with the .EXE will be used to obtain unpacked game data.");
+                    "The location of the game's .EXE or EBOOT.BIN file.\nThe folder with the executable will be used to obtain unpacked game data.");
                 ImGui.SameLine();
                 var gname = _newProjectOptions.settings.GameRoot;
                 if (ImGui.InputText("##gdir", ref gname, 255))
@@ -1111,7 +1111,7 @@ namespace StudioCore
                 {
                     var browseDlg = new System.Windows.Forms.OpenFileDialog()
                     {
-                        Filter = AssetLocator.GameExecutatbleFilter,
+                        Filter = AssetLocator.GameExecutableFilter,
                         ValidateNames = true,
                         CheckFileExists = true,
                         CheckPathExists = true,


### PR DESCRIPTION
Makes EBOOT.BIN files visible by default.