### PR TITLE
Clean field labels in param editor

### DIFF
--- a/StudioCore/CFG.cs
+++ b/StudioCore/CFG.cs
@@ -230,7 +230,7 @@ namespace StudioCore
 
         // Param settings
         public bool Param_ShowAltNames = true;
-        public bool Param_AlwaysShowOriginalName = true;
+        public bool Param_SecondaryNameInBrackets = false;
         public bool Param_ShowFieldOffsets = false; 
         public bool Param_HideReferenceRows = false;
         public bool Param_HideEnums = false;

--- a/StudioCore/ParamEditor/ParamRowEditor.cs
+++ b/StudioCore/ParamEditor/ParamRowEditor.cs
@@ -656,36 +656,59 @@ namespace StudioCore.ParamEditor
             }
             else
             {
-                string printedName = (AltName != null && CFG.Current.Param_ShowAltNames) ? (CFG.Current.Param_AlwaysShowOriginalName ? $"{internalName} ({AltName})" : AltName) : internalName;
-                ImGui.TextUnformatted(fieldOffset != null && CFG.Current.Param_ShowFieldOffsets ? fieldOffset + " " + printedName : printedName);
+                string printedName = internalName;
+                if (AltName != null)
+                {
+                    if (CFG.Current.Param_ShowAltNames)
+                    {
+                        printedName = AltName;
+                        if (CFG.Current.Param_SecondaryNameInBrackets)
+                            printedName = $"{printedName} ({internalName})";
+                    }
+                    else if (CFG.Current.Param_SecondaryNameInBrackets) {
+                            printedName = $"{printedName} ({AltName})";
+                    }
+                }
+                if (fieldOffset != null && CFG.Current.Param_ShowFieldOffsets)
+                    printedName = $"{fieldOffset} {printedName}";
+
+                ImGui.TextUnformatted(printedName);
             }
         }
 
-        private void PropertyRowNameContextMenu(ParamBank bank, string originalName, FieldMetaData cellMeta, string activeParam, bool showPinOptions, bool isPinned)
+        private void PropertyRowNameContextMenu(ParamBank bank, string internalName, FieldMetaData cellMeta, string activeParam, bool showPinOptions, bool isPinned)
         {
             float scale = ImGuiRenderer.GetUIScale();
+            string altName = cellMeta?.AltName;
+            string shownName = internalName;
 
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(0f, 10f) * scale);
             if (ImGui.BeginPopupContextItem("rowName"))
             {
-                if (CFG.Current.Param_ShowAltNames == true && CFG.Current.Param_AlwaysShowOriginalName == false)
+                if (altName != null)
                 {
-                    ImGui.TextColored(new Vector4(1f, .7f, .4f, 1f), originalName);
+                    if (CFG.Current.Param_ShowAltNames)
+                    {
+                        shownName = altName;
+                        ImGui.TextColored(new Vector4(1f, .7f, .4f, 1f), internalName);
+                    }
+                    else
+                        ImGui.TextColored(new Vector4(1f, .7f, .4f, 1f), altName);
                     ImGui.Separator();
                 }
                 if (ImGui.MenuItem("Add to Searchbar"))
                 {
-                    EditorCommandQueue.AddCommand($@"param/search/prop {originalName.Replace(" ", "\\s")} ");
+                    EditorCommandQueue.AddCommand($@"param/search/prop {internalName.Replace(" ", "\\s")} ");
                 }
-                if (showPinOptions && ImGui.MenuItem((isPinned ? "Unpin " : "Pin " + originalName)))
+                if (showPinOptions && ImGui.MenuItem((isPinned ? "Unpin " : "Pin " + shownName)))
                 {
                     if (!_paramEditor._projectSettings.PinnedFields.ContainsKey(activeParam))
                         _paramEditor._projectSettings.PinnedFields.Add(activeParam, new List<string>());
                     List<string> pinned = _paramEditor._projectSettings.PinnedFields[activeParam];
                     if (isPinned)
-                        pinned.Remove(originalName);
-                    else if (!pinned.Contains(originalName))
-                        pinned.Add(originalName);
+                        pinned.Remove(internalName);
+                    else if (!pinned.Contains(internalName))
+                        pinned.Add(internalName);
                 }
                 if (ParamEditorScreen.EditorMode && cellMeta != null)
                 {

--- a/StudioCore/ParamEditor/ParamRowEditor.cs
+++ b/StudioCore/ParamEditor/ParamRowEditor.cs
@@ -495,7 +495,6 @@ namespace StudioCore.ParamEditor
             ParamEnum Enum = cellMeta?.EnumType;
             string Wiki = cellMeta?.Wiki;
             bool IsBool = cellMeta?.IsBool ?? false;
-            string AltName = cellMeta?.AltName;
 
             object newval = null;
 
@@ -504,7 +503,10 @@ namespace StudioCore.ParamEditor
             if (Wiki != null)
             {
                 if (EditorDecorations.HelpIcon(internalName, ref Wiki, true))
+                {
                     cellMeta.Wiki = Wiki;
+                }
+                ImGui.SameLine();
             }
             else
             {
@@ -644,29 +646,29 @@ namespace StudioCore.ParamEditor
 
         private static void PropertyRowName(string fieldOffset, ref string internalName, FieldMetaData cellMeta)
         {
-            string AltName = cellMeta?.AltName;
+            string altName = cellMeta?.AltName;
             if (cellMeta != null && ParamEditorScreen.EditorMode)
             {
-                string EditName = AltName ?? internalName;
-                ImGui.InputText("##editName", ref EditName, 128);
-                if (EditName.Equals(internalName) || EditName.Equals(""))
+                string editName = !string.IsNullOrWhiteSpace(altName) ? altName : internalName;
+                ImGui.InputText("##editName", ref editName, 128);
+                if (editName.Equals(internalName) || editName.Equals(""))
                     cellMeta.AltName = null;
                 else
-                    cellMeta.AltName = EditName;
+                    cellMeta.AltName = editName;
             }
             else
             {
                 string printedName = internalName;
-                if (AltName != null)
+                if (!string.IsNullOrWhiteSpace(altName))
                 {
                     if (CFG.Current.Param_ShowAltNames)
                     {
-                        printedName = AltName;
+                        printedName = altName;
                         if (CFG.Current.Param_SecondaryNameInBrackets)
                             printedName = $"{printedName} ({internalName})";
                     }
                     else if (CFG.Current.Param_SecondaryNameInBrackets) {
-                            printedName = $"{printedName} ({AltName})";
+                            printedName = $"{printedName} ({altName})";
                     }
                 }
                 if (fieldOffset != null && CFG.Current.Param_ShowFieldOffsets)
@@ -685,7 +687,7 @@ namespace StudioCore.ParamEditor
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(0f, 10f) * scale);
             if (ImGui.BeginPopupContextItem("rowName"))
             {
-                if (altName != null)
+                if (!string.IsNullOrWhiteSpace(altName))
                 {
                     if (CFG.Current.Param_ShowAltNames)
                     {

--- a/StudioCore/SettingsMenu.cs
+++ b/StudioCore/SettingsMenu.cs
@@ -351,8 +351,8 @@ namespace StudioCore
             {
                 ImGui.Indent();
 
-                ImGui.Checkbox("Show alternate field names", ref CFG.Current.Param_ShowAltNames);
-                ImGui.Checkbox("Always show original field names", ref CFG.Current.Param_AlwaysShowOriginalName);
+                ImGui.Checkbox("Show community-sourced field names", ref CFG.Current.Param_ShowAltNames);
+                ImGui.Checkbox("Show secondary field names in brackets", ref CFG.Current.Param_SecondaryNameInBrackets);
                 ImGui.Checkbox("Show field data offsets", ref CFG.Current.Param_ShowFieldOffsets);
                 ImGui.Checkbox("Hide field references", ref CFG.Current.Param_HideReferenceRows);
                 ImGui.Checkbox("Hide field enums", ref CFG.Current.Param_HideEnums);


### PR DESCRIPTION
Will now always show the "secondary" field name in the context menu on right click.

So if it's using the Alt Names, will show the internal name, and vice versa.

The brackets can now be toggled on/off.

Also changed the names of the field name settings in the menu a little.