### PR TITLE
Wait for meta to load before allowing param editing

### DIFF
--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -1015,12 +1015,19 @@ namespace StudioCore.ParamEditor
                 }
             }
 
+            if (ParamBank.PrimaryBank.IsLoadingParams)
+            {
+                ImGui.Text("Loading Params...");
+                return;
+            }
+            if (!ParamBank.IsMetaLoaded)
+            {
+                ImGui.Text("Loading Meta...");
+                return;
+            }
             if (ParamBank.PrimaryBank.Params == null)
             {
-                if (ParamBank.PrimaryBank.IsLoadingParams)
-                {
-                    ImGui.Text("Loading...");
-                }
+                ImGui.Text("No params loaded");
                 return;
             }
 


### PR DESCRIPTION
Prevents a crash.