### PR TITLE
Add options to load related overworld maps, unload all maps. & cleanup

### DIFF
--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -88,6 +88,17 @@ namespace StudioCore
 
         public MapStudioNew()
         {
+            {
+                List<string> str = new();
+                for (var i = 0; i < 59999999; i++)
+                {
+                    str.Add(i.ToString());
+                }
+                str = null;
+            }
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
             CFG.AttemptLoadOrDefault();
 
             if (UseRenderdoc)

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -88,17 +88,6 @@ namespace StudioCore
 
         public MapStudioNew()
         {
-            {
-                List<string> str = new();
-                for (var i = 0; i < 59999999; i++)
-                {
-                    str.Add(i.ToString());
-                }
-                str = null;
-            }
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
             CFG.AttemptLoadOrDefault();
 
             if (UseRenderdoc)

--- a/StudioCore/MsbEditor/MsbEditorScreen.cs
+++ b/StudioCore/MsbEditor/MsbEditorScreen.cs
@@ -1067,7 +1067,6 @@ namespace StudioCore.MsbEditor
         public void ReloadUniverse()
         {
             Universe.UnloadAllMaps();
-            GC.Collect();
             Universe.PopulateMapList();
 
             if (AssetLocator.Type != GameType.Undefined)

--- a/StudioCore/MsbEditor/MsbEditorScreen.cs
+++ b/StudioCore/MsbEditor/MsbEditorScreen.cs
@@ -1067,6 +1067,9 @@ namespace StudioCore.MsbEditor
         public void ReloadUniverse()
         {
             Universe.UnloadAllMaps();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
             Universe.PopulateMapList();
 
             if (AssetLocator.Type != GameType.Undefined)

--- a/StudioCore/MsbEditor/SceneTree.cs
+++ b/StudioCore/MsbEditor/SceneTree.cs
@@ -749,6 +749,9 @@ namespace StudioCore.MsbEditor
                                 _selection.ClearSelection();
                                 _editorActionManager.Clear();
                                 _universe.UnloadContainer(m);
+                                GC.Collect();
+                                GC.WaitForPendingFinalizers();
+                                GC.Collect();
                             }
                         }
                         if (_universe.GetLoadedMapCount() > 1)
@@ -761,6 +764,9 @@ namespace StudioCore.MsbEditor
                                     _selection.ClearSelection();
                                     _editorActionManager.Clear();
                                     _universe.UnloadAllMaps();
+                                    GC.Collect();
+                                    GC.WaitForPendingFinalizers();
+                                    GC.Collect();
                                 }
                             }
                         }

--- a/StudioCore/MsbEditor/SpecialMapConnections.cs
+++ b/StudioCore/MsbEditor/SpecialMapConnections.cs
@@ -76,8 +76,9 @@ namespace StudioCore.MsbEditor
             GameType gameType,
             string mapid,
             IReadOnlyCollection<string> allMapIds,
-            List<byte[]> connectColMaps)
+            List<byte[]> connectColMaps = null)
         {
+            connectColMaps ??= new List<byte[]>();
             SortedDictionary<string, RelationType> relations = new SortedDictionary<string, RelationType>();
             if (!TryParseMap(mapid, out byte[] parts))
             {

--- a/StudioCore/MsbEditor/Universe.cs
+++ b/StudioCore/MsbEditor/Universe.cs
@@ -1449,7 +1449,7 @@ namespace StudioCore.MsbEditor
             {
                 if (un is Map ma)
                 {
-                    UnloadContainer(ma, false);
+                    UnloadContainer(ma);
                 }
             }
         }

--- a/StudioCore/MsbEditor/Universe.cs
+++ b/StudioCore/MsbEditor/Universe.cs
@@ -933,10 +933,6 @@ namespace StudioCore.MsbEditor
                 LoadMapExceptions = System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(e);
 #endif
             }
-
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
         }
 
         public static void CheckDupeEntityIDs(Map map)
@@ -1419,7 +1415,7 @@ namespace StudioCore.MsbEditor
             }
         }
 
-        public void UnloadContainer(ObjectContainer container, bool clearFromList = false, bool collectGarbage = true)
+        public void UnloadContainer(ObjectContainer container, bool clearFromList = false)
         {
             if (LoadedObjectContainers.ContainsKey(container.Name))
             {
@@ -1436,35 +1432,26 @@ namespace StudioCore.MsbEditor
                 {
                     LoadedObjectContainers.Remove(container.Name);
                 }
-                if (collectGarbage)
-                {
-                    GC.Collect();
-                }
             }
         }
 
         public void UnloadAllMaps()
         {
+            List<ObjectContainer> toUnload = new List<ObjectContainer>();
+            foreach (var key in LoadedObjectContainers.Keys)
             {
-                List<ObjectContainer> toUnload = new List<ObjectContainer>();
-                foreach (var key in LoadedObjectContainers.Keys)
+                if (LoadedObjectContainers[key] != null)
                 {
-                    if (LoadedObjectContainers[key] != null)
-                    {
-                        toUnload.Add(LoadedObjectContainers[key]);
-                    }
-                }
-                foreach (var un in toUnload)
-                {
-                    if (un is Map ma)
-                    {
-                        UnloadContainer(ma, false, false);
-                    }
+                    toUnload.Add(LoadedObjectContainers[key]);
                 }
             }
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+            foreach (var un in toUnload)
+            {
+                if (un is Map ma)
+                {
+                    UnloadContainer(ma, false);
+                }
+            }
         }
 
         public void UnloadAll(bool clearFromList = false)


### PR DESCRIPTION
Adds option to load all maps directly related to an overworld tile map.
Example: for _02 maps, it will load all overlaid _01 and _00 maps. _00 maps will load its related _01 and _02 maps.

Adds an option to unload all currently loaded maps (+ confirmation).