### PR TITLE
Change default UI tabs shown in map editor when swapping editors

### DIFF
--- a/StudioCore/MsbEditor/MsbEditorScreen.cs
+++ b/StudioCore/MsbEditor/MsbEditorScreen.cs
@@ -970,13 +970,12 @@ namespace StudioCore.MsbEditor
             Viewport.OnGui();
 
             SceneTree.OnGui();
+            PropSearch.OnGui(propSearchCmd);
             if (MapStudioNew.FirstFrame)
             {
                 ImGui.SetNextWindowFocus();
             }
             PropEditor.OnGui(_selection, "mapeditprop", Viewport.Width, Viewport.Height);
-            DispGroupEditor.OnGui(Universe._dispGroupCount);
-            PropSearch.OnGui(propSearchCmd);
 
             // Not usable yet
             if (FeatureFlags.EnableNavmeshBuilder)
@@ -986,6 +985,8 @@ namespace StudioCore.MsbEditor
 
             ResourceManager.OnGuiDrawTasks(Viewport.Width, Viewport.Height);
             ResourceManager.OnGuiDrawResourceList();
+
+            DispGroupEditor.OnGui(Universe._dispGroupCount);
 
             if (_activeModal != null)
             {


### PR DESCRIPTION
When swapping between editors, multiple elements in one window will just display whatever runs last.

PR makes prop editor shown instead of prop search, and render group editor instead of resource list