### PR TITLE
Improve project.json load error handling

### DIFF
--- a/StudioCore/CFG.cs
+++ b/StudioCore/CFG.cs
@@ -60,7 +60,8 @@ namespace StudioCore
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show($"{e.Message}\n\nConfig could not be loaded, and will be reset.", $"{Config_FileName} Load Error");
+                    MessageBox.Show($"{e.Message}\n\nConfig could not be loaded, and will be reset.",
+                        $"{Config_FileName} Load Error", MessageBoxButtons.OK);
                     Current = new CFG();
                 }
             }
@@ -82,7 +83,8 @@ namespace StudioCore
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show($"{e.Message}\n\nKeybinds could not be loaded, and will be reset.", $"{Keybinds_FileName} Load Error", MessageBoxButtons.OK);
+                    MessageBox.Show($"{e.Message}\n\nKeybinds could not be loaded, and will be reset.",
+                        $"{Keybinds_FileName} Load Error", MessageBoxButtons.OK);
                     KeyBindings.Current = new KeyBindings.Bindings();
                 }
             }

--- a/StudioCore/CFG.cs
+++ b/StudioCore/CFG.cs
@@ -60,9 +60,14 @@ namespace StudioCore
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show($"{e.Message}\n\nConfig could not be loaded, and will be reset.",
-                        $"{Config_FileName} Load Error", MessageBoxButtons.OK);
+                    var result = MessageBox.Show($"{e.Message}\n\nConfig could not be loaded. Reset settings?",
+                        $"{Config_FileName} Load Error", MessageBoxButtons.YesNo);
+                    if ( result == DialogResult.No)
+                    {
+                        throw new Exception($"{Config_FileName} could not be loaded.\n\n{e.Message}");
+                    }
                     Current = new CFG();
+                    SaveConfig();
                 }
             }
         }
@@ -83,9 +88,14 @@ namespace StudioCore
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show($"{e.Message}\n\nKeybinds could not be loaded, and will be reset.",
-                        $"{Keybinds_FileName} Load Error", MessageBoxButtons.OK);
+                    var result = MessageBox.Show($"{e.Message}\n\nKeybinds could not be loaded. Reset keybinds?",
+                        $"{Keybinds_FileName} Load Error", MessageBoxButtons.YesNo);
+                    if (result == DialogResult.No)
+                    {
+                        throw new Exception($"{Keybinds_FileName} could not be loaded.\n\n{e.Message}");
+                    }
                     KeyBindings.Current = new KeyBindings.Bindings();
+                    SaveKeybinds();
                 }
             }
         }

--- a/StudioCore/Editor/ProjectSettings.cs
+++ b/StudioCore/Editor/ProjectSettings.cs
@@ -50,21 +50,23 @@ namespace StudioCore.Editor
         {
             var jsonString = File.ReadAllBytes(path);
             var readOnlySpan = new ReadOnlySpan<byte>(jsonString);
-            ProjectSettings settings;
             try
             {
-                settings = JsonSerializer.Deserialize<ProjectSettings>(readOnlySpan);
+                ProjectSettings settings = JsonSerializer.Deserialize<ProjectSettings>(readOnlySpan);
                 if (settings == null)
                     throw new Exception("JsonConvert returned null");
+                return settings;
             }
             catch (Exception e)
             {
-                MessageBox.Show($"{e.Message}\n\nProject.json cannot be loaded, and will be deleted. Please create a new project.",
-                    $"Project Load Error", MessageBoxButtons.OK);
-                File.Delete(path);
-                throw;
+                var result = MessageBox.Show($"{e.Message}\n\nProject.json cannot be loaded. Delete project.json?",
+                    $"Project Load Error", MessageBoxButtons.YesNo);
+                if (result == DialogResult.Yes)
+                {
+                    File.Delete(path);
+                }
+                return null;
             }
-            return settings;
         }
     }
 

--- a/StudioCore/Editor/ProjectSettings.cs
+++ b/StudioCore/Editor/ProjectSettings.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.IO;
 using Newtonsoft.Json.Linq;
+using System.Windows.Forms;
 
 namespace StudioCore.Editor
 {
@@ -49,7 +50,21 @@ namespace StudioCore.Editor
         {
             var jsonString = File.ReadAllBytes(path);
             var readOnlySpan = new ReadOnlySpan<byte>(jsonString);
-            return JsonSerializer.Deserialize<ProjectSettings>(readOnlySpan);
+            ProjectSettings settings;
+            try
+            {
+                settings = JsonSerializer.Deserialize<ProjectSettings>(readOnlySpan);
+                if (settings == null)
+                    throw new Exception("JsonConvert returned null");
+            }
+            catch (Exception e)
+            {
+                MessageBox.Show($"{e.Message}\n\nProject.json cannot be loaded, and will be deleted. Please create a new project.",
+                    $"Project Load Error", MessageBoxButtons.OK);
+                File.Delete(path);
+                throw;
+            }
+            return settings;
         }
     }
 

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -167,6 +167,12 @@ namespace StudioCore
                     var project = Editor.ProjectSettings.Deserialize(CFG.Current.LastProjectFile);
                     AttemptLoadProject(project, CFG.Current.LastProjectFile, false);
                 }
+                else
+                {
+                    MessageBox.Show($"Project.json at \"{CFG.Current.LastProjectFile}\" does not exist.", "Project Load Error", MessageBoxButtons.OK);
+                    CFG.Current.LastProjectFile = "";
+                    CFG.Save();
+                }
             }
         }
 
@@ -831,6 +837,12 @@ namespace StudioCore
                                     {
                                         recent = p;
                                     }
+                                }
+                                else
+                                {
+                                    MessageBox.Show($"Project.json at \"{p.ProjectFile}\" does not exist.\nRemoving project from recent projects list.", "Project Load Error", MessageBoxButtons.OK);
+                                    CFG.Current.RecentProjects.Remove(p);
+                                    CFG.Save();
                                 }
                             }
                             if (ImGui.BeginPopupContextItem())

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -164,8 +164,16 @@ namespace StudioCore
             {
                 if (File.Exists(CFG.Current.LastProjectFile))
                 {
-                    var project = Editor.ProjectSettings.Deserialize(CFG.Current.LastProjectFile);
-                    AttemptLoadProject(project, CFG.Current.LastProjectFile, false);
+                    var settings = Editor.ProjectSettings.Deserialize(CFG.Current.LastProjectFile);
+                    if (settings == null)
+                    {
+                        CFG.Current.LastProjectFile = "";
+                        CFG.Save();
+                    }
+                    else
+                    {
+                        AttemptLoadProject(settings, CFG.Current.LastProjectFile, false);
+                    }
                 }
                 else
                 {
@@ -819,7 +827,10 @@ namespace StudioCore
                         if (browseDlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
                         {
                             var settings = Editor.ProjectSettings.Deserialize(browseDlg.FileName);
-                            AttemptLoadProject(settings, browseDlg.FileName);
+                            if (settings != null)
+                            {
+                                AttemptLoadProject(settings, browseDlg.FileName);
+                            }
                         }
                     }
                     if (ImGui.BeginMenu("Recent Projects", Editor.TaskManager.GetLiveThreads().Count == 0 && CFG.Current.RecentProjects.Count > 0))
@@ -833,9 +844,12 @@ namespace StudioCore
                                 if (File.Exists(p.ProjectFile))
                                 {
                                     var settings = Editor.ProjectSettings.Deserialize(p.ProjectFile);
-                                    if (AttemptLoadProject(settings, p.ProjectFile, false))
+                                    if (settings != null)
                                     {
-                                        recent = p;
+                                        if (AttemptLoadProject(settings, p.ProjectFile, false))
+                                        {
+                                            recent = p;
+                                        }
                                     }
                                 }
                                 else


### PR DESCRIPTION
Try/Catch deserialization. When it fails, inform user then delete project.json, preventing a crash on load loop (same system as config and keybinds).

If a targeted project.json file doesn't exist when trying to load it, inform user and remove it from CFG recent projects list/last instead of doing nothing.