### PR TITLE
Add "advanced" tab to new project menu for more user control

### DIFF
--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -1186,7 +1186,7 @@ namespace StudioCore
                 {
                     _standardProjectUIOpened = false;
                 }
-
+                
                 if (ImGui.BeginTabItem("Standalone"))
                 {
                     NewProject_NameGUI();
@@ -1212,7 +1212,7 @@ namespace StudioCore
                     NewProject_GameTypeComboGUI();
                     ImGui.EndTabItem();
                 }
-
+                
                 if (ImGui.BeginTabItem("Advanced"))
                 {
                     NewProject_NameGUI();
@@ -1331,7 +1331,7 @@ namespace StudioCore
                         if (message == DialogResult.No)
                             validated = false;
                     }
-                    if (validated && (Path.GetDirectoryName(_newProjectOptions.settings.GameRoot)).Equals(_newProjectOptions.directory))
+                    if (validated && _newProjectOptions.settings.GameRoot == _newProjectOptions.directory)
                     {
                         var message = System.Windows.Forms.MessageBox.Show(
                             "Project Directory is the same as Game Directory, which allows game files to be overwritten directly.\n\n" +
@@ -1377,12 +1377,12 @@ namespace StudioCore
                 ImGui.SameLine();
                 Utils.ImGuiGenericHelpPopup("Help", "##Help_NewProject",
                     "Projects determine where DSMapStudio will obtain game data, and where modified data will be saved.\n" +
-                    "  There are two types of projects:\n\n" +
+                    "  There are two basic project configurations:\n\n" +
                     "Standard projects (recommended)\n" +
-                    "  Obtains data from the game folder for modding & vanilla reference. Saves modified data to the project folder.\n" +
+                    "  Obtains unpacked game files from the game folder, and saves modified files to the project folder.\n" +
                     "  Using this with Mod Engine is recommended, or with two copies of the game: one vanilla, one modified.\n\n" +
                     "Standalone projects\n" +
-                    "  Obtains and modify files within the project folder, directly overwriting game files with modded files."
+                    "  Obtains and modify files within a single project folder, directly overwriting files."
                     );
 
                 ImGui.EndPopup();

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -681,6 +681,21 @@ namespace StudioCore
             }
         }
 
+        private void NewProjectNameUI()
+        {
+            ImGui.AlignTextToFramePadding();
+            ImGui.Text("Project Name:      ");
+            ImGui.SameLine();
+            Utils.ImGuiGenericHelpPopup("?", "##Help_ProjectName",
+                "Project's display name. Only affects visuals within DSMS.");
+            ImGui.SameLine();
+            var pname = _newProjectOptions.settings.ProjectName;
+            if (ImGui.InputText("##pname", ref pname, 255))
+            {
+                _newProjectOptions.settings.ProjectName = pname;
+            }
+        }
+
         private void Update(float deltaseconds)
         {
             var ctx = Tracy.TracyCZoneN(1, "Imgui");
@@ -1075,75 +1090,109 @@ namespace StudioCore
             }
             if (ImGui.BeginPopupModal("New Project", ref open, ImGuiWindowFlags.AlwaysAutoResize))
             {
-                ImGui.AlignTextToFramePadding();
-                ImGui.Text("Project Name:      ");
-                ImGui.SameLine();
-                Utils.ImGuiGenericHelpPopup("?", "##Help_ProjectName",
-                    "Project's display name. Only affects visuals within DSMS.");
-                ImGui.SameLine();
-                var pname = _newProjectOptions.settings.ProjectName;
-                if (ImGui.InputText("##pname", ref pname, 255))
+                //
+                ImGui.BeginTabBar("NewProjectTabBar");
+                if (ImGui.BeginTabItem("Standard"))
                 {
-                    _newProjectOptions.settings.ProjectName = pname;
-                }
+                    if (_newProjectOptions.settings.GameRoot == "")
+                        _newProjectOptions.settings.GameType = GameType.Undefined;
 
-                ImGui.AlignTextToFramePadding();
-                ImGui.Text("Project Directory: ");
-                ImGui.SameLine();
-                Utils.ImGuiGenericHelpPopup("?", "##Help_ProjectDirectory",
-                    "The location mod files will be saved.\nTypically, this should be Mod Engine's Mod folder.");
-                ImGui.SameLine();
-                ImGui.InputText("##pdir", ref _newProjectOptions.directory, 255);
-                ImGui.SameLine();
-                if (ImGui.Button($@"{ForkAwesome.FileO}"))
-                {
-                    var browseDlg = new System.Windows.Forms.FolderBrowserDialog();
-
-                    if (browseDlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                    NewProjectNameUI();
+                    ImGui.AlignTextToFramePadding();
+                    ImGui.Text("Project Directory: ");
+                    ImGui.SameLine();
+                    Utils.ImGuiGenericHelpPopup("?", "##Help_ProjectDirectory",
+                        "The location mod files will be saved.\nTypically, this should be Mod Engine's Mod folder.");
+                    ImGui.SameLine();
+                    ImGui.InputText("##pdir", ref _newProjectOptions.directory, 255);
+                    ImGui.SameLine();
+                    if (ImGui.Button($@"{ForkAwesome.FileO}"))
                     {
-                        _newProjectOptions.directory = browseDlg.SelectedPath;
+                        var browseDlg = new System.Windows.Forms.FolderBrowserDialog();
+
+                        if (browseDlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                        {
+                            _newProjectOptions.directory = browseDlg.SelectedPath;
+                        }
                     }
-                }
 
-                ImGui.AlignTextToFramePadding();
-                ImGui.Text("Game Executable:   ");
-                ImGui.SameLine();
-                Utils.ImGuiGenericHelpPopup("?", "##Help_GameExecutable",
-                    "The location of the game's .EXE or EBOOT.BIN file.\nThe folder with the executable will be used to obtain unpacked game data.");
-                ImGui.SameLine();
-                var gname = _newProjectOptions.settings.GameRoot;
-                if (ImGui.InputText("##gdir", ref gname, 255))
-                {
-                    _newProjectOptions.settings.GameRoot = gname;
-                    _newProjectOptions.settings.GameType = _assetLocator.GetGameTypeForExePath(_newProjectOptions.settings.GameRoot);
-                }
-                ImGui.SameLine();
-                ImGui.PushID("fd2");
-                if (ImGui.Button($@"{ForkAwesome.FileO}"))
-                {
-                    var browseDlg = new System.Windows.Forms.OpenFileDialog()
+                    ImGui.AlignTextToFramePadding();
+                    ImGui.Text("Game Executable:   ");
+                    ImGui.SameLine();
+                    Utils.ImGuiGenericHelpPopup("?", "##Help_GameExecutable",
+                        "The location of the game's .EXE or EBOOT.BIN file.\nThe folder with the executable will be used to obtain unpacked game data.");
+                    ImGui.SameLine();
+                    var gname = _newProjectOptions.settings.GameRoot;
+                    if (ImGui.InputText("##gdir", ref gname, 255))
                     {
-                        Filter = AssetLocator.GameExecutableFilter,
-                        ValidateNames = true,
-                        CheckFileExists = true,
-                        CheckPathExists = true,
-                        //ShowReadOnly = true,
-                    };
-
-                    if (browseDlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
-                    {
-                        _newProjectOptions.settings.GameRoot = browseDlg.FileName;
+                        _newProjectOptions.settings.GameRoot = gname;
                         _newProjectOptions.settings.GameType = _assetLocator.GetGameTypeForExePath(_newProjectOptions.settings.GameRoot);
                     }
-                }
-                ImGui.PopID();
-                ImGui.Text($@"Detected Game:      {_newProjectOptions.settings.GameType.ToString()}");
+                    ImGui.SameLine();
+                    ImGui.PushID("fd2");
+                    if (ImGui.Button($@"{ForkAwesome.FileO}"))
+                    {
+                        var browseDlg = new System.Windows.Forms.OpenFileDialog()
+                        {
+                            Filter = AssetLocator.GameExecutableFilter,
+                            ValidateNames = true,
+                            CheckFileExists = true,
+                            CheckPathExists = true,
+                            //ShowReadOnly = true,
+                        };
 
-                ImGui.NewLine();
+                        if (browseDlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                        {
+                            _newProjectOptions.settings.GameRoot = browseDlg.FileName;
+                            _newProjectOptions.settings.GameType = _assetLocator.GetGameTypeForExePath(_newProjectOptions.settings.GameRoot);
+                        }
+                    }
+                    ImGui.PopID();
+                    ImGui.Text($@"Detected Game:      {_newProjectOptions.settings.GameType.ToString()}");
+
+                    ImGui.EndTabItem();
+                }
+
+                if (ImGui.BeginTabItem("Standalone"))
+                {
+                    NewProjectNameUI();
+                    ImGui.AlignTextToFramePadding();
+                    ImGui.Text("Project Directory: ");
+                    ImGui.SameLine();
+                    Utils.ImGuiGenericHelpPopup("?", "##Help_ProjectDirectory",
+                        "The location mod files will be saved.\nTypically, this should be Mod Engine's Mod folder.");
+                    ImGui.SameLine();
+                    ImGui.InputText("##pdir", ref _newProjectOptions.directory, 255);
+                    ImGui.SameLine();
+                    if (ImGui.Button($@"{ForkAwesome.FileO}"))
+                    {
+                        var browseDlg = new System.Windows.Forms.FolderBrowserDialog();
+
+                        if (browseDlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                        {
+                            _newProjectOptions.settings.GameRoot = browseDlg.SelectedPath;
+                            _newProjectOptions.directory = browseDlg.SelectedPath;
+                        }
+                    }
+
+                    ImGui.AlignTextToFramePadding();
+                    ImGui.Text($@"Game Type:         ");
+                    ImGui.SameLine();
+                    string[] games = Enum.GetNames(typeof(GameType));
+                    int gameIndex = Array.IndexOf(games, _newProjectOptions.settings.GameType.ToString());
+                    if (ImGui.Combo("##GameTypeCombo", ref gameIndex, games, games.Length))
+                    {
+                        _newProjectOptions.settings.GameType = Enum.Parse<GameType>(games[gameIndex]);
+                    }
+                    ImGui.EndTabItem();
+                }
+                ImGui.EndTabBar();
+                //
+
                 ImGui.Separator();
-                ImGui.NewLine();
                 if (_newProjectOptions.settings.GameType is GameType.DarkSoulsIISOTFS or GameType.DarkSoulsIII)
                 {
+                    ImGui.NewLine();
                     ImGui.AlignTextToFramePadding();
                     ImGui.Text($@"Loose Params:      ");
                     ImGui.SameLine();
@@ -1157,10 +1206,10 @@ namespace StudioCore
                     {
                         _newProjectOptions.settings.UseLooseParams = looseparams;
                     }
-                    ImGui.NewLine();
                 }
                 else if (FeatureFlags.EnablePartialParam && _newProjectOptions.settings.GameType == GameType.EldenRing)
                 {
+                    ImGui.NewLine();
                     ImGui.AlignTextToFramePadding();
                     ImGui.Text($@"Save partial regulation:  ");
                     ImGui.SameLine();
@@ -1174,8 +1223,9 @@ namespace StudioCore
                     }
                     ImGui.SameLine();
                     ImGui.TextUnformatted("Warning: partial params require merging before use in game.\nRow names on unchanged rows will be forgotten between saves");
-                    ImGui.NewLine();
                 }
+                ImGui.NewLine();
+
                 ImGui.AlignTextToFramePadding();
                 ImGui.Text($@"Import row names:  ");
                 ImGui.SameLine();
@@ -1184,14 +1234,15 @@ namespace StudioCore
                 ImGui.SameLine();
                 ImGui.Checkbox("##loadDefaultNames", ref _newProjectOptions.loadDefaultNames);
                 if (_newProjectOptions.settings.UseLooseParams == false
-                    && _newProjectOptions.loadDefaultNames == true 
+                    && _newProjectOptions.loadDefaultNames == true
                     && _newProjectOptions.settings.GameType == GameType.DarkSoulsIISOTFS)
                 {
-                    ImGui.NewLine();
                     ImGui.TextColored(new Vector4(1.0f, 0.4f, 0.4f, 1.0f), "Warning: Saving row names onto non-loose params will crash the game. It is highly recommended you use loose params with Dark Souls 2.");
                 }
                 ImGui.NewLine();
 
+                if (_newProjectOptions.settings.GameType == GameType.Undefined)
+                    ImGui.BeginDisabled();
                 if (ImGui.Button("Create", new Vector2(120, 0) * scale))
                 {
                     bool validated = true;
@@ -1262,11 +1313,25 @@ namespace StudioCore
                         ImGui.CloseCurrentPopup();
                     }
                 }
+                if (_newProjectOptions.settings.GameType == GameType.Undefined)
+                    ImGui.EndDisabled();
+
                 ImGui.SameLine();
                 if (ImGui.Button("Cancel", new Vector2(120, 0) * scale))
                 {
                     ImGui.CloseCurrentPopup();
                 }
+                ImGui.SameLine();
+                Utils.ImGuiGenericHelpPopup("Help", "##Help_NewProject",
+                    "Projects determine where DSMapStudio will obtain game data, and where modified data will be saved.\n" +
+                    "  There are two types of projects:\n\n" +
+                    "Standard projects (recommended)\n" +
+                    "  Obtains data from the game folder when needed or for reference. Saves modified data to the project folder.\n" +
+                    "  Using this with Mod Engine is recommended, or with two copies of the game: one vanilla, one modified.\n\n" +
+                    "Standalone projects\n" +
+                    "  Obtains and modify files within the project folder."
+                    );
+
                 ImGui.EndPopup();
             }
             ImGui.PopStyleVar(3);

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -718,6 +718,19 @@ namespace StudioCore
             }
         }
 
+        private void NewProject_GameTypeComboGUI()
+        {
+            ImGui.AlignTextToFramePadding();
+            ImGui.Text($@"Game Type:         ");
+            ImGui.SameLine();
+            string[] games = Enum.GetNames(typeof(GameType));
+            int gameIndex = Array.IndexOf(games, _newProjectOptions.settings.GameType.ToString());
+            if (ImGui.Combo("##GameTypeCombo", ref gameIndex, games, games.Length))
+            {
+                _newProjectOptions.settings.GameType = Enum.Parse<GameType>(games[gameIndex]);
+            }
+        }
+
         private void Update(float deltaseconds)
         {
             var ctx = Tracy.TracyCZoneN(1, "Imgui");
@@ -1196,15 +1209,7 @@ namespace StudioCore
                         }
                     }
 
-                    ImGui.AlignTextToFramePadding();
-                    ImGui.Text($@"Game Type:         ");
-                    ImGui.SameLine();
-                    string[] games = Enum.GetNames(typeof(GameType));
-                    int gameIndex = Array.IndexOf(games, _newProjectOptions.settings.GameType.ToString());
-                    if (ImGui.Combo("##GameTypeCombo", ref gameIndex, games, games.Length))
-                    {
-                        _newProjectOptions.settings.GameType = Enum.Parse<GameType>(games[gameIndex]);
-                    }
+                    NewProject_GameTypeComboGUI();
                     ImGui.EndTabItem();
                 }
 
@@ -1234,16 +1239,7 @@ namespace StudioCore
                             _newProjectOptions.settings.GameRoot = browseDlg.SelectedPath;
                         }
                     }
-
-                    ImGui.AlignTextToFramePadding();
-                    ImGui.Text($@"Game Type:         ");
-                    ImGui.SameLine();
-                    string[] games = Enum.GetNames(typeof(GameType));
-                    int gameIndex = Array.IndexOf(games, _newProjectOptions.settings.GameType.ToString());
-                    if (ImGui.Combo("##GameTypeCombo", ref gameIndex, games, games.Length))
-                    {
-                        _newProjectOptions.settings.GameType = Enum.Parse<GameType>(games[gameIndex]);
-                    }
+                    NewProject_GameTypeComboGUI();
                     ImGui.EndTabItem();
                 }
                 ImGui.EndTabBar();
@@ -1332,9 +1328,7 @@ namespace StudioCore
                         var message = System.Windows.Forms.MessageBox.Show("Your selected project directory already contains a project.json. Would you like to replace it?", "Error",
                                          System.Windows.Forms.MessageBoxButtons.YesNo,
                                          System.Windows.Forms.MessageBoxIcon.None);
-                        if (message == DialogResult.Yes)
-                            File.Delete($@"{_newProjectOptions.directory}\project.json");
-                        else
+                        if (message == DialogResult.No)
                             validated = false;
                     }
                     if (validated && (Path.GetDirectoryName(_newProjectOptions.settings.GameRoot)).Equals(_newProjectOptions.directory))

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -1187,32 +1187,6 @@ namespace StudioCore
                     _standardProjectUIOpened = false;
                 }
                 
-                if (ImGui.BeginTabItem("Standalone"))
-                {
-                    NewProject_NameGUI();
-                    ImGui.AlignTextToFramePadding();
-                    ImGui.Text("Shared Directory:  ");
-                    ImGui.SameLine();
-                    Utils.ImGuiGenericHelpPopup("?", "##Help_ProjectDirectory",
-                        "The location game files will be read and mod files will be saved.");
-                    ImGui.SameLine();
-                    ImGui.InputText("##pdir", ref _newProjectOptions.directory, 255);
-                    ImGui.SameLine();
-                    if (ImGui.Button($@"{ForkAwesome.FileO}"))
-                    {
-                        var browseDlg = new System.Windows.Forms.FolderBrowserDialog();
-
-                        if (browseDlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
-                        {
-                            _newProjectOptions.directory = browseDlg.SelectedPath;
-                            _newProjectOptions.settings.GameRoot = browseDlg.SelectedPath;
-                        }
-                    }
-
-                    NewProject_GameTypeComboGUI();
-                    ImGui.EndTabItem();
-                }
-                
                 if (ImGui.BeginTabItem("Advanced"))
                 {
                     NewProject_NameGUI();
@@ -1374,16 +1348,6 @@ namespace StudioCore
                 {
                     ImGui.CloseCurrentPopup();
                 }
-                ImGui.SameLine();
-                Utils.ImGuiGenericHelpPopup("Help", "##Help_NewProject",
-                    "Projects determine where DSMapStudio will obtain game data, and where modified data will be saved.\n" +
-                    "  There are two basic project configurations:\n\n" +
-                    "Standard projects (recommended)\n" +
-                    "  Obtains unpacked game files from the game folder, and saves modified files to the project folder.\n" +
-                    "  Using this with Mod Engine is recommended, or with two copies of the game: one vanilla, one modified.\n\n" +
-                    "Standalone projects\n" +
-                    "  Obtains and modify files within a single project folder, directly overwriting files."
-                    );
 
                 ImGui.EndPopup();
             }


### PR DESCRIPTION
Adds a tab to the new project menu that optionally allows user to provide a directory for game files instead of targeting an executable. Requires user to define game type manually.

Also makes it so when a new project's project folder already contains a project.json, it will prompt user to replace it instead of refusing to continue.