### PR TITLE
Fix crash when loading HorseRideOverride

### DIFF
--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PointParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PointParam.cs
@@ -2403,7 +2403,7 @@ namespace SoulsFormats
                 /// <summary>
                 /// OverrideType
                 /// </summary>
-                public enum HorseRideOverrideType : int
+                public enum HorseRideOverrideType : uint
                 {
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
                     PreventRiding = 1,

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PointParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PointParam.cs
@@ -2436,7 +2436,7 @@ namespace SoulsFormats
 
                 private protected override void WriteTypeData(BinaryWriterEx bw)
                 {
-                    bw.WriteInt32((int)OverrideType);
+                    bw.WriteUInt32((uint)OverrideType);
                     bw.WriteInt32(0);
                 }
             }


### PR DESCRIPTION
Introduced in #346, was never in a release.
Caused by SF reading an int enum.

I don't know why SF enum read insists on uint (seems like an oversight?), but it doesn't matter for this enum anyway so that'll be a task for another day.

_(I'm not sure why it didn't cause an issue during initial testing. I remember testing the enums, but I guess I couldn't have! Oops!)_