### PR TITLE
Add text wrap to various UI elements

### DIFF
--- a/StudioCore/MsbEditor/SceneTree.cs
+++ b/StudioCore/MsbEditor/SceneTree.cs
@@ -699,10 +699,12 @@ namespace StudioCore.MsbEditor
                     if (metaName != "")
                     {
                         ImGui.SameLine();
-                        if (metaName.StartsWith("--")) //marked as normally unused (use red text)
+                        ImGui.PushTextWrapPos();
+                        if (metaName.StartsWith("--")) // Marked as normally unused (use red text)
                             ImGui.TextColored(new Vector4(1.0f, 0.0f, 0.0f, 1.0f), @$"<{metaName.Replace("--","")}>");
                         else
                             ImGui.TextColored(new Vector4(1.0f, 1.0f, 0.0f, 1.0f), @$"<{metaName}>");
+                        ImGui.PopTextWrapPos();
                     }
                     ImGui.EndGroup();
                     if (_selection.ShouldGoto(mapRoot) || _selection.ShouldGoto(mapRef))

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -1961,7 +1961,9 @@ namespace StudioCore.ParamEditor
                 }
             }
 
-            if (ImGui.Selectable($@"{r.ID} {Utils.ImGuiEscape(r.Name, "")}", selected))
+            string label = $@"{r.ID} {Utils.ImGuiEscape(r.Name, "")}";
+            label = Utils.ImGui_WordWrapString(label, ImGui.GetColumnWidth());
+            if (ImGui.Selectable(label, selected))
             {
                 _focusRows = true;
                 if (InputTracker.GetKey(Key.LControl))

--- a/StudioCore/TextEditor/FMGBank.cs
+++ b/StudioCore/TextEditor/FMGBank.cs
@@ -729,9 +729,6 @@ namespace StudioCore.TextEditor
                 case FmgIDType.SummarySwordArts:
                     return FmgEntryCategory.SwordArts;
 
-                case FmgIDType.TitleMessage:
-                    return FmgEntryCategory.Message;
-
                 case FmgIDType.WeaponEffect:
                     return FmgEntryCategory.ItemFmgDummy;
 
@@ -820,7 +817,6 @@ namespace StudioCore.TextEditor
                 case FmgIDType.TitleSpells_Patch:
                 case FmgIDType.TitleWeapons_Patch:
                 case FmgIDType.TitleGem:
-                case FmgIDType.TitleMessage:
                 case FmgIDType.TitleSwordArts:
                     return FmgEntryTextType.Title;
 

--- a/StudioCore/TextEditor/TextEditorScreen.cs
+++ b/StudioCore/TextEditor/TextEditorScreen.cs
@@ -359,8 +359,10 @@ namespace StudioCore.TextEditor
                 // Entries
                 foreach (var r in _EntryLabelCacheFiltered)
                 {
-                    var text = (r.Text == null) ? "%null%" : r.Text.Replace("\n", "\n".PadRight(r.ID.ToString().Length+2)); 
-                    if (ImGui.Selectable($@"{r.ID} {text}", _activeIDCache == r.ID))
+                    var text = (r.Text == null) ? "%null%" : r.Text.Replace("\n", "\n".PadRight(r.ID.ToString().Length+2));
+                    var label = $@"{r.ID} {text}";
+                    label = Utils.ImGui_WordWrapString(label, ImGui.GetColumnWidth());
+                    if (ImGui.Selectable(label, _activeIDCache == r.ID))
                     {
                         _activeEntryGroup = FMGBank.GenerateEntryGroup(r.ID, _activeFmgInfo);
                     }

--- a/StudioCore/Utils.cs
+++ b/StudioCore/Utils.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Numerics;
 using System.Reflection;
 using System.Text;
+using System.Linq;
 using ImGuiNET;
 using Microsoft.Win32;
 using SoulsFormats;
@@ -779,6 +780,53 @@ namespace StudioCore
                     val = refval;
                 }
             }
+        }
+
+        /// <summary>
+        /// Inserts new lines into a string to make it fit in the specified UI width.
+        /// </summary>
+        public static string ImGui_WordWrapString(string text, float uiWidth, int maxLines = 3)
+        {
+            float textWidth = ImGui.CalcTextSize(text).X;
+
+            // Determine how many line breaks are needed
+            float rowNum = float.Ceiling(textWidth / uiWidth);
+            if (rowNum > maxLines)
+            {
+                rowNum = maxLines;
+            }
+
+            // Insert line breaks into text
+            for (float iRow = 1; iRow < rowNum; iRow++)
+            {
+                int pos_default = (int)(text.Length * (iRow / rowNum));
+                int pos_final;
+                int iPos = 0;
+                int sign = 1;
+                while (true)
+                {
+                    // Find position in string to insert new line without interrupting any words
+                    pos_final = pos_default + (iPos * sign);
+                    if (pos_final <= pos_default * 0.7f || pos_final >= pos_default * 1.3f)
+                    {
+                        // Couldn't find empty position within limited range, insert at fractional position instead.
+                        text = text.Insert(pos_default, "-\n ");
+                        break;
+                    }
+                    if (text[pos_final] is ' ' or '-')
+                    {
+                        text = text.Insert(pos_final, "\n");
+                        break;
+                    }
+
+                    sign *= -1;
+                    if (sign == -1)
+                    {
+                        iPos++;
+                    }
+                }
+            }
+            return text;
         }
     }
 }


### PR DESCRIPTION
Adds text wrap to map meta names, FMG entry preview, and param row names.
ImGui_WordWrapString() is pretty silly, but decently functional. I'm open to suggestions on how to improve it.

(Also includes a minor improvement in fmgbank.cs)