### PR TITLE
Rework initialization and maybe fix Intel GPUs

### DIFF
--- a/StudioCore/Scene/TexturePool.cs
+++ b/StudioCore/Scene/TexturePool.cs
@@ -322,7 +322,8 @@ namespace StudioCore.Scene
             }
 
             var layoutdesc = new ResourceLayoutDescription(
-                new ResourceLayoutElementDescription(_resourceName, ResourceKind.TextureReadOnly, ShaderStages.Fragment, TextureCount));
+                new ResourceLayoutElementDescription(_resourceName, ResourceKind.TextureReadOnly,
+                    ShaderStages.Fragment, ResourceLayoutElementOptions.VariableCount, TextureCount));
             _poolLayout = d.ResourceFactory.CreateResourceLayout(layoutdesc);
         }
 

--- a/Veldrid/ResourceLayoutElementDescription.cs
+++ b/Veldrid/ResourceLayoutElementDescription.cs
@@ -50,12 +50,18 @@ namespace Veldrid
         /// <param name="kind">The kind of resource.</param>
         /// <param name="stages">The <see cref="ShaderStages"/> in which this element is used.</param>
         /// <param name="descCount">The number of descriptors to use.</param>
-        public ResourceLayoutElementDescription(string name, ResourceKind kind, ShaderStages stages, uint descCount)
+        /// <param name="options">Miscellaneous resource options for this element.</param>
+        public ResourceLayoutElementDescription(
+            string name, 
+            ResourceKind kind, 
+            ShaderStages stages,
+            ResourceLayoutElementOptions options,
+            uint descCount)
         {
             Name = name;
             Kind = kind;
             Stages = stages;
-            Options = ResourceLayoutElementOptions.None;
+            Options = options;
             DescriptorCount = descCount;
         }
 
@@ -117,5 +123,9 @@ namespace Veldrid
         /// <see cref="GraphicsDevice.StructuredBufferMinOffsetAlignment"/>.
         /// </summary>
         DynamicBinding = 1 << 0,
+        /// <summary>
+        /// Element has a variable descriptor count. This must be the last element in the layout.
+        /// </summary>
+        VariableCount = 1 << 1,
     }
 }

--- a/Veldrid/Vk/VkDescriptorPoolManager.cs
+++ b/Veldrid/Vk/VkDescriptorPoolManager.cs
@@ -18,12 +18,20 @@ namespace Veldrid.Vk
             _pools.Add(CreateNewPool());
         }
 
-        public unsafe DescriptorAllocationToken Allocate(DescriptorResourceCounts counts, VkDescriptorSetLayout setLayout)
+        public unsafe DescriptorAllocationToken Allocate(DescriptorResourceCounts counts,
+            VkDescriptorSetLayout setLayout, uint variableCount)
         {
             VkDescriptorPool pool = GetPool(counts);
+            var variableCountAI = new VkDescriptorSetVariableDescriptorCountAllocateInfo
+            {
+                sType = VkStructureType.DescriptorSetVariableDescriptorCountAllocateInfo,
+                descriptorSetCount = 1,
+                pDescriptorCounts = &variableCount,
+            };
             VkDescriptorSetAllocateInfo dsAI = new VkDescriptorSetAllocateInfo
             {
                 sType = VkStructureType.DescriptorSetAllocateInfo,
+                pNext = &variableCountAI,
                 descriptorSetCount = 1,
                 pSetLayouts = &setLayout,
                 descriptorPool = pool
@@ -93,7 +101,7 @@ namespace Veldrid.Vk
             var poolCI = new VkDescriptorPoolCreateInfo
             {
                 sType = VkStructureType.DescriptorPoolCreateInfo,
-                flags = VkDescriptorPoolCreateFlags.FreeDescriptorSet,
+                flags = VkDescriptorPoolCreateFlags.FreeDescriptorSet | VkDescriptorPoolCreateFlags.UpdateAfterBind,
                 maxSets = totalSets,
                 pPoolSizes = sizes,
                 poolSizeCount = poolSizeCount
@@ -136,7 +144,7 @@ namespace Veldrid.Vk
             var poolCI = new VkDescriptorPoolCreateInfo
             {
                 sType = VkStructureType.DescriptorPoolCreateInfo,
-                flags = VkDescriptorPoolCreateFlags.FreeDescriptorSet,
+                flags = VkDescriptorPoolCreateFlags.FreeDescriptorSet | VkDescriptorPoolCreateFlags.UpdateAfterBind,
                 maxSets = totalSets,
                 pPoolSizes = sizes,
                 poolSizeCount = poolSizeCount

--- a/Veldrid/Vk/VkResourceSet.cs
+++ b/Veldrid/Vk/VkResourceSet.cs
@@ -27,13 +27,11 @@ namespace Veldrid.Vk
         public VkResourceSet(VkGraphicsDevice gd, ref ResourceSetDescription description)
             : base(ref description)
         {
+            // TODO: There's a lot of hacks done in here to "support" unbounded arrays/descriptor indexing. It
+            // needs to be reworked eventually to get rid of them.
             _gd = gd;
             RefCount = new ResourceRefCount(DisposeCore);
             VkResourceLayout vkLayout = Util.AssertSubtype<ResourceLayout, VkResourceLayout>(description.Layout);
-
-            VkDescriptorSetLayout dsl = vkLayout.DescriptorSetLayout;
-            _descriptorCounts = vkLayout.DescriptorResourceCounts;
-            _descriptorAllocationToken = _gd.DescriptorPoolManager.Allocate(_descriptorCounts, dsl);
 
             BindableResource[] boundResources = description.BoundResources;
             int descriptorWriteCount = vkLayout.Description.Elements.Length;
@@ -43,6 +41,13 @@ namespace Veldrid.Vk
             {
                 desccount += e.DescriptorCount;
             }
+            
+            bool variableCount =
+                (vkLayout.Description.Elements[^1].Options & ResourceLayoutElementOptions.VariableCount) != 0;
+            VkDescriptorSetLayout dsl = vkLayout.DescriptorSetLayout;
+            _descriptorCounts = vkLayout.DescriptorResourceCounts;
+            _descriptorAllocationToken =
+                _gd.DescriptorPoolManager.Allocate(_descriptorCounts, dsl, variableCount ? desccount : 0);
 
             VkWriteDescriptorSet* descriptorWrites = stackalloc VkWriteDescriptorSet[(int)descriptorWriteCount];
             VkDescriptorBufferInfo* bufferInfos = stackalloc VkDescriptorBufferInfo[(int)descriptorWriteCount];


### PR DESCRIPTION
* Vulkan initialization will now explicitly check all available GPUs for the features it needs until it finds one with everything that's needed is supported while prioritizing dedicated GPUs.
* Attempt at fixing startup crash on Intel GPUs by making the bindless texture pools update after bind, which gives Intel GPUs a much higher sampled image limit.