### PR TITLE
Add barrier commands and directly map vertex/index staging buffers

### DIFF
--- a/StudioCore/ImGuiRenderer.cs
+++ b/StudioCore/ImGuiRenderer.cs
@@ -556,6 +556,14 @@ namespace StudioCore
                 indexOffsetInElements += (uint)cmd_list.IdxBuffer.Size;
             }
 
+            if (draw_data.CmdListsCount > 0)
+            {
+                cl.Barrier(VkPipelineStageFlags2.Transfer, 
+                    VkAccessFlags2.TransferWrite,
+                    VkPipelineStageFlags2.VertexInput,
+                    VkAccessFlags2.VertexAttributeRead | VkAccessFlags2.IndexRead);
+            }
+
             // Setup orthographic projection matrix into our constant buffer
             {
                 var io = ImGui.GetIO();

--- a/StudioCore/Resource/HavokCollisionResource.cs
+++ b/StudioCore/Resource/HavokCollisionResource.cs
@@ -44,20 +44,25 @@ namespace StudioCore.Resource
             if(mesh.Indices8?.Capacity > 0)
             {
                 indices = mesh.Indices8.GetArrayData().Elements;
-            } else if(mesh.Indices16?.Capacity > 0)
+            }
+            else if(mesh.Indices16?.Capacity > 0)
             {
                 indices = mesh.Indices16.GetArrayData().Elements;
-            } else //Indices32 have to be there if those aren't
+            }
+            else //Indices32 have to be there if those aren't
             {
                 indices = mesh.Indices32.GetArrayData().Elements;
             }
-            var MeshIndices = new int[(indices.Count / 4) * 3];
-            var MeshVertices = new CollisionLayout[(indices.Count / 4) * 3];
+            dest.VertexCount = (indices.Count / 4) * 3;
+            dest.IndexCount = (indices.Count / 4) * 3;
+            uint buffersize = (uint)dest.IndexCount * 4u;
+            uint vbuffersize = (uint)dest.VertexCount * CollisionLayout.SizeInBytes;
+            dest.GeomBuffer = Scene.Renderer.GeometryBufferAllocator.Allocate(vbuffersize, buffersize, (int)CollisionLayout.SizeInBytes, 4);
+            var MeshIndices = new Span<int>(dest.GeomBuffer.MapIBuffer().ToPointer(), dest.IndexCount);
+            var MeshVertices = new Span<CollisionLayout>(dest.GeomBuffer.MapVBuffer().ToPointer(), dest.VertexCount);
             dest.PickingVertices = new Vector3[(indices.Count / 4) * 3];
             dest.PickingIndices = new int[(indices.Count / 4) * 3];
-
-            var factory = Scene.Renderer.Factory;
-
+            
             for (int id = 0; id < indices.Count; id += 4)
             {
                 int i = (id / 4) * 3;
@@ -112,30 +117,14 @@ namespace StudioCore.Resource
                 dest.PickingIndices[i + 1] = i + 1;
                 dest.PickingIndices[i + 2] = i + 2;
             }
-
-            dest.VertexCount = MeshVertices.Length;
-            dest.IndexCount = MeshIndices.Length;
-
-            uint buffersize = (uint)dest.IndexCount * 4u;
+            
+            dest.GeomBuffer.UnmapIBuffer();
+            dest.GeomBuffer.UnmapVBuffer();
 
             fixed (void* ptr = dest.PickingVertices)
             {
                 dest.Bounds = BoundingBox.CreateFromPoints((Vector3*)ptr, dest.PickingVertices.Count(), 12, Quaternion.Identity, Vector3.Zero, Vector3.One);
             }
-
-            uint vbuffersize = (uint)MeshVertices.Length * CollisionLayout.SizeInBytes;
-
-            dest.GeomBuffer = Scene.Renderer.GeometryBufferAllocator.Allocate(vbuffersize, buffersize, (int)CollisionLayout.SizeInBytes, 4, (h) =>
-            {
-                h.FillIBuffer(MeshIndices, () =>
-                {
-                    MeshIndices = null;
-                });
-                h.FillVBuffer(MeshVertices, () =>
-                {
-                    MeshVertices = null;
-                });
-            });
         }
 
         internal static Vector3 TransformVert(System.Numerics.Vector3 vert, HKX.HKNPBodyCInfo body)
@@ -262,9 +251,13 @@ namespace StudioCore.Resource
             dest.PickingIndices = indices.ToArray();
             dest.PickingVertices = verts.ToArray();
 
-            var MeshIndices = new int[indices.Count];
-            var MeshVertices = new CollisionLayout[indices.Count];
-            var factory = Scene.Renderer.Factory;
+            dest.VertexCount = indices.Count;
+            dest.IndexCount = indices.Count;
+            uint buffersize = (uint)dest.IndexCount * 4u;
+            uint vbuffersize = (uint)dest.VertexCount * CollisionLayout.SizeInBytes;
+            dest.GeomBuffer = Scene.Renderer.GeometryBufferAllocator.Allocate(vbuffersize, buffersize, (int)CollisionLayout.SizeInBytes, 4);
+            var MeshIndices = new Span<int>(dest.GeomBuffer.MapIBuffer().ToPointer(), dest.IndexCount);
+            var MeshVertices = new Span<CollisionLayout>(dest.GeomBuffer.MapVBuffer().ToPointer(), dest.VertexCount);
 
             for (int i = 0; i < indices.Count; i += 3)
             {
@@ -313,30 +306,14 @@ namespace StudioCore.Resource
                 MeshIndices[i + 1] = i + 1;
                 MeshIndices[i + 2] = i + 2;
             }
-
-            dest.VertexCount = MeshVertices.Length;
-            dest.IndexCount = MeshIndices.Length;
-
-            uint buffersize = (uint)dest.IndexCount * 4u;
+            
+            dest.GeomBuffer.UnmapVBuffer();
+            dest.GeomBuffer.UnmapIBuffer();
 
             fixed (void* ptr = dest.PickingVertices)
             {
                 dest.Bounds = BoundingBox.CreateFromPoints((Vector3*)ptr, dest.PickingVertices.Count(), 12, Quaternion.Identity, Vector3.Zero, Vector3.One);
             }
-
-            uint vbuffersize = (uint)MeshVertices.Length * CollisionLayout.SizeInBytes;
-
-            dest.GeomBuffer = Scene.Renderer.GeometryBufferAllocator.Allocate(vbuffersize, buffersize, (int)CollisionLayout.SizeInBytes, 4, (h) =>
-            {
-                h.FillIBuffer(MeshIndices, () =>
-                {
-                    MeshIndices = null;
-                });
-                h.FillVBuffer(MeshVertices, () =>
-                {
-                    MeshVertices = null;
-                });
-            });
         }
 
         unsafe private void ProcessMesh(HKX2.fsnpCustomParamCompressedMeshShape mesh, HKX2.hknpBodyCinfo bodyinfo, CollisionSubmesh dest)
@@ -442,9 +419,13 @@ namespace StudioCore.Resource
             dest.PickingIndices = indices.ToArray();
             dest.PickingVertices = verts.ToArray();
 
-            var MeshIndices = new int[indices.Count];
-            var MeshVertices = new CollisionLayout[indices.Count];
-            var factory = Scene.Renderer.Factory;
+            dest.VertexCount = indices.Count;
+            dest.IndexCount = indices.Count;
+            uint buffersize = (uint)dest.IndexCount * 4u;
+            uint vbuffersize = (uint)dest.VertexCount * CollisionLayout.SizeInBytes;
+            dest.GeomBuffer = Scene.Renderer.GeometryBufferAllocator.Allocate(vbuffersize, buffersize, (int)CollisionLayout.SizeInBytes, 4);
+            var MeshIndices = new Span<int>(dest.GeomBuffer.MapIBuffer().ToPointer(), dest.IndexCount);
+            var MeshVertices = new Span<CollisionLayout>(dest.GeomBuffer.MapVBuffer().ToPointer(), dest.VertexCount);
 
             for (int i = 0; i < indices.Count; i += 3)
             {
@@ -493,30 +474,14 @@ namespace StudioCore.Resource
                 MeshIndices[i + 1] = i + 1;
                 MeshIndices[i + 2] = i + 2;
             }
-
-            dest.VertexCount = MeshVertices.Length;
-            dest.IndexCount = MeshIndices.Length;
-
-            uint buffersize = (uint)dest.IndexCount * 4u;
-
+            
+            dest.GeomBuffer.UnmapIBuffer();
+            dest.GeomBuffer.UnmapVBuffer();
+            
             fixed (void* ptr = dest.PickingVertices)
             {
                 dest.Bounds = BoundingBox.CreateFromPoints((Vector3*)ptr, dest.PickingVertices.Count(), 12, Quaternion.Identity, Vector3.Zero, Vector3.One);
             }
-
-            uint vbuffersize = (uint)MeshVertices.Length * CollisionLayout.SizeInBytes;
-
-            dest.GeomBuffer = Scene.Renderer.GeometryBufferAllocator.Allocate(vbuffersize, buffersize, (int)CollisionLayout.SizeInBytes, 4, (h) =>
-            {
-                h.FillIBuffer(MeshIndices, () =>
-                {
-                    MeshIndices = null;
-                });
-                h.FillVBuffer(MeshVertices, () =>
-                {
-                    MeshVertices = null;
-                });
-            });
         }
 
         private bool LoadInternal(AccessLevel al)

--- a/StudioCore/Resource/HavokNavmeshResource.cs
+++ b/StudioCore/Resource/HavokNavmeshResource.cs
@@ -162,12 +162,17 @@ namespace StudioCore.Resource
                 indexCount += g.m_numEdges;
             }
 
-            var MeshIndices = new int[indexCount * 2];
-            var MeshVertices = new PositionColor[indexCount * 2];
+            GraphVertexCount = indexCount * 2;
+            GraphIndexCount = indexCount * 2;
+            uint buffersize = (uint)GraphIndexCount * 4u;
+            var lsize = MeshLayoutUtils.GetLayoutVertexSize(MeshLayoutType.LayoutPositionColor);
+            uint vbuffersize = (uint)GraphVertexCount * lsize;
+
+            CostGraphGeomBuffer = Scene.Renderer.GeometryBufferAllocator.Allocate(vbuffersize, buffersize, (int)lsize, 4);
+            var MeshIndices = new Span<int>(CostGraphGeomBuffer.MapIBuffer().ToPointer(), GraphIndexCount);
+            var MeshVertices = new Span<PositionColor>(CostGraphGeomBuffer.MapVBuffer().ToPointer(), GraphVertexCount);
             var vertPos = new Vector3[indexCount * 2];
-
-            var factory = Scene.Renderer.Factory;
-
+            
             int idx = 0;
 
             for (int id = 0; id < graph.m_nodes.Count; id++)
@@ -203,11 +208,9 @@ namespace StudioCore.Resource
                     idx += 2;
                 }
             }
-
-            GraphVertexCount = MeshVertices.Length;
-            GraphIndexCount = MeshIndices.Length;
-
-            uint buffersize = (uint)GraphIndexCount * 4u;
+            
+            CostGraphGeomBuffer.UnmapIBuffer();
+            CostGraphGeomBuffer.UnmapVBuffer();
 
             if (GraphVertexCount > 0)
             {
@@ -220,21 +223,6 @@ namespace StudioCore.Resource
             {
                 Bounds = new BoundingBox();
             }
-
-            var lsize = MeshLayoutUtils.GetLayoutVertexSize(MeshLayoutType.LayoutPositionColor);
-            uint vbuffersize = (uint)MeshVertices.Length * lsize;
-
-            CostGraphGeomBuffer = Scene.Renderer.GeometryBufferAllocator.Allocate(vbuffersize, buffersize, (int)lsize, 4, (h) =>
-            {
-                h.FillIBuffer(MeshIndices, () =>
-                {
-                    MeshIndices = null;
-                });
-                h.FillVBuffer(MeshVertices, () =>
-                {
-                    MeshVertices = null;
-                });
-            });
         }
 
         private bool LoadInternal(AccessLevel al)

--- a/StudioCore/Resource/HavokNavmeshResource.cs
+++ b/StudioCore/Resource/HavokNavmeshResource.cs
@@ -44,10 +44,17 @@ namespace StudioCore.Resource
                 indexCount += (f.m_numEdges - 2) * 3;
             }
 
-            var MeshIndices = new int[indexCount * 3];
-            var MeshVertices = new NavmeshLayout[indexCount * 3];
-            PickingVertices = new Vector3[indexCount * 3];
-            PickingIndices = new int[indexCount * 3];
+            VertexCount = indexCount * 3;
+            IndexCount = indexCount * 3;
+            uint buffersize = (uint)IndexCount * 4u;
+            uint vbuffersize = (uint)VertexCount * NavmeshLayout.SizeInBytes;
+            GeomBuffer =
+                Scene.Renderer.GeometryBufferAllocator.Allocate(
+                    vbuffersize, buffersize, (int)NavmeshLayout.SizeInBytes, 4);
+            var MeshIndices = new Span<int>(GeomBuffer.MapIBuffer().ToPointer(), IndexCount);
+            var MeshVertices = new Span<NavmeshLayout>(GeomBuffer.MapVBuffer().ToPointer(), VertexCount);
+            PickingVertices = new Vector3[VertexCount];
+            PickingIndices = new int[IndexCount];
 
             var factory = Scene.Renderer.Factory;
 
@@ -128,11 +135,9 @@ namespace StudioCore.Resource
                     idx += 3;
                 }
             }
-
-            VertexCount = MeshVertices.Length;
-            IndexCount = MeshIndices.Length;
-
-            uint buffersize = (uint)IndexCount * 4u;
+            
+            GeomBuffer.UnmapIBuffer();
+            GeomBuffer.UnmapVBuffer();
 
             if (VertexCount > 0)
             {
@@ -145,20 +150,6 @@ namespace StudioCore.Resource
             {
                 Bounds = new BoundingBox();
             }
-
-            uint vbuffersize = (uint)MeshVertices.Length * NavmeshLayout.SizeInBytes;
-
-            GeomBuffer = Scene.Renderer.GeometryBufferAllocator.Allocate(vbuffersize, buffersize, (int)NavmeshLayout.SizeInBytes, 4, (h) =>
-            {
-                h.FillIBuffer(MeshIndices, () =>
-                {
-                    MeshIndices = null;
-                });
-                h.FillVBuffer(MeshVertices, () =>
-                {
-                    MeshVertices = null;
-                });
-            });
         }
 
         unsafe private void ProcessGraph(hkaiDirectedGraphExplicitCost graph)

--- a/StudioCore/Resource/NVMNavmeshResource.cs
+++ b/StudioCore/Resource/NVMNavmeshResource.cs
@@ -30,13 +30,16 @@ namespace StudioCore.Resource
         unsafe private void ProcessMesh(NVM mesh)
         {
             var verts = mesh.Vertices;
-            var MeshIndices = new int[mesh.Triangles.Count * 3];
-            var MeshVertices = new NavmeshLayout[mesh.Triangles.Count * 3];
+            VertexCount = mesh.Triangles.Count * 3;
+            IndexCount = mesh.Triangles.Count * 3;
+            uint buffersize = (uint)IndexCount * 4u;
+            uint vbuffersize = (uint)VertexCount * NavmeshLayout.SizeInBytes;
+            GeomBuffer = Scene.Renderer.GeometryBufferAllocator.Allocate(vbuffersize, buffersize, (int)NavmeshLayout.SizeInBytes, 4);
+            var MeshIndices = new Span<int>(GeomBuffer.MapIBuffer().ToPointer(), IndexCount);
+            var MeshVertices = new Span<NavmeshLayout>(GeomBuffer.MapVBuffer().ToPointer(), VertexCount);
             PickingVertices = new Vector3[mesh.Triangles.Count * 3];
             PickingIndices = new int[mesh.Triangles.Count * 3];
-
-            var factory = Scene.Renderer.Factory;
-
+            
             for (int id = 0; id < mesh.Triangles.Count; id++)
             {
                 var i = id * 3;
@@ -110,11 +113,9 @@ namespace StudioCore.Resource
                 PickingIndices[i + 1] = i + 1;
                 PickingIndices[i + 2] = i + 2;
             }
-
-            VertexCount = MeshVertices.Length;
-            IndexCount = MeshIndices.Length;
-
-            uint buffersize = (uint)IndexCount * 4u;
+            
+            GeomBuffer.UnmapIBuffer();
+            GeomBuffer.UnmapVBuffer();
 
             if (VertexCount > 0)
             {
@@ -127,20 +128,6 @@ namespace StudioCore.Resource
             {
                 Bounds = new BoundingBox();
             }
-
-            uint vbuffersize = (uint)MeshVertices.Length * NavmeshLayout.SizeInBytes;
-
-            GeomBuffer = Scene.Renderer.GeometryBufferAllocator.Allocate(vbuffersize, buffersize, (int)NavmeshLayout.SizeInBytes, 4, (h) =>
-            {
-                h.FillIBuffer(MeshIndices, () =>
-                {
-                    MeshIndices = null;
-                });
-                h.FillVBuffer(MeshVertices, () =>
-                {
-                    MeshVertices = null;
-                });
-            });
         }
 
         private bool LoadInternal(AccessLevel al)

--- a/StudioCore/Scene/FullScreenQuad.cs
+++ b/StudioCore/Scene/FullScreenQuad.cs
@@ -61,6 +61,11 @@ namespace StudioCore.Scene
                     VmaMemoryUsage.AutoPreferDevice,
                     0));
             cl.UpdateBuffer(_ib, 0, s_quadIndices);
+            
+            cl.Barrier(VkPipelineStageFlags2.Transfer,
+                VkAccessFlags2.TransferWrite,
+                VkPipelineStageFlags2.VertexInput | VkPipelineStageFlags2.IndexInput,
+                VkAccessFlags2.VertexAttributeRead);
         }
 
         public void DestroyDeviceObjects()

--- a/StudioCore/Scene/Renderer.cs
+++ b/StudioCore/Scene/Renderer.cs
@@ -529,7 +529,7 @@ namespace StudioCore.Scene
 
             SamplerSet.Initialize(device);
 
-            GeometryBufferAllocator = new VertexIndexBufferAllocator(256 * 1024 * 1024, 128 * 1024 * 1024);
+            GeometryBufferAllocator = new VertexIndexBufferAllocator(Device, 256 * 1024 * 1024, 128 * 1024 * 1024);
             UniformBufferAllocator = new GPUBufferAllocator(5 * 1024 * 1024, VkBufferUsageFlags.StorageBuffer, (uint)sizeof(InstanceData));
 
             MaterialBufferAllocator = new GPUBufferAllocator("materials", 5 * 1024 * 1024, VkBufferUsageFlags.StorageBuffer, (uint)sizeof(Material), VkShaderStageFlags.Fragment);

--- a/Veldrid/Util.cs
+++ b/Veldrid/Util.cs
@@ -6,7 +6,7 @@ using Vortice.Vulkan;
 
 namespace Veldrid
 {
-    internal static class Util
+    public static class Util
     {
         [DebuggerNonUserCode]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -340,6 +340,28 @@ namespace Veldrid
         {
             ulong src64 = low | ((ulong)high << 32);
             return (IntPtr)src64;
+        }
+
+        public static VkAccessFlags2 AccessFlagsFromBufferUsageFlags(VkBufferUsageFlags flags)
+        {
+            VkAccessFlags2 ret = VkAccessFlags2.None;
+            if (flags.HasFlag(VkBufferUsageFlags.TransferSrc))
+                ret |= VkAccessFlags2.TransferRead;
+            if (flags.HasFlag(VkBufferUsageFlags.TransferDst))
+                ret |= VkAccessFlags2.TransferWrite;
+            if (flags.HasFlag(VkBufferUsageFlags.UniformBuffer))
+                ret |= VkAccessFlags2.UniformRead;
+            if (flags.HasFlag(VkBufferUsageFlags.StorageBuffer))
+                ret |= VkAccessFlags2.ShaderStorageRead | VkAccessFlags2.ShaderStorageWrite;
+            if (flags.HasFlag(VkBufferUsageFlags.IndexBuffer))
+                ret |= VkAccessFlags2.IndexRead;
+            if (flags.HasFlag(VkBufferUsageFlags.VertexBuffer))
+                ret |= VkAccessFlags2.VertexAttributeRead;
+            if (flags.HasFlag(VkBufferUsageFlags.IndirectBuffer))
+                ret |= VkAccessFlags2.IndirectCommandRead;
+            if (flags.HasFlag(VkBufferUsageFlags.ShaderDeviceAddress))
+                ret |= VkAccessFlags2.ShaderStorageRead;
+            return ret;
         }
     }
 }


### PR DESCRIPTION
Buffer barriers are now manually inserted by DSMS instead of being handled by Veldrid, which allows for more optimal barriers. Vertex and index staging buffers are now directly mapped and read into by the resource loaders instead of copied into by another temp buffer, reducing memory usage and copy overhead when loading a map. This should allow for slightly faster map loading times.