### PR TITLE
Change to mergeable & conflicts searches

### DIFF
--- a/StudioCore/ParamEditor/SearchEngine.cs
+++ b/StudioCore/ParamEditor/SearchEngine.cs
@@ -206,16 +206,16 @@ namespace StudioCore.Editor
                 string paramName = context.Item1.GetKeyForParam(context.Item2);
                 if (paramName == null)
                     return (row) => true;
-                HashSet<int> cache = context.Item1.GetVanillaDiffRows(paramName);
+                HashSet<int> pCache = ParamBank.PrimaryBank.GetVanillaDiffRows(paramName);
                 var auxCaches = ParamBank.AuxBanks.Select(x=>(x.Value.GetPrimaryDiffRows(paramName), x.Value.GetVanillaDiffRows(paramName))).ToList();
-                return (row) => !cache.Contains(row.ID) && auxCaches.Where((x) => x.Item2.Contains(row.ID) && x.Item1.Contains(row.ID)).Count() > 0;
+                return (row) => !pCache.Contains(row.ID) && auxCaches.Where((x) => x.Item2.Contains(row.ID) && x.Item1.Contains(row.ID)).Count() == 1;
                 }
             )));
             filterList.Add("conflicts", (new string[0], noArgs((context)=>{
                 string paramName = context.Item1.GetKeyForParam(context.Item2);
-                HashSet<int> cache = context.Item1.GetVanillaDiffRows(paramName);
+                HashSet<int> pCache = ParamBank.PrimaryBank.GetVanillaDiffRows(paramName);
                 var auxCaches = ParamBank.AuxBanks.Select(x=>(x.Value.GetPrimaryDiffRows(paramName), x.Value.GetVanillaDiffRows(paramName))).ToList();
-                return (row)=>cache.Contains(row.ID) && auxCaches.Where((x) => x.Item2.Contains(row.ID) && x.Item1.Contains(row.ID)).Count() > 0;
+                return (row) => (pCache.Contains(row.ID)?1:0) + auxCaches.Where((x) => x.Item2.Contains(row.ID) && x.Item1.Contains(row.ID)).Count() > 1;
                 }
             )));
             filterList.Add("id", (new string[]{"row id (regex)"}, (args, lenient)=>{


### PR DESCRIPTION
Makes mergeable and conflicts searches more accurate when multiple auxparams involved and when searched from auxparam.

Prior behaviour is that for a primary bank row, it is classed mergeable when unmodified and there is any number of modifications in aux banks.
New behaviour is that for a primary bank row, it is classed mergeable when unmodified and there is only one modification in aux banks.
Prior behaviour is that for an aux bank row, is it classed mergeable when unmodified and there is any number of modifications in aux banks (including itself)
New behaviour is that for an aux bank row, it is classed mergeable when the primary bank is unmodified and there is only one modification in aux banks (presumed itself. While this may appear to cause issues for someone aiming to place these rows into the primary bank, the primary bank will remain unmodified until the modified bank is merged, at which point subsequent operations will no longer mark it mergeable.)

Prior behaviour is that for a primary bank row, it is classed conflicting when modified and there is any number of modifications in aux banks.
New behaviour is that for a primary bank row, it is classed conflicting when there is more than 1 modification to the row among primary bank and aux banks.
Prior behaviour is that for an aux bank row, it is classed conflicting when modified and there is any number of modifications in aux banks (including itself)
New behaviour is that for an aux bank row, it is classed conflicting when there is more than 1 modification to the row among primary bank and aux banks (including itself).

This change in behaviour has no effect for the primary bank with 1 aux bank comparisons.

It does however improve search reliability when filtering an auxbank, as it could previously conflict with itself, as well as ignore the primary bank. In the case of multiple auxbanks, it also prevents rows being marked mergeable when there are mutual edits outside of the primary bank.