### PR TITLE
Ds2 map offset fix. & forbid DS2 map load before param load

### DIFF
--- a/StudioCore/MsbEditor/ObjectContainer.cs
+++ b/StudioCore/MsbEditor/ObjectContainer.cs
@@ -803,14 +803,15 @@ namespace StudioCore.MsbEditor
                     var loc = mp.GetRow("generator-loc");
                     if (loc != null)
                     {
-                        // Adjust the location to be relative to the mapoffset
+                        
+                        // Set param positions
                         var newloc = new Param.Row(loc, locations);
                         newloc.GetCellHandleOrThrow("PositionX").SetValue(
-                            (float)loc.GetCellHandleOrThrow("PositionX").Value - MapOffset.Position.X);
+                            (float)loc.GetCellHandleOrThrow("PositionX").Value);
                         newloc.GetCellHandleOrThrow("PositionY").SetValue( 
-                            (float)loc.GetCellHandleOrThrow("PositionY").Value - MapOffset.Position.Y);
+                            (float)loc.GetCellHandleOrThrow("PositionY").Value);
                         newloc.GetCellHandleOrThrow("PositionZ").SetValue( 
-                            (float)loc.GetCellHandleOrThrow("PositionZ").Value - MapOffset.Position.Z);
+                            (float)loc.GetCellHandleOrThrow("PositionZ").Value);
                         locations.AddRow(newloc);
                     }
                     var gen = mp.GetRow("generator");
@@ -885,15 +886,15 @@ namespace StudioCore.MsbEditor
                         MessageBox.Show($@"{mp.Name} has an ID that's already used. Please change it to something unique and save again.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         return false;
                     }
-
-                    // Adjust the location to be relative to the mapoffset
+                    
+                    // Set param location positions
                     var newloc = new Param.Row(mp, locs);
                     newloc.GetCellHandleOrThrow("PositionX").SetValue(
-                        (float)mp.GetCellHandleOrThrow("PositionX").Value - MapOffset.Position.X);
+                        (float)mp.GetCellHandleOrThrow("PositionX").Value);
                     newloc.GetCellHandleOrThrow("PositionY").SetValue( 
-                        (float)mp.GetCellHandleOrThrow("PositionY").Value - MapOffset.Position.Y);
+                        (float)mp.GetCellHandleOrThrow("PositionY").Value);
                     newloc.GetCellHandleOrThrow("PositionZ").SetValue( 
-                        (float)mp.GetCellHandleOrThrow("PositionZ").Value - MapOffset.Position.Z);
+                        (float)mp.GetCellHandleOrThrow("PositionZ").Value);
                     locs.AddRow(newloc);
                 }
             }

--- a/StudioCore/MsbEditor/SceneTree.cs
+++ b/StudioCore/MsbEditor/SceneTree.cs
@@ -612,6 +612,19 @@ namespace StudioCore.MsbEditor
                 ImGui.PopStyleVar();
                 if (_configuration == Configuration.MapEditor)
                 {
+
+                    if (_assetLocator.Type is GameType.DarkSoulsIISOTFS)
+                    {
+                        if (ParamEditor.ParamBank.PrimaryBank.IsLoadingParams)
+                        {
+                            ImGui.NewLine();
+                            ImGui.Text("  Please wait for params to finish loading.");
+                            ImGui.End();
+                            ImGui.PopStyleColor();
+                            return;
+                        }
+                    }
+
                     ImGui.Spacing();
                     ImGui.Indent(30 * scale);
                     ImGui.AlignTextToFramePadding();

--- a/StudioCore/MsbEditor/Universe.cs
+++ b/StudioCore/MsbEditor/Universe.cs
@@ -397,13 +397,6 @@ namespace StudioCore.MsbEditor
                     row.Name = "generator_" + row.ID.ToString();
                 }
 
-                // Offset the generators by the map offset
-                row.GetCellHandleOrThrow("PositionX").SetValue(
-                    (float)row.GetCellHandleOrThrow("PositionX").Value + map.MapOffset.Position.X);
-                row.GetCellHandleOrThrow("PositionY").SetValue(
-                    (float)row.GetCellHandleOrThrow("PositionY").Value + map.MapOffset.Position.Y);
-                row.GetCellHandleOrThrow("PositionZ").SetValue(
-                    (float)row.GetCellHandleOrThrow("PositionZ").Value + map.MapOffset.Position.Z);
                 
                 var mergedRow = new MergedParamRow();
                 mergedRow.AddRow("generator-loc", row);
@@ -412,6 +405,7 @@ namespace StudioCore.MsbEditor
                 var obj = new MapEntity(map, mergedRow, MapEntity.MapEntityType.DS2Generator);
                 generatorObjs.Add(row.ID, obj);
                 map.AddObject(obj);
+                map.MapOffsetNode.AddChild(obj);
             }
 
             var chrsToLoad = new HashSet<AssetDescription>();
@@ -477,17 +471,10 @@ namespace StudioCore.MsbEditor
                     row.Name = "eventloc_" + row.ID.ToString();
                 }
                 eventLocationParams.Add(row.ID, row);
-
-                // Offset the generators by the map offset
-                row.GetCellHandleOrThrow("PositionX").SetValue(
-                    (float)row.GetCellHandleOrThrow("PositionX").Value + map.MapOffset.Position.X);
-                row.GetCellHandleOrThrow("PositionY").SetValue(
-                    (float)row.GetCellHandleOrThrow("PositionY").Value + map.MapOffset.Position.Y);
-                row.GetCellHandleOrThrow("PositionZ").SetValue(
-                    (float)row.GetCellHandleOrThrow("PositionZ").Value + map.MapOffset.Position.Z);
-
+                
                 var obj = new MapEntity(map, row, MapEntity.MapEntityType.DS2EventLocation);
                 map.AddObject(obj);
+                map.MapOffsetNode.AddChild(obj);
 
                 // Try rendering as a box for now
                 var mesh = DebugPrimitiveRenderableProxy.GetBoxRegionProxy(_renderScene);


### PR DESCRIPTION
Properly hooks up DS2 generator locations to MapOffsetNode, which also fixes locations being too offset on successive map loads.

Prevents user trying to load DS2 maps before params are fully loaded, fixing a potential crash.