### PR TITLE
Disambiguate fields of duplicate names in propertyeditor

### DIFF
--- a/StudioCore/ParamEditor/ParamUtils.cs
+++ b/StudioCore/ParamEditor/ParamUtils.cs
@@ -85,7 +85,7 @@ namespace StudioCore.ParamEditor
 
         public static (PseudoColumn, Param.Column) GetAs(this (PseudoColumn, Param.Column) col, Param newParam)
         {
-            return (col.Item1, col.Item2 == null || newParam == null ? null : newParam.Cells.FirstOrDefault((x) => x.Def.InternalName == col.Item2.Def.InternalName));
+            return (col.Item1, col.Item2 == null || newParam == null ? null : newParam.Cells.FirstOrDefault((x) => x.Def.InternalName == col.Item2.Def.InternalName && x.GetByteOffset() == col.Item2.GetByteOffset()));
         }
         public static bool IsColumnValid(this (PseudoColumn, Param.Column) col)
         {


### PR DESCRIPTION
It would be nice to also fix sekiro's defs (networkparam) but I can't guarantee those aren't authentic.