### PR TITLE
Display value type in MSB/Param property editors

### DIFF
--- a/StudioCore/MsbEditor/PropertyEditor.cs
+++ b/StudioCore/MsbEditor/PropertyEditor.cs
@@ -533,6 +533,7 @@ namespace StudioCore.MsbEditor
             ImGui.SetNextItemWidth(-1);
 
             object newval;
+            // Property Editor UI
             (bool, bool) propEditResults = PropertyRow(propType, oldval, out newval, proprow);
             bool changed = propEditResults.Item1;
             bool committed = propEditResults.Item2;
@@ -700,7 +701,7 @@ namespace StudioCore.MsbEditor
                                 var oldval = a.GetValue(i);
                                 object newval = null;
 
-                                // Property Edtior UI
+                                // Property Editor UI
                                 (bool, bool) propEditResults = PropertyRow(typ.GetElementType(), oldval, out newval, prop);
                                 bool changed = propEditResults.Item1;
                                 bool committed = propEditResults.Item2;
@@ -755,7 +756,7 @@ namespace StudioCore.MsbEditor
                                 var oldval = itemprop.GetValue(l, new object[] { i });
                                 object newval = null;
 
-                                // Property Edtior UI
+                                // Property Editor UI
                                 (bool, bool) propEditResults = PropertyRow(arrtyp, oldval, out newval, prop);
                                 bool changed = propEditResults.Item1;
                                 bool committed = propEditResults.Item2;
@@ -910,7 +911,7 @@ namespace StudioCore.MsbEditor
                         var oldval = prop.GetValue(obj);
                         object newval = null;
 
-                        // Property Edtior UI
+                        // Property Editor UI
                         (bool, bool) propEditResults = PropertyRow(typ, oldval, out newval, prop);
                         bool changed = propEditResults.Item1;
                         bool committed = propEditResults.Item2;

--- a/StudioCore/MsbEditor/PropertyEditor.cs
+++ b/StudioCore/MsbEditor/PropertyEditor.cs
@@ -32,11 +32,10 @@ namespace StudioCore.MsbEditor
 
         private (bool, bool) PropertyRow(Type typ, object oldval, out object newval, PropertyInfo prop)
         {
-            ImGui.SetNextItemWidth(ImGui.CalcItemWidth() - 28f * CFG.Current.UIScale);
+            ImGui.SetNextItemWidth(-1);
 
             newval = null;
             bool isChanged = false;
-            string valueTypeStr = "";
             if (typ == typeof(long))
             {
                 long val = (long)oldval;
@@ -50,7 +49,6 @@ namespace StudioCore.MsbEditor
                         isChanged = true;
                     }
                 }
-                valueTypeStr = "s64";
             }
             else if (typ == typeof(int))
             {
@@ -60,7 +58,6 @@ namespace StudioCore.MsbEditor
                     newval = val;
                     isChanged = true;
                 }
-                valueTypeStr = "s32";
             }
             else if (typ == typeof(uint))
             {
@@ -75,7 +72,6 @@ namespace StudioCore.MsbEditor
                         isChanged = true;
                     }
                 }
-                valueTypeStr = "u64";
             }
             else if (typ == typeof(short))
             {
@@ -85,7 +81,6 @@ namespace StudioCore.MsbEditor
                     newval = (short)val;
                     isChanged = true;
                 }
-                valueTypeStr = "s16";
             }
             else if (typ == typeof(ushort))
             {
@@ -100,7 +95,6 @@ namespace StudioCore.MsbEditor
                         isChanged = true;
                     }
                 }
-                valueTypeStr = "u16";
             }
             else if (typ == typeof(sbyte))
             {
@@ -110,7 +104,6 @@ namespace StudioCore.MsbEditor
                     newval = (sbyte)val;
                     isChanged = true;
                 }
-                valueTypeStr = "s8 ";
             }
             else if (typ == typeof(byte))
             {
@@ -125,7 +118,6 @@ namespace StudioCore.MsbEditor
                         isChanged = true;
                     }
                 }
-                valueTypeStr = "u8 ";
                 /*
                 // TODO: Set Next Unique Value
                 // (needs prop search to scan through structs)
@@ -150,7 +142,6 @@ namespace StudioCore.MsbEditor
                     newval = val;
                     isChanged = true;
                 }
-                valueTypeStr = "u8 ";
             }
             else if (typ == typeof(float))
             {
@@ -160,7 +151,6 @@ namespace StudioCore.MsbEditor
                     newval = val;
                     isChanged = true;
                 }
-                valueTypeStr = "f32";
             }
             else if (typ == typeof(string))
             {
@@ -174,7 +164,6 @@ namespace StudioCore.MsbEditor
                     newval = val;
                     isChanged = true;
                 }
-                valueTypeStr = "str";
             }
             else if (typ == typeof(Vector2))
             {
@@ -288,8 +277,21 @@ namespace StudioCore.MsbEditor
             }
             bool isDeactivatedAfterEdit = ImGui.IsItemDeactivatedAfterEdit() || !ImGui.IsAnyItemActive();
 
-            ImGui.SameLine();
-            ImGui.TextUnformatted(valueTypeStr);
+            // Tooltip
+            if (ImGui.IsItemHovered(ImGuiHoveredFlags.DelayNormal | ImGuiHoveredFlags.NoSharedDelay))
+            {
+                string str = $"Value Type: {typ.Name}";
+                if (typ.IsValueType)
+                {
+                    var min = typ.GetField("MinValue")?.GetValue(typ);
+                    var max = typ.GetField("MaxValue")?.GetValue(typ);
+                    if (min != null & max != null)
+                    {
+                        str += $" (Min {min}, Max {max})";
+                    }
+                }
+                ImGui.SetTooltip(str);
+            }
 
             return (isChanged, isDeactivatedAfterEdit);
         }

--- a/StudioCore/ParamEditor/ParamRowEditor.cs
+++ b/StudioCore/ParamEditor/ParamRowEditor.cs
@@ -39,9 +39,6 @@ namespace StudioCore.ParamEditor
         private unsafe (bool, bool) PropertyRow(Type typ, object oldval, ref object newval, bool isBool)
         {
             ImGui.SetNextItemWidth(-1);
-            ImGui.SetNextItemWidth(ImGui.CalcItemWidth() - 28f * CFG.Current.UIScale);
-
-            string valueTypeStr = "";
             bool isChanged = false;
             bool isDeactivatedAfterEdit = false;
             try
@@ -59,7 +56,6 @@ namespace StudioCore.ParamEditor
                     isDeactivatedAfterEdit = ImGui.IsItemDeactivatedAfterEdit();
                     ImGui.SameLine();
                     ImGui.SetNextItemWidth(-1);
-                    ImGui.SetNextItemWidth(ImGui.CalcItemWidth() - 28f * CFG.Current.UIScale);
                 }
             }
             catch
@@ -81,7 +77,6 @@ namespace StudioCore.ParamEditor
                         isChanged = true;
                     }
                 }
-                valueTypeStr = "s64";
             }
             else if (typ == typeof(int))
             {
@@ -92,7 +87,6 @@ namespace StudioCore.ParamEditor
                     _editedPropCache = newval;
                     isChanged = true;
                 }
-                valueTypeStr = "s32";
             }
             else if (typ == typeof(uint))
             {
@@ -108,7 +102,6 @@ namespace StudioCore.ParamEditor
                         isChanged = true;
                     }
                 }
-                valueTypeStr = "u64";
             }
             else if (typ == typeof(short))
             {
@@ -119,7 +112,6 @@ namespace StudioCore.ParamEditor
                     _editedPropCache = newval;
                     isChanged = true;
                 }
-                valueTypeStr = "s16";
             }
             else if (typ == typeof(ushort))
             {
@@ -135,7 +127,6 @@ namespace StudioCore.ParamEditor
                         isChanged = true;
                     }
                 }
-                valueTypeStr = "u16";
             }
             else if (typ == typeof(sbyte))
             {
@@ -146,7 +137,6 @@ namespace StudioCore.ParamEditor
                     _editedPropCache = newval;
                     isChanged = true;
                 }
-                valueTypeStr = "s8";
             }
             else if (typ == typeof(byte))
             {
@@ -162,7 +152,6 @@ namespace StudioCore.ParamEditor
                         isChanged = true;
                     }
                 }
-                valueTypeStr = "u8";
             }
             else if (typ == typeof(bool))
             {
@@ -173,7 +162,6 @@ namespace StudioCore.ParamEditor
                     _editedPropCache = newval;
                     isChanged = true;
                 }
-                valueTypeStr = "u8";
             }
             else if (typ == typeof(float))
             {
@@ -184,7 +172,6 @@ namespace StudioCore.ParamEditor
                     _editedPropCache = newval;
                     isChanged = true;
                 }
-                valueTypeStr = "f32";
             }
             else if (typ == typeof(double))
             {
@@ -195,7 +182,6 @@ namespace StudioCore.ParamEditor
                     _editedPropCache = newval;
                     isChanged = true;
                 }
-                valueTypeStr = "f64";
             }
             else if (typ == typeof(string))
             {
@@ -210,7 +196,6 @@ namespace StudioCore.ParamEditor
                     _editedPropCache = newval;
                     isChanged = true;
                 }
-                valueTypeStr = "str";
             }
             else if (typ == typeof(Vector2))
             {
@@ -246,7 +231,6 @@ namespace StudioCore.ParamEditor
                         isChanged = true;
                     }
                 }
-                valueTypeStr = "u8";
             }
             else
             {
@@ -255,9 +239,6 @@ namespace StudioCore.ParamEditor
                 ImGui.InputText(null, ref implMe, 256, ImGuiInputTextFlags.ReadOnly);
             }
             isDeactivatedAfterEdit |= ImGui.IsItemDeactivatedAfterEdit();
-
-            ImGui.SameLine();
-            ImGui.TextUnformatted(valueTypeStr);
 
             return (isChanged, isDeactivatedAfterEdit);
         }
@@ -552,10 +533,32 @@ namespace StudioCore.ParamEditor
                 ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(1.0f, 0.5f, 1.0f, 1.0f));
             else if (matchDefault)
                 ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(0.75f, 0.75f, 0.75f, 1.0f));
+            
+            // Property Editor UI
             (changed, committed) = PropertyRow(propType, oldval, ref newval, IsBool);
 
             if (isRef || matchDefault) //if diffVanilla, remove styling later
                 ImGui.PopStyleColor();
+
+            // Tooltip
+            if (ImGui.IsItemHovered(ImGuiHoveredFlags.DelayNormal | ImGuiHoveredFlags.NoSharedDelay))
+            {
+                string str = $"Value Type: {propType.Name}";
+                if (propType.IsValueType)
+                {
+                    var min = propType.GetField("MinValue")?.GetValue(propType);
+                    var max = propType.GetField("MaxValue")?.GetValue(propType);
+                    if (min != null & max != null)
+                    {
+                        str += $" (Min {min}, Max {max})";
+                    }
+                }
+                if (Wiki != null)
+                {
+                    str += $"\n\n{Wiki}";
+                }
+                ImGui.SetTooltip(str);
+            }
 
             PropertyRowValueContextMenu(bank, row, internalName, VirtualRef, ExtRefs, oldval);
 

--- a/StudioCore/ParamEditor/ParamRowEditor.cs
+++ b/StudioCore/ParamEditor/ParamRowEditor.cs
@@ -38,6 +38,10 @@ namespace StudioCore.ParamEditor
 
         private unsafe (bool, bool) PropertyRow(Type typ, object oldval, ref object newval, bool isBool)
         {
+            ImGui.SetNextItemWidth(-1);
+            ImGui.SetNextItemWidth(ImGui.CalcItemWidth() - 28f * CFG.Current.UIScale);
+
+            string valueTypeStr = "";
             bool isChanged = false;
             bool isDeactivatedAfterEdit = false;
             try
@@ -54,6 +58,8 @@ namespace StudioCore.ParamEditor
                     }
                     isDeactivatedAfterEdit = ImGui.IsItemDeactivatedAfterEdit();
                     ImGui.SameLine();
+                    ImGui.SetNextItemWidth(-1);
+                    ImGui.SetNextItemWidth(ImGui.CalcItemWidth() - 28f * CFG.Current.UIScale);
                 }
             }
             catch
@@ -75,6 +81,7 @@ namespace StudioCore.ParamEditor
                         isChanged = true;
                     }
                 }
+                valueTypeStr = "s64";
             }
             else if (typ == typeof(int))
             {
@@ -85,6 +92,7 @@ namespace StudioCore.ParamEditor
                     _editedPropCache = newval;
                     isChanged = true;
                 }
+                valueTypeStr = "s32";
             }
             else if (typ == typeof(uint))
             {
@@ -100,6 +108,7 @@ namespace StudioCore.ParamEditor
                         isChanged = true;
                     }
                 }
+                valueTypeStr = "u64";
             }
             else if (typ == typeof(short))
             {
@@ -110,6 +119,7 @@ namespace StudioCore.ParamEditor
                     _editedPropCache = newval;
                     isChanged = true;
                 }
+                valueTypeStr = "s16";
             }
             else if (typ == typeof(ushort))
             {
@@ -125,6 +135,7 @@ namespace StudioCore.ParamEditor
                         isChanged = true;
                     }
                 }
+                valueTypeStr = "u16";
             }
             else if (typ == typeof(sbyte))
             {
@@ -135,6 +146,7 @@ namespace StudioCore.ParamEditor
                     _editedPropCache = newval;
                     isChanged = true;
                 }
+                valueTypeStr = "s8";
             }
             else if (typ == typeof(byte))
             {
@@ -150,6 +162,7 @@ namespace StudioCore.ParamEditor
                         isChanged = true;
                     }
                 }
+                valueTypeStr = "u8";
             }
             else if (typ == typeof(bool))
             {
@@ -160,6 +173,7 @@ namespace StudioCore.ParamEditor
                     _editedPropCache = newval;
                     isChanged = true;
                 }
+                valueTypeStr = "u8";
             }
             else if (typ == typeof(float))
             {
@@ -170,6 +184,7 @@ namespace StudioCore.ParamEditor
                     _editedPropCache = newval;
                     isChanged = true;
                 }
+                valueTypeStr = "f32";
             }
             else if (typ == typeof(double))
             {
@@ -180,6 +195,7 @@ namespace StudioCore.ParamEditor
                     _editedPropCache = newval;
                     isChanged = true;
                 }
+                valueTypeStr = "f64";
             }
             else if (typ == typeof(string))
             {
@@ -194,6 +210,7 @@ namespace StudioCore.ParamEditor
                     _editedPropCache = newval;
                     isChanged = true;
                 }
+                valueTypeStr = "str";
             }
             else if (typ == typeof(Vector2))
             {
@@ -229,6 +246,7 @@ namespace StudioCore.ParamEditor
                         isChanged = true;
                     }
                 }
+                valueTypeStr = "u8";
             }
             else
             {
@@ -237,6 +255,9 @@ namespace StudioCore.ParamEditor
                 ImGui.InputText(null, ref implMe, 256, ImGuiInputTextFlags.ReadOnly);
             }
             isDeactivatedAfterEdit |= ImGui.IsItemDeactivatedAfterEdit();
+
+            ImGui.SameLine();
+            ImGui.TextUnformatted(valueTypeStr);
 
             return (isChanged, isDeactivatedAfterEdit);
         }
@@ -512,7 +533,6 @@ namespace StudioCore.ParamEditor
 
             //PropertyRowMetaDefContextMenu();
             ImGui.NextColumn();
-            ImGui.SetNextItemWidth(-1);
             bool changed = false;
             bool committed = false;
 


### PR DESCRIPTION
No option to toggle on/off (ATM).

Also contains a little setup for merging param/msb prop editor UI functions somewhere down the road.