### PR TITLE
Override param meta enum keys instead of crashing

### DIFF
--- a/StudioCore/ParamEditor/ParamMeta.cs
+++ b/StudioCore/ParamEditor/ParamMeta.cs
@@ -479,7 +479,7 @@ namespace StudioCore.ParamEditor
             name = enumNode.Attributes["Name"].InnerText;
             foreach (XmlNode option in enumNode.SelectNodes("Option"))
             {
-                values.Add(option.Attributes["Value"].InnerText, option.Attributes["Name"].InnerText);
+                values[option.Attributes["Value"].InnerText] = option.Attributes["Name"].InnerText;
             }
         }
     }


### PR DESCRIPTION
At a minimum, fixes crash introduced in #448.
