### PR TITLE
OpenGL Renderer option

### DIFF
--- a/DSMapStudio/DSMapStudio.csproj
+++ b/DSMapStudio/DSMapStudio.csproj
@@ -26,6 +26,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="LaunchWithoutVulkan.bat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="imgui.ini.backup">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/DSMapStudio/LaunchWithoutVulkan.bat
+++ b/DSMapStudio/LaunchWithoutVulkan.bat
@@ -1,0 +1,1 @@
+Start "" "DSMapStudio.exe" "--noVulkan"

--- a/DSMapStudio/Program.cs
+++ b/DSMapStudio/Program.cs
@@ -29,10 +29,20 @@ namespace DSMapStudio
 
             //SDL_version version;
             //Sdl2Native.SDL_GetVersion(&version);
+            bool noVulkan = false;
+            for (int i=0; i<args.Length; i++)
+            {
+                String s = args[i];
+                switch (s)
+                {
+                    case "--noVulkan":
+                        noVulkan = true;
+                        break;
+                }
+            }
 
             Directory.SetCurrentDirectory(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location));
-
-            var mapStudio = new MapStudioNew();
+            var mapStudio = new MapStudioNew(noVulkan);
 #if !DEBUG
             try
             {

--- a/StudioCore/GLRenderer.cs
+++ b/StudioCore/GLRenderer.cs
@@ -1,0 +1,627 @@
+using ImGuiNET;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using OpenTK.Graphics.OpenGL4;
+using OpenTK.Mathematics;
+using OpenTK.Windowing.Common.Input;
+using OpenTK.Windowing.Desktop;
+using OpenTK.Windowing.GraphicsLibraryFramework;
+using System.Diagnostics;
+using ErrorCode = OpenTK.Graphics.OpenGL4.ErrorCode;
+using OpenTK.Windowing.Common;
+
+namespace StudioCore
+{
+    public class GLWindow : GameWindow
+    {
+        GLImGuiRenderer _controller;
+        MapStudioNew _msn;
+        bool _firstframe = true;
+        public GLWindow(MapStudioNew msn) : base(GameWindowSettings.Default, new NativeWindowSettings(){ Size = new Vector2i(1600, 900), APIVersion = new Version(3, 3) })
+        {
+            _msn = msn;
+        }
+
+        protected override void OnLoad()
+        {
+            base.OnLoad();
+            Title = "DSMAPSTUDIO OPENGL TEST";
+            _controller = new GLImGuiRenderer(ClientSize.X, ClientSize.Y);
+        }
+        
+        protected override void OnResize(ResizeEventArgs e)
+        {
+            base.OnResize(e);
+
+            // Update the opengl viewport
+            GL.Viewport(0, 0, ClientSize.X, ClientSize.Y);
+
+            // Tell ImGui of the new size
+            _controller.WindowResized(ClientSize.X, ClientSize.Y);
+        }
+
+        protected override void OnRenderFrame(FrameEventArgs e)
+        {
+            base.OnRenderFrame(e);
+
+            _controller.Update(this, (float)e.Time);
+
+            GL.ClearColor(new Color4(0.176f, 0.176f, 0.188f, 1.0f));
+            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit);
+            
+            if (_firstframe)
+            {
+                ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.NavEnableKeyboard;
+                var style = ImGui.GetStyle();
+                style.TabBorderSize = 0;
+                _firstframe = false;
+            }
+            _msn.Update(1.0f);
+
+            _controller.Render();
+
+            GLImGuiRenderer.CheckGLError("End of frame");
+
+            SwapBuffers();
+        }
+
+        protected override void OnTextInput(TextInputEventArgs e)
+        {
+            base.OnTextInput(e);
+            
+            
+            _controller.PressChar((char)e.Unicode);
+        }
+
+        protected override void OnMouseWheel(MouseWheelEventArgs e)
+        {
+            base.OnMouseWheel(e);
+            
+            _controller.MouseScroll(e.Offset);
+        }
+    }
+
+    public class GLImGuiRenderer : IDisposable
+    {
+        private bool _frameBegun;
+
+        private int _vertexArray;
+        private int _vertexBuffer;
+        private int _vertexBufferSize;
+        private int _indexBuffer;
+        private int _indexBufferSize;
+
+        //private Texture _fontTexture;
+
+        private int _fontTexture;
+
+        private int _shader;
+        private int _shaderFontTextureLocation;
+        private int _shaderProjectionMatrixLocation;
+        
+        private int _windowWidth;
+        private int _windowHeight;
+
+        private System.Numerics.Vector2 _scaleFactor = System.Numerics.Vector2.One;
+
+        private static bool KHRDebugAvailable = false;
+
+        /// <summary>
+        /// Constructs a new ImGuiController.
+        /// </summary>
+        public GLImGuiRenderer(int width, int height)
+        {
+            _windowWidth = width;
+            _windowHeight = height;
+
+            int major = GL.GetInteger(GetPName.MajorVersion);
+            int minor = GL.GetInteger(GetPName.MinorVersion);
+
+            KHRDebugAvailable = (major == 4 && minor >= 3) || IsExtensionSupported("KHR_debug");
+
+            IntPtr context = ImGui.CreateContext();
+            ImGui.SetCurrentContext(context);
+            var io = ImGui.GetIO();
+            io.Fonts.AddFontDefault();
+
+            io.BackendFlags |= ImGuiBackendFlags.RendererHasVtxOffset;
+            io.ConfigFlags |= ImGuiConfigFlags.DockingEnable;
+
+            CreateDeviceResources();
+            SetKeyMappings();
+
+            SetPerFrameImGuiData(1f / 60f);
+            ImGui.LoadIniSettingsFromDisk("imgui.ini");
+
+            ImGui.NewFrame();
+            _frameBegun = true;
+        }
+
+        public void WindowResized(int width, int height)
+        {
+            _windowWidth = width;
+            _windowHeight = height;
+        }
+
+        public void DestroyDeviceObjects()
+        {
+            Dispose();
+        }
+
+        public void CreateDeviceResources()
+        {
+            _vertexBufferSize = 10000;
+            _indexBufferSize = 2000;
+
+            int prevVAO = GL.GetInteger(GetPName.VertexArrayBinding);
+            int prevArrayBuffer = GL.GetInteger(GetPName.ArrayBufferBinding);
+
+            _vertexArray = GL.GenVertexArray();
+            GL.BindVertexArray(_vertexArray);
+            LabelObject(ObjectLabelIdentifier.VertexArray, _vertexArray, "ImGui");
+
+            _vertexBuffer = GL.GenBuffer();
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _vertexBuffer);
+            LabelObject(ObjectLabelIdentifier.Buffer, _vertexBuffer, "VBO: ImGui");
+            GL.BufferData(BufferTarget.ArrayBuffer, _vertexBufferSize, IntPtr.Zero, BufferUsageHint.DynamicDraw);
+
+            _indexBuffer = GL.GenBuffer();
+            GL.BindBuffer(BufferTarget.ElementArrayBuffer, _indexBuffer);
+            LabelObject(ObjectLabelIdentifier.Buffer, _indexBuffer, "EBO: ImGui");
+            GL.BufferData(BufferTarget.ElementArrayBuffer, _indexBufferSize, IntPtr.Zero, BufferUsageHint.DynamicDraw);
+
+            RecreateFontDeviceTexture();
+
+            string VertexSource = @"#version 330 core
+
+uniform mat4 projection_matrix;
+
+layout(location = 0) in vec2 in_position;
+layout(location = 1) in vec2 in_texCoord;
+layout(location = 2) in vec4 in_color;
+
+out vec4 color;
+out vec2 texCoord;
+
+void main()
+{
+    gl_Position = projection_matrix * vec4(in_position, 0, 1);
+    color = in_color;
+    texCoord = in_texCoord;
+}";
+            string FragmentSource = @"#version 330 core
+
+uniform sampler2D in_fontTexture;
+
+in vec4 color;
+in vec2 texCoord;
+
+out vec4 outputColor;
+
+void main()
+{
+    outputColor = color * texture(in_fontTexture, texCoord);
+}";
+
+            _shader = CreateProgram("ImGui", VertexSource, FragmentSource);
+            _shaderProjectionMatrixLocation = GL.GetUniformLocation(_shader, "projection_matrix");
+            _shaderFontTextureLocation = GL.GetUniformLocation(_shader, "in_fontTexture");
+
+            int stride = Unsafe.SizeOf<ImDrawVert>();
+            GL.VertexAttribPointer(0, 2, VertexAttribPointerType.Float, false, stride, 0);
+            GL.VertexAttribPointer(1, 2, VertexAttribPointerType.Float, false, stride, 8);
+            GL.VertexAttribPointer(2, 4, VertexAttribPointerType.UnsignedByte, true, stride, 16);
+
+            GL.EnableVertexAttribArray(0);
+            GL.EnableVertexAttribArray(1);
+            GL.EnableVertexAttribArray(2);
+
+            GL.BindVertexArray(prevVAO);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, prevArrayBuffer);
+
+            CheckGLError("End of ImGui setup");
+        }
+
+        /// <summary>
+        /// Recreates the device texture used to render text.
+        /// </summary>
+        public void RecreateFontDeviceTexture()
+        {
+            ImGuiIOPtr io = ImGui.GetIO();
+            io.Fonts.GetTexDataAsRGBA32(out IntPtr pixels, out int width, out int height, out int bytesPerPixel);
+
+            int mips = (int)Math.Floor(Math.Log(Math.Max(width, height), 2));
+
+            int prevActiveTexture = GL.GetInteger(GetPName.ActiveTexture);
+            GL.ActiveTexture(TextureUnit.Texture0);
+            int prevTexture2D = GL.GetInteger(GetPName.TextureBinding2D);
+
+            _fontTexture = GL.GenTexture();
+            GL.BindTexture(TextureTarget.Texture2D, _fontTexture);
+            GL.TexStorage2D(TextureTarget2d.Texture2D, mips, SizedInternalFormat.Rgba8, width, height);
+            LabelObject(ObjectLabelIdentifier.Texture, _fontTexture, "ImGui Text Atlas");
+
+            GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, width, height, PixelFormat.Bgra, PixelType.UnsignedByte, pixels);
+
+            GL.GenerateMipmap(GenerateMipmapTarget.Texture2D);
+
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int)TextureWrapMode.Repeat);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int)TextureWrapMode.Repeat);
+
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, mips - 1);
+
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Linear);
+
+            // Restore state
+            GL.BindTexture(TextureTarget.Texture2D, prevTexture2D);
+            GL.ActiveTexture((TextureUnit)prevActiveTexture);
+
+            io.Fonts.SetTexID((IntPtr)_fontTexture);
+
+            io.Fonts.ClearTexData();
+        }
+
+        /// <summary>
+        /// Renders the ImGui draw list data.
+        /// </summary>
+        public void Render()
+        {
+            if (_frameBegun)
+            {
+                _frameBegun = false;
+                ImGui.Render();
+                RenderImDrawData(ImGui.GetDrawData());
+            }
+        }
+
+        /// <summary>
+        /// Updates ImGui input and IO configuration state.
+        /// </summary>
+        public void Update(GameWindow wnd, float deltaSeconds)
+        {
+            if (_frameBegun)
+            {
+                ImGui.Render();
+            }
+
+            SetPerFrameImGuiData(deltaSeconds);
+            UpdateImGuiInput(wnd);
+
+            _frameBegun = true;
+            ImGui.NewFrame();
+        }
+
+        /// <summary>
+        /// Sets per-frame data based on the associated window.
+        /// This is called by Update(float).
+        /// </summary>
+        private void SetPerFrameImGuiData(float deltaSeconds)
+        {
+            ImGuiIOPtr io = ImGui.GetIO();
+            io.DisplaySize = new System.Numerics.Vector2(
+                _windowWidth / _scaleFactor.X,
+                _windowHeight / _scaleFactor.Y);
+            io.DisplayFramebufferScale = _scaleFactor;
+            io.DeltaTime = deltaSeconds; // DeltaTime is in seconds.
+        }
+
+        readonly List<char> PressedChars = new List<char>();
+
+        private void UpdateImGuiInput(GameWindow wnd)
+        {
+            ImGuiIOPtr io = ImGui.GetIO();
+
+            MouseState MouseState = wnd.MouseState;
+            KeyboardState KeyboardState = wnd.KeyboardState;
+
+            io.MouseDown[0] = MouseState[MouseButton.Left];
+            io.MouseDown[1] = MouseState[MouseButton.Right];
+            io.MouseDown[2] = MouseState[MouseButton.Middle];
+
+            var screenPoint = new Vector2i((int)MouseState.X, (int)MouseState.Y);
+            var point = screenPoint;//wnd.PointToClient(screenPoint);
+            io.MousePos = new System.Numerics.Vector2(point.X, point.Y);
+            
+            foreach (Keys key in Enum.GetValues(typeof(Keys)))
+            {
+                if (key == Keys.Unknown)
+                {
+                    continue;
+                }
+                io.KeysDown[(int)key] = KeyboardState.IsKeyDown(key);
+            }
+
+            foreach (var c in PressedChars)
+            {
+                io.AddInputCharacter(c);
+            }
+            PressedChars.Clear();
+
+            io.KeyCtrl = KeyboardState.IsKeyDown(Keys.LeftControl) || KeyboardState.IsKeyDown(Keys.RightControl);
+            io.KeyAlt = KeyboardState.IsKeyDown(Keys.LeftAlt) || KeyboardState.IsKeyDown(Keys.RightAlt);
+            io.KeyShift = KeyboardState.IsKeyDown(Keys.LeftShift) || KeyboardState.IsKeyDown(Keys.RightShift);
+            io.KeySuper = KeyboardState.IsKeyDown(Keys.LeftSuper) || KeyboardState.IsKeyDown(Keys.RightSuper);
+        }
+
+        internal void PressChar(char keyChar)
+        {
+            PressedChars.Add(keyChar);
+        }
+
+        internal void MouseScroll(Vector2 offset)
+        {
+            ImGuiIOPtr io = ImGui.GetIO();
+            
+            io.MouseWheel = offset.Y;
+            io.MouseWheelH = offset.X;
+        }
+
+        private static void SetKeyMappings()
+        {
+            ImGuiIOPtr io = ImGui.GetIO();
+            io.KeyMap[(int)ImGuiKey.Tab] = (int)Keys.Tab;
+            io.KeyMap[(int)ImGuiKey.LeftArrow] = (int)Keys.Left;
+            io.KeyMap[(int)ImGuiKey.RightArrow] = (int)Keys.Right;
+            io.KeyMap[(int)ImGuiKey.UpArrow] = (int)Keys.Up;
+            io.KeyMap[(int)ImGuiKey.DownArrow] = (int)Keys.Down;
+            io.KeyMap[(int)ImGuiKey.PageUp] = (int)Keys.PageUp;
+            io.KeyMap[(int)ImGuiKey.PageDown] = (int)Keys.PageDown;
+            io.KeyMap[(int)ImGuiKey.Home] = (int)Keys.Home;
+            io.KeyMap[(int)ImGuiKey.End] = (int)Keys.End;
+            io.KeyMap[(int)ImGuiKey.Delete] = (int)Keys.Delete;
+            io.KeyMap[(int)ImGuiKey.Backspace] = (int)Keys.Backspace;
+            io.KeyMap[(int)ImGuiKey.Enter] = (int)Keys.Enter;
+            io.KeyMap[(int)ImGuiKey.Escape] = (int)Keys.Escape;
+            io.KeyMap[(int)ImGuiKey.A] = (int)Keys.A;
+            io.KeyMap[(int)ImGuiKey.C] = (int)Keys.C;
+            io.KeyMap[(int)ImGuiKey.V] = (int)Keys.V;
+            io.KeyMap[(int)ImGuiKey.X] = (int)Keys.X;
+            io.KeyMap[(int)ImGuiKey.Y] = (int)Keys.Y;
+            io.KeyMap[(int)ImGuiKey.Z] = (int)Keys.Z;
+        }
+
+        private void RenderImDrawData(ImDrawDataPtr draw_data)
+        {
+            if (draw_data.CmdListsCount == 0)
+            {
+                return;
+            }
+
+            // Get intial state.
+            int prevVAO = GL.GetInteger(GetPName.VertexArrayBinding);
+            int prevArrayBuffer = GL.GetInteger(GetPName.ArrayBufferBinding);
+            int prevProgram = GL.GetInteger(GetPName.CurrentProgram);
+            bool prevBlendEnabled = GL.GetBoolean(GetPName.Blend);
+            bool prevScissorTestEnabled = GL.GetBoolean(GetPName.ScissorTest);
+            int prevBlendEquationRgb = GL.GetInteger(GetPName.BlendEquationRgb);
+            int prevBlendEquationAlpha = GL.GetInteger(GetPName.BlendEquationAlpha);
+            int prevBlendFuncSrcRgb = GL.GetInteger(GetPName.BlendSrcRgb);
+            int prevBlendFuncSrcAlpha = GL.GetInteger(GetPName.BlendSrcAlpha);
+            int prevBlendFuncDstRgb = GL.GetInteger(GetPName.BlendDstRgb);
+            int prevBlendFuncDstAlpha = GL.GetInteger(GetPName.BlendDstAlpha);
+            bool prevCullFaceEnabled = GL.GetBoolean(GetPName.CullFace);
+            bool prevDepthTestEnabled = GL.GetBoolean(GetPName.DepthTest);
+            int prevActiveTexture = GL.GetInteger(GetPName.ActiveTexture);
+            GL.ActiveTexture(TextureUnit.Texture0);
+            int prevTexture2D = GL.GetInteger(GetPName.TextureBinding2D);
+            Span<int> prevScissorBox = stackalloc int[4];
+            unsafe
+            {
+                fixed (int* iptr = &prevScissorBox[0])
+                {
+                    GL.GetInteger(GetPName.ScissorBox, iptr);
+                }
+            }
+
+            // Bind the element buffer (thru the VAO) so that we can resize it.
+            GL.BindVertexArray(_vertexArray);
+            // Bind the vertex buffer so that we can resize it.
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _vertexBuffer);
+            for (int i = 0; i < draw_data.CmdListsCount; i++)
+            {
+                ImDrawListPtr cmd_list = draw_data.CmdListsRange[i];
+
+                int vertexSize = cmd_list.VtxBuffer.Size * Unsafe.SizeOf<ImDrawVert>();
+                if (vertexSize > _vertexBufferSize)
+                {
+                    int newSize = (int)Math.Max(_vertexBufferSize * 1.5f, vertexSize);
+                    
+                    GL.BufferData(BufferTarget.ArrayBuffer, newSize, IntPtr.Zero, BufferUsageHint.DynamicDraw);
+                    _vertexBufferSize = newSize;
+
+                    Console.WriteLine($"Resized dear imgui vertex buffer to new size {_vertexBufferSize}");
+                }
+
+                int indexSize = cmd_list.IdxBuffer.Size * sizeof(ushort);
+                if (indexSize > _indexBufferSize)
+                {
+                    int newSize = (int)Math.Max(_indexBufferSize * 1.5f, indexSize);
+                    GL.BufferData(BufferTarget.ElementArrayBuffer, newSize, IntPtr.Zero, BufferUsageHint.DynamicDraw);
+                    _indexBufferSize = newSize;
+
+                    Console.WriteLine($"Resized dear imgui index buffer to new size {_indexBufferSize}");
+                }
+            }
+
+            // Setup orthographic projection matrix into our constant buffer
+            ImGuiIOPtr io = ImGui.GetIO();
+            Matrix4 mvp = Matrix4.CreateOrthographicOffCenter(
+                0.0f,
+                io.DisplaySize.X,
+                io.DisplaySize.Y,
+                0.0f,
+                -1.0f,
+                1.0f);
+
+            GL.UseProgram(_shader);
+            GL.UniformMatrix4(_shaderProjectionMatrixLocation, false, ref mvp);
+            GL.Uniform1(_shaderFontTextureLocation, 0);
+            CheckGLError("Projection");
+
+            GL.BindVertexArray(_vertexArray);
+            CheckGLError("VAO");
+
+            draw_data.ScaleClipRects(io.DisplayFramebufferScale);
+
+            GL.Enable(EnableCap.Blend);
+            GL.Enable(EnableCap.ScissorTest);
+            GL.BlendEquation(BlendEquationMode.FuncAdd);
+            GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+            GL.Disable(EnableCap.CullFace);
+            GL.Disable(EnableCap.DepthTest);
+
+            // Render command lists
+            for (int n = 0; n < draw_data.CmdListsCount; n++)
+            {
+                ImDrawListPtr cmd_list = draw_data.CmdListsRange[n];
+
+                GL.BufferSubData(BufferTarget.ArrayBuffer, IntPtr.Zero, cmd_list.VtxBuffer.Size * Unsafe.SizeOf<ImDrawVert>(), cmd_list.VtxBuffer.Data);
+                CheckGLError($"Data Vert {n}");
+
+                GL.BufferSubData(BufferTarget.ElementArrayBuffer, IntPtr.Zero, cmd_list.IdxBuffer.Size * sizeof(ushort), cmd_list.IdxBuffer.Data);
+                CheckGLError($"Data Idx {n}");
+
+                for (int cmd_i = 0; cmd_i < cmd_list.CmdBuffer.Size; cmd_i++)
+                {
+                    ImDrawCmdPtr pcmd = cmd_list.CmdBuffer[cmd_i];
+                    if (pcmd.UserCallback != IntPtr.Zero)
+                    {
+                        throw new NotImplementedException();
+                    }
+                    else
+                    {
+                        GL.ActiveTexture(TextureUnit.Texture0);
+                        GL.BindTexture(TextureTarget.Texture2D, (int)pcmd.TextureId);
+                        CheckGLError("Texture");
+
+                        // We do _windowHeight - (int)clip.W instead of (int)clip.Y because gl has flipped Y when it comes to these coordinates
+                        var clip = pcmd.ClipRect;
+                        GL.Scissor((int)clip.X, _windowHeight - (int)clip.W, (int)(clip.Z - clip.X), (int)(clip.W - clip.Y));
+                        CheckGLError("Scissor");
+
+                        if ((io.BackendFlags & ImGuiBackendFlags.RendererHasVtxOffset) != 0)
+                        {
+                            GL.DrawElementsBaseVertex(PrimitiveType.Triangles, (int)pcmd.ElemCount, DrawElementsType.UnsignedShort, (IntPtr)(pcmd.IdxOffset * sizeof(ushort)), unchecked((int)pcmd.VtxOffset));
+                        }
+                        else
+                        {
+                            GL.DrawElements(BeginMode.Triangles, (int)pcmd.ElemCount, DrawElementsType.UnsignedShort, (int)pcmd.IdxOffset * sizeof(ushort));
+                        }
+                        CheckGLError("Draw");
+                    }
+                }
+            }
+
+            GL.Disable(EnableCap.Blend);
+            GL.Disable(EnableCap.ScissorTest);
+
+            // Reset state
+            GL.BindTexture(TextureTarget.Texture2D, prevTexture2D);
+            GL.ActiveTexture((TextureUnit)prevActiveTexture);
+            GL.UseProgram(prevProgram);
+            GL.BindVertexArray(prevVAO);
+            GL.Scissor(prevScissorBox[0], prevScissorBox[1], prevScissorBox[2], prevScissorBox[3]);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, prevArrayBuffer);
+            GL.BlendEquationSeparate((BlendEquationMode)prevBlendEquationRgb, (BlendEquationMode)prevBlendEquationAlpha);
+            GL.BlendFuncSeparate(
+                (BlendingFactorSrc)prevBlendFuncSrcRgb,
+                (BlendingFactorDest)prevBlendFuncDstRgb,
+                (BlendingFactorSrc)prevBlendFuncSrcAlpha,
+                (BlendingFactorDest)prevBlendFuncDstAlpha);
+            if (prevBlendEnabled) GL.Enable(EnableCap.Blend); else GL.Disable(EnableCap.Blend);
+            if (prevDepthTestEnabled) GL.Enable(EnableCap.DepthTest); else GL.Disable(EnableCap.DepthTest);
+            if (prevCullFaceEnabled) GL.Enable(EnableCap.CullFace); else GL.Disable(EnableCap.CullFace);
+            if (prevScissorTestEnabled) GL.Enable(EnableCap.ScissorTest); else GL.Disable(EnableCap.ScissorTest);
+        }
+
+        /// <summary>
+        /// Frees all graphics resources used by the renderer.
+        /// </summary>
+        public void Dispose()
+        {
+            GL.DeleteVertexArray(_vertexArray);
+            GL.DeleteBuffer(_vertexBuffer);
+            GL.DeleteBuffer(_indexBuffer);
+
+            GL.DeleteTexture(_fontTexture);
+            GL.DeleteProgram(_shader);
+        }
+
+        public static void LabelObject(ObjectLabelIdentifier objLabelIdent, int glObject, string name)
+        {
+            if (KHRDebugAvailable)
+                GL.ObjectLabel(objLabelIdent, glObject, name.Length, name);
+        }
+
+        static bool IsExtensionSupported(string name)
+        {
+            int n = GL.GetInteger(GetPName.NumExtensions);
+            for (int i = 0; i < n; i++)
+            {
+                string extension = GL.GetString(StringNameIndexed.Extensions, i);
+                if (extension == name) return true;
+            }
+
+            return false;
+        }
+
+        public static int CreateProgram(string name, string vertexSource, string fragmentSoruce)
+        {
+            int program = GL.CreateProgram();
+            LabelObject(ObjectLabelIdentifier.Program, program, $"Program: {name}");
+
+            int vertex = CompileShader(name, ShaderType.VertexShader, vertexSource);
+            int fragment = CompileShader(name, ShaderType.FragmentShader, fragmentSoruce);
+
+            GL.AttachShader(program, vertex);
+            GL.AttachShader(program, fragment);
+
+            GL.LinkProgram(program);
+
+            GL.GetProgram(program, GetProgramParameterName.LinkStatus, out int success);
+            if (success == 0)
+            {
+                string info = GL.GetProgramInfoLog(program);
+                Debug.WriteLine($"GL.LinkProgram had info log [{name}]:\n{info}");
+            }
+
+            GL.DetachShader(program, vertex);
+            GL.DetachShader(program, fragment);
+
+            GL.DeleteShader(vertex);
+            GL.DeleteShader(fragment);
+
+            return program;
+        }
+
+        private static int CompileShader(string name, ShaderType type, string source)
+        {
+            int shader = GL.CreateShader(type);
+            LabelObject(ObjectLabelIdentifier.Shader, shader, $"Shader: {name}");
+
+            GL.ShaderSource(shader, source);
+            GL.CompileShader(shader);
+
+            GL.GetShader(shader, ShaderParameter.CompileStatus, out int success);
+            if (success == 0)
+            {
+                string info = GL.GetShaderInfoLog(shader);
+                Debug.WriteLine($"GL.CompileShader for shader '{name}' [{type}] had info log:\n{info}");
+            }
+
+            return shader;
+        }
+
+        public static void CheckGLError(string title)
+        {
+            ErrorCode error;
+            int i = 1;
+            while ((error = GL.GetError()) != ErrorCode.NoError)
+            {
+                Debug.Print($"{title} ({i++}): {error}");
+            }
+        }
+    }
+}

--- a/StudioCore/GLRenderer.cs
+++ b/StudioCore/GLRenderer.cs
@@ -15,7 +15,7 @@ namespace StudioCore
 {
     public class GLWindow : GameWindow
     {
-        GLImGuiRenderer _controller;
+        public GLImGuiRenderer _controller;
         MapStudioNew _msn;
         bool _firstframe = true;
         public GLWindow(MapStudioNew msn, string title) : base(GameWindowSettings.Default, new NativeWindowSettings(){ Size = new Vector2i(1600, 900), APIVersion = new Version(3, 3) })
@@ -52,6 +52,7 @@ namespace StudioCore
             
             if (_firstframe)
             {
+                _msn.SetupFonts();
                 ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.NavEnableKeyboard;
                 var style = ImGui.GetStyle();
                 style.TabBorderSize = 0;

--- a/StudioCore/GLRenderer.cs
+++ b/StudioCore/GLRenderer.cs
@@ -18,15 +18,15 @@ namespace StudioCore
         GLImGuiRenderer _controller;
         MapStudioNew _msn;
         bool _firstframe = true;
-        public GLWindow(MapStudioNew msn) : base(GameWindowSettings.Default, new NativeWindowSettings(){ Size = new Vector2i(1600, 900), APIVersion = new Version(3, 3) })
+        public GLWindow(MapStudioNew msn, string title) : base(GameWindowSettings.Default, new NativeWindowSettings(){ Size = new Vector2i(1600, 900), APIVersion = new Version(3, 3) })
         {
             _msn = msn;
+            Title = title;
         }
 
         protected override void OnLoad()
         {
             base.OnLoad();
-            Title = "DSMAPSTUDIO OPENGL TEST";
             _controller = new GLImGuiRenderer(ClientSize.X, ClientSize.Y);
         }
         

--- a/StudioCore/GLRenderer.cs
+++ b/StudioCore/GLRenderer.cs
@@ -315,6 +315,18 @@ void main()
 
             MouseState MouseState = wnd.MouseState;
             KeyboardState KeyboardState = wnd.KeyboardState;
+            List<int> mouseDowns = new List<int>();
+            List<int> mouseUps = new List<int>();
+            List<Veldrid.Key> keyDowns = new List<Veldrid.Key>();
+            List<Veldrid.Key> keyUps = new List<Veldrid.Key>();
+            
+            foreach (MouseButton button in Enum.GetValues(typeof(MouseButton)))
+            {
+                if (MouseState.IsButtonPressed(button))
+                    mouseDowns.Add((int)button);
+                else if (MouseState.IsButtonReleased(button))
+                    mouseUps.Add((int)button);
+            }
 
             io.MouseDown[0] = MouseState[MouseButton.Left];
             io.MouseDown[1] = MouseState[MouseButton.Right];
@@ -330,8 +342,17 @@ void main()
                 {
                     continue;
                 }
+                if (KeyboardState.IsKeyPressed(key))
+                    keyDowns.Add(TranslateTKKeyToVeldridKey(key));
+                else if (KeyboardState.IsKeyReleased(key))
+                    keyUps.Add(TranslateTKKeyToVeldridKey(key));
                 io.KeysDown[(int)key] = KeyboardState.IsKeyDown(key);
             }
+
+            InputTracker.UpdateFrameInput(
+                new System.Numerics.Vector2(MouseState.Position.X, MouseState.Position.Y),
+                new System.Numerics.Vector2(MouseState.Delta.X, MouseState.Delta.Y),
+                MouseState.ScrollDelta.X, mouseDowns, mouseUps, keyDowns, keyUps);
 
             foreach (var c in PressedChars)
             {
@@ -343,6 +364,34 @@ void main()
             io.KeyAlt = KeyboardState.IsKeyDown(Keys.LeftAlt) || KeyboardState.IsKeyDown(Keys.RightAlt);
             io.KeyShift = KeyboardState.IsKeyDown(Keys.LeftShift) || KeyboardState.IsKeyDown(Keys.RightShift);
             io.KeySuper = KeyboardState.IsKeyDown(Keys.LeftSuper) || KeyboardState.IsKeyDown(Keys.RightSuper);
+        }
+
+        private static Veldrid.Key TranslateTKKeyToVeldridKey(Keys k)
+        {
+            if (k >= Keys.D0 && k <= Keys.D9)
+                return (Veldrid.Key) (int)k + ((int)Veldrid.Key.Number0 - (int)Keys.D0);
+            if (k >= Keys.A && k <= Keys.Z)
+                return (Veldrid.Key) (int)k + ((int)Veldrid.Key.A - (int)Keys.A);
+            
+            switch (k)
+            {
+                case Keys.LeftBracket: return Veldrid.Key.BracketLeft;
+                case Keys.RightBracket: return Veldrid.Key.BracketRight;
+                case Keys.GraveAccent: return Veldrid.Key.Grave;
+                case Keys.KeyPadEnter: return Veldrid.Key.Enter;
+                case Keys.LeftShift: return Veldrid.Key.ShiftLeft;
+                case Keys.LeftControl: return Veldrid.Key.ControlLeft;
+                case Keys.LeftAlt: return Veldrid.Key.AltLeft;
+                case Keys.LeftSuper: return Veldrid.Key.WinLeft;
+                case Keys.RightShift: return Veldrid.Key.ShiftRight;
+                case Keys.RightControl: return Veldrid.Key.ControlRight;
+                case Keys.RightAlt: return Veldrid.Key.AltRight;
+                case Keys.RightSuper: return Veldrid.Key.WinRight;
+            }
+            Veldrid.Key ko;
+            if (Enum.TryParse<Veldrid.Key>(k.ToString(), true, out ko))
+                return ko;
+            return (Veldrid.Key) k;
         }
 
         internal void PressChar(char keyChar)

--- a/StudioCore/GLRenderer.cs
+++ b/StudioCore/GLRenderer.cs
@@ -13,6 +13,11 @@ using OpenTK.Windowing.Common;
 
 namespace StudioCore
 {
+
+    /*
+     * Sourcecode heavily created from NogginBops's sample program for ImGui.NET on OpenTK, posted as CC0.
+     * https://github.com/NogginBops/ImGui.NET_OpenTK_Sample/issues/13
+     */
     public class GLWindow : GameWindow
     {
         public GLImGuiRenderer _controller;
@@ -70,15 +75,12 @@ namespace StudioCore
         protected override void OnTextInput(TextInputEventArgs e)
         {
             base.OnTextInput(e);
-            
-            
             _controller.PressChar((char)e.Unicode);
         }
 
         protected override void OnMouseWheel(MouseWheelEventArgs e)
         {
             base.OnMouseWheel(e);
-            
             _controller.MouseScroll(e.Offset);
         }
     }
@@ -92,11 +94,7 @@ namespace StudioCore
         private int _vertexBufferSize;
         private int _indexBuffer;
         private int _indexBufferSize;
-
-        //private Texture _fontTexture;
-
         private int _fontTexture;
-
         private int _shader;
         private int _shaderFontTextureLocation;
         private int _shaderProjectionMatrixLocation;

--- a/StudioCore/InputTracker.cs
+++ b/StudioCore/InputTracker.cs
@@ -158,6 +158,32 @@ namespace StudioCore
                 }
             }
         }
+        public static void UpdateFrameInput(Vector2 mousePos, Vector2 mouseDelta, float scrollDelta, List<int> mouseDowns, List<int> mouseUps, List<Key> keyDowns, List<Key> keyUps)
+        {
+            _newKeysThisFrame.Clear();
+            _newMouseButtonsThisFrame.Clear();
+            MousePosition = mousePos;
+            MouseDelta = mouseDelta;
+            MouseScrollWheelDelta = scrollDelta;
+            foreach (int m in mouseDowns)
+            {
+                if (m <= (int)MouseButton.LastButton)
+                    MouseDown((MouseButton)m);
+            }
+            foreach (int m in mouseUps)
+            {
+                if (m <= (int)MouseButton.LastButton)
+                    MouseUp((MouseButton)m);
+            }
+            foreach (Key k in keyDowns)
+            {
+                KeyDown(k);
+            }
+            foreach (Key k in keyUps)
+            {
+                KeyUp(k);
+            }
+        }
 
         private static void MouseUp(MouseButton mouseButton)
         {

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -104,7 +104,7 @@ namespace StudioCore
             }
             if (LaunchNoVulkan)
             {
-                _glwindow = new GLWindow(this);
+                _glwindow = new GLWindow(this, _programTitle);
             }
             else
             {

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -204,7 +204,7 @@ namespace StudioCore
         /// </summary>
         private readonly char[] SpecialCharsJP = { '鉤', '梟', '倅', '…', '飴', '護', '戮', 'ā', 'ī', 'ū', 'ē', 'ō', 'Ā', 'Ē', 'Ī', 'Ō', 'Ū' };
 
-        private unsafe void SetupFonts()
+        public unsafe void SetupFonts()
         {
             var fonts = ImGui.GetIO().Fonts;
             var fileEn = Path.Combine(AppContext.BaseDirectory, $@"Assets\Fonts\RobotoMono-Light.ttf");
@@ -279,7 +279,11 @@ namespace StudioCore
                 }
             }
 
-            if (!LaunchNoVulkan)
+            if (LaunchNoVulkan)
+            {
+                _glwindow._controller.RecreateFontDeviceTexture();
+            }
+            else
             {
                 ImguiRenderer.RecreateFontDeviceTexture();
             }
@@ -787,7 +791,15 @@ namespace StudioCore
 
             float scale = ImGuiRenderer.GetUIScale();
 
-            if (!LaunchNoVulkan)
+            if (LaunchNoVulkan)
+            {
+                if (_settingsMenu.FontRebuildRequest)
+                {
+                    SetupFonts();
+                    _settingsMenu.FontRebuildRequest = false;
+                }
+            }
+            else
             {
                 if (_settingsMenu.FontRebuildRequest)
                 {

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -70,7 +70,7 @@ namespace StudioCore
         private bool _textEditorFocused = false;
         private TextEditor.TextEditorScreen _textEditor;
 
-        //private SoapstoneService _soapstoneService;
+        private SoapstoneService _soapstoneService;
 
         public static RenderDoc RenderDocManager;
 
@@ -155,7 +155,7 @@ namespace StudioCore
             }
             _paramEditor = new ParamEditor.ParamEditorScreen(_window, _gd);
             _textEditor = new TextEditor.TextEditorScreen(_window, _gd);
-            //_soapstoneService = new SoapstoneService(_version, _assetLocator, _msbEditor);
+            _soapstoneService = new SoapstoneService(_version, _assetLocator, _msbEditor);
 
             _settingsMenu.MsbEditor = _msbEditor;
             _settingsMenu.ModelEditor = _modelEditor;

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -148,11 +148,8 @@ namespace StudioCore
             }
 
             _assetLocator = new AssetLocator();
-            if (!LaunchNoVulkan)
-            {
-                _msbEditor = new MsbEditor.MsbEditorScreen(_window, _gd, _assetLocator);
-                _modelEditor = new MsbEditor.ModelEditorScreen(_window, _gd, _assetLocator);
-            }
+            _msbEditor = new MsbEditor.MsbEditorScreen(_window, _gd, _assetLocator);
+            _modelEditor = new MsbEditor.ModelEditorScreen(_window, _gd, _assetLocator);
             _paramEditor = new ParamEditor.ParamEditorScreen(_window, _gd);
             _textEditor = new TextEditor.TextEditorScreen(_window, _gd);
             _soapstoneService = new SoapstoneService(_version, _assetLocator, _msbEditor);
@@ -166,10 +163,7 @@ namespace StudioCore
             ParamEditor.ParamBank.PrimaryBank.SetAssetLocator(_assetLocator);
             ParamEditor.ParamBank.VanillaBank.SetAssetLocator(_assetLocator);
             TextEditor.FMGBank.SetAssetLocator(_assetLocator);
-            if (!LaunchNoVulkan)
-            {
-                MsbEditor.MtdBank.LoadMtds(_assetLocator);
-            }
+            MsbEditor.MtdBank.LoadMtds(_assetLocator);
 
             if (!LaunchNoVulkan)
             {
@@ -473,6 +467,7 @@ namespace StudioCore
 
             Editor.AliasBank.ReloadAliases();
             ParamEditor.ParamBank.ReloadParams(newsettings, options);
+
             if (!LaunchNoVulkan)
             {
                 MsbEditor.MtdBank.ReloadMtds();
@@ -481,11 +476,8 @@ namespace StudioCore
             }
 
             //Resources loaded here should be moved to databanks
-            if (!LaunchNoVulkan)
-            {
-                _msbEditor.OnProjectChanged(_projectSettings);
-                _modelEditor.OnProjectChanged(_projectSettings);
-            }
+            _msbEditor.OnProjectChanged(_projectSettings);
+            _modelEditor.OnProjectChanged(_projectSettings);
             _textEditor.OnProjectChanged(_projectSettings);
             _paramEditor.OnProjectChanged(_projectSettings);
         }
@@ -661,13 +653,9 @@ namespace StudioCore
                     CFG.Current.LastProjectFile = filename;
                     
                     if (LaunchNoVulkan)
-                    {
-
-                    }
+                        _glwindow.Title = $"{_programTitle}  -  {_projectSettings.ProjectName}";
                     else
-                    {
                         _window.Title = $"{_programTitle}  -  {_projectSettings.ProjectName}";
-                    }
 
                     if (updateRecents)
                     {
@@ -1463,7 +1451,7 @@ namespace StudioCore
                 }
             }
 
-            if (LaunchNoVulkan)
+            if (LaunchNoVulkan) // Is this a bug?
                 ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(5.0f, 5.0f));
             else
                 ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(0.0f, 0.0f));
@@ -1512,11 +1500,8 @@ namespace StudioCore
                     SaveFocusedEditor();
                 if (InputTracker.GetKeyDown(KeyBindings.Current.Core_SaveAllEditors))
                 {
-                    if (!LaunchNoVulkan)
-                    {
-                        _msbEditor.SaveAll();
-                        _modelEditor.SaveAll();
-                    }
+                    _msbEditor.SaveAll();
+                    _modelEditor.SaveAll();
                     _paramEditor.SaveAll();
                     _textEditor.SaveAll();
                 }
@@ -1561,7 +1546,7 @@ namespace StudioCore
 
         public void SettingsGUI()
         {
-                _settingsMenu.Display();
+            _settingsMenu.Display();
         }
 
         private void RecreateWindowFramebuffers(CommandList cl)
@@ -1595,8 +1580,6 @@ namespace StudioCore
 
         private void Draw()
         {
-            if (LaunchNoVulkan)
-                return;
             Debug.Assert(_window.Exists);
             int width = _window.Width;
             int height = _window.Height;

--- a/StudioCore/MsbEditor/ModelEditorScreen.cs
+++ b/StudioCore/MsbEditor/ModelEditorScreen.cs
@@ -38,6 +38,8 @@ namespace StudioCore.MsbEditor
 
         public ModelEditorScreen(Sdl2Window window, GraphicsDevice device, AssetLocator locator)
         {
+            if (window == null || device == null)
+                return;
             Rect = window.Bounds;
             AssetLocator = locator;
             ResourceManager.Locator = AssetLocator;

--- a/StudioCore/MsbEditor/MsbEditorScreen.cs
+++ b/StudioCore/MsbEditor/MsbEditorScreen.cs
@@ -73,6 +73,8 @@ namespace StudioCore.MsbEditor
 
         public MsbEditorScreen(Sdl2Window window, GraphicsDevice device, AssetLocator locator)
         {
+            if (window == null || device == null)
+                return;
             Rect = window.Bounds;
             AssetLocator = locator;
             ResourceManager.Locator = AssetLocator;

--- a/StudioCore/StudioCore.csproj
+++ b/StudioCore/StudioCore.csproj
@@ -428,6 +428,7 @@
     <PackageReference Include="ProcessMemoryUtilities.Net" Version="1.3.4" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
     <PackageReference Include="Vortice.Vulkan" Version="1.6.4" />
+    <PackageReference Include="OpenTK" Version="4.7.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds commandline flag to not launch usual renderer, including msbeditor & modeleditor, along with related universe setup etc.
Adds a launch bat to run with this startup flag.

The render path is entirely separate and only consumes the imgui work. It should be relatively easy to maintain separation from advanced vulkan work in the future.
This means the param and text editors should be able to continue supporting older or poorly-supported graphics cards, and this may be relevant for modders of older games.

Supporting an alternate render path for map and model editors is not in scope.
Old mapstudio versions will surely be used in perpetuity by people who only play ds1 on their 2014 integrated gpu.

Currently config option is stored in mapstudionew and isn't actually static. Maybe an issue?
The constant if checks are a bit awkward.
Chinese characters currently cause the character atlas to fail to be created.