### PR TITLE
Fix readme for 7.0 .NET requirements. Move requirements upwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ A: Likely not. Rendering the entirety of the maps for DS3, Bloodborne, and Sekir
 * Windows 7/8/8.1/10/11 (64-bit only)
 * Visual C++ Redistributable x64 - INSTALL THIS IF THE PROGRAM CRASHES ON STARTUP (https://aka.ms/vs/16/release/vc_redist.x64.exe)
 * For the error message "You must install or update .NET to run this application", use these exact download links. It is not enough to install the default .NET runtime.
-  * Microsoft .NET Core 6.0 **Desktop** Runtime (https://aka.ms/dotnet/6.0/windowsdesktop-runtime-win-x64.exe)
-  * (if Windows not updated) Microsoft .NET Core 6.0 ASP.NET Core Runtime (https://aka.ms/dotnet/6.0/aspnetcore-runtime-win-x64.exe)
+  * Microsoft .NET Core 7.0 **Desktop** Runtime (https://aka.ms/dotnet/6.0/windowsdesktop-runtime-win-x64.exe)
+  * Microsoft .NET Core 7.0 ASP.NET Core Runtime (https://aka.ms/dotnet/6.0/aspnetcore-runtime-win-x64.exe)
 * **A Vulkan Compatible Graphics Device with support for descriptor indexing**, even if you're just modding DS1: PTDE
 * Intel GPUs currently don't seem to be working properly. At the moment, you will probably need a somewhat recent (2014+) NVIDIA or AMD GPU
 * A 4GB (8GB recommended) graphics card if modding DS3/BB/Sekiro/ER maps due to huge map sizes

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@ DS Map Studio is a standalone integrated modding tool for modern FromSoft games,
 
 ![msb-editor-screenshot](https://user-images.githubusercontent.com/44953920/209740902-ab75c7fb-e281-4833-aeab-4c2ea41da815.png)
 
+## Requirements
+* Windows 7/8/8.1/10/11 (64-bit only)
+* Visual C++ Redistributable x64 - INSTALL THIS IF THE PROGRAM CRASHES ON STARTUP (https://aka.ms/vs/16/release/vc_redist.x64.exe)
+* For the error message "You must install or update .NET to run this application", use these exact download links. It is not enough to install the default .NET runtime.
+  * Microsoft .NET Core 7.0 **Desktop** Runtime (https://aka.ms/dotnet/7.0/windowsdesktop-runtime-win-x64.exe)
+  * Microsoft .NET Core 7.0 ASP.NET Core Runtime (https://aka.ms/dotnet/7.0/aspnetcore-runtime-win-x64.exe)
+* **A Vulkan Compatible Graphics Device with support for descriptor indexing**, even if you're just modding DS1: PTDE
+* Intel GPUs currently don't seem to be working properly. At the moment, you will probably need a somewhat recent (2014+) NVIDIA or AMD GPU
+* A 4GB (8GB recommended) graphics card if modding DS3/BB/Sekiro/ER maps due to huge map sizes
+
 ## Basic usage instructions
 ### Game instructions
 * **Dark Souls Prepare to die Edition**: Game must be unpacked with UDSFM before usage with Map Studio (https://www.nexusmods.com/darksouls/mods/1304).
@@ -34,17 +44,7 @@ A: That's the goal, but asset pipeline work is still needed to get there. I'm cu
 ### Q: Why are graphics requirements so steep? Will you ever support DX11 again?
 A: Likely not. Rendering the entirety of the maps for DS3, Bloodborne, and Sekiro are quite challenging. In game they have techniques to limit draw calls, but in the editor context sometimes literally every mesh in the map may end up rendered. I thus use some modern Vulkan features to be able to batch and issue 10's of thousands of draw calls per frame, which unfortunately makes my renderer architecture incompatible with DX11.
 
-## System Requirements:
-* Windows 7/8/8.1/10/11 (64-bit only)
-* Visual C++ Redistributable x64 - INSTALL THIS IF THE PROGRAM CRASHES ON STARTUP (https://aka.ms/vs/16/release/vc_redist.x64.exe)
-* For the error message "You must install or update .NET to run this application", use these exact download links. It is not enough to install the default .NET runtime.
-  * Microsoft .NET Core 7.0 **Desktop** Runtime (https://aka.ms/dotnet/6.0/windowsdesktop-runtime-win-x64.exe)
-  * Microsoft .NET Core 7.0 ASP.NET Core Runtime (https://aka.ms/dotnet/6.0/aspnetcore-runtime-win-x64.exe)
-* **A Vulkan Compatible Graphics Device with support for descriptor indexing**, even if you're just modding DS1: PTDE
-* Intel GPUs currently don't seem to be working properly. At the moment, you will probably need a somewhat recent (2014+) NVIDIA or AMD GPU
-* A 4GB (8GB recommended) graphics card if modding DS3/BB/Sekiro/ER maps due to huge map sizes
-
-## Credits:
+## Credits
 * Katalash - primary author
 * philiquaz - major contributor to integrated param editor
 * george - stable boy


### PR DESCRIPTION
Fixes readme since we require 7.0 now.
Moves requirements closer to the top of the list, in the hopes that more people will see it.