### PR TITLE
DS2: Fix non-loose param loading priority & fix loading defs multiple times

### DIFF
--- a/StudioCore/AssetLocator.cs
+++ b/StudioCore/AssetLocator.cs
@@ -780,7 +780,6 @@ namespace StudioCore
         public PARAMDEF GetParamdefForParam(string paramType)
         {
             PARAMDEF pd = PARAMDEF.XmlDeserialize($@"{GetParamdefDir()}\{paramType}.xml");
-            //ParamEditor.ParamMetaData meta = ParamEditor.ParamMetaData.XmlDeserialize($@"{GetParammetaDir()}\{paramType}.xml", pd);
             return pd;
         }
 

--- a/StudioCore/AssetLocator.cs
+++ b/StudioCore/AssetLocator.cs
@@ -780,7 +780,7 @@ namespace StudioCore
         public PARAMDEF GetParamdefForParam(string paramType)
         {
             PARAMDEF pd = PARAMDEF.XmlDeserialize($@"{GetParamdefDir()}\{paramType}.xml");
-            ParamEditor.ParamMetaData meta = ParamEditor.ParamMetaData.XmlDeserialize($@"{GetParammetaDir()}\{paramType}.xml", pd);
+            //ParamEditor.ParamMetaData meta = ParamEditor.ParamMetaData.XmlDeserialize($@"{GetParammetaDir()}\{paramType}.xml", pd);
             return pd;
         }
 

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -597,12 +597,11 @@ namespace StudioCore.ParamEditor
 
                     try
                     {
-                        PARAMDEF def = _paramdefs[lp.ParamType];
-
-                        lp.ApplyParamdef(def);
                         if (loose)
                         {
                             // Loose params: override params already loaded via regulation
+                            PARAMDEF def = _paramdefs[lp.ParamType];
+                            lp.ApplyParamdef(def);
                             _params[name] = lp;
                         }
                         else
@@ -610,6 +609,8 @@ namespace StudioCore.ParamEditor
                             // Non-loose params: do not override params already loaded via regulation
                             if (!_params.ContainsKey(name))
                             {
+                                PARAMDEF def = _paramdefs[lp.ParamType];
+                                lp.ApplyParamdef(def);
                                 _params.Add(name, lp);
                             }
                         }

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -495,7 +495,7 @@ namespace StudioCore.ParamEditor
             "treasureboxparam",
         };
 
-        private void LoadParamsDS2()
+        private void LoadParamsDS2(bool loose)
         {
             var dir = AssetLocator.GameRootDirectory;
             var mod = AssetLocator.GameModDirectory;
@@ -530,9 +530,9 @@ namespace StudioCore.ParamEditor
             {
                 enemyFile = $@"{dir}\Param\EnemyParam.param";
             }
-            LoadParamsDS2FromFile(scandir, param, enemyFile);
+            LoadParamsDS2FromFile(scandir, param, enemyFile, loose);
         }
-        private void LoadVParamsDS2()
+        private void LoadVParamsDS2(bool loose)
         {
             if (!File.Exists($@"{AssetLocator.GameRootDirectory}\enc_regulation.bnd.dcx"))
             {
@@ -547,35 +547,10 @@ namespace StudioCore.ParamEditor
             List<string> scandir = new List<string>();
             scandir.Add($@"{AssetLocator.GameRootDirectory}\Param");
 
-            LoadParamsDS2FromFile(scandir, $@"{AssetLocator.GameRootDirectory}\enc_regulation.bnd.dcx", $@"{AssetLocator.GameRootDirectory}\Param\EnemyParam.param");
+            LoadParamsDS2FromFile(scandir, $@"{AssetLocator.GameRootDirectory}\enc_regulation.bnd.dcx", $@"{AssetLocator.GameRootDirectory}\Param\EnemyParam.param", loose);
         }
-        private void LoadParamsDS2FromFile(List<string> loosedir, string path, string enemypath)
+        private void LoadParamsDS2FromFile(List<string> loosedir, string path, string enemypath, bool loose)
         {
-            foreach (var d in loosedir)
-            {
-                var paramfiles = Directory.GetFileSystemEntries(d, @"*.param");
-                foreach (var p in paramfiles)
-                {
-                    var name = Path.GetFileNameWithoutExtension(p);
-                    var lp = Param.Read(p);
-                    var fname = lp.ParamType;
-
-                    try
-                    {
-                        PARAMDEF def = AssetLocator.GetParamdefForParam(fname);
-                        lp.ApplyParamdef(def);
-                        if (!_params.ContainsKey(name))
-                        {
-                            _params.Add(name, lp);
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        TaskManager.warningList.TryAdd($"{fname} DefFail", $"Could not apply ParamDef for {fname}");
-                    }
-                }
-            }
-
             BND4 paramBnd;
             if (!BND4.Is(path))
             {
@@ -610,6 +585,41 @@ namespace StudioCore.ParamEditor
                 }
             }
             LoadParamFromBinder(paramBnd, ref _params, out _paramVersion);
+
+            foreach (var d in loosedir)
+            {
+                var paramfiles = Directory.GetFileSystemEntries(d, @"*.param");
+                foreach (var p in paramfiles)
+                {
+                    var name = Path.GetFileNameWithoutExtension(p);
+                    var lp = Param.Read(p);
+                    var fname = lp.ParamType;
+
+                    try
+                    {
+                        PARAMDEF def = AssetLocator.GetParamdefForParam(fname);
+                        lp.ApplyParamdef(def);
+                        if (loose)
+                        {
+                            // Loose params: override params already loaded via regulation
+                            _params[name] = lp;
+                        }
+                        else
+                        {
+                            // Non-loose params: do not override params already loaded via regulation
+                            if (!_params.ContainsKey(name))
+                            {
+                                _params.Add(name, lp);
+                            }
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        TaskManager.warningList.TryAdd($"{fname} DefFail", $"Could not apply ParamDef for {fname}");
+                    }
+                }
+            }
+
         }
 
         private void LoadParamsDS3(bool loose)
@@ -750,7 +760,7 @@ namespace StudioCore.ParamEditor
                 }
                 if (locator.Type == GameType.DarkSoulsIISOTFS)
                 {
-                    PrimaryBank.LoadParamsDS2();
+                    PrimaryBank.LoadParamsDS2(settings.UseLooseParams);
                 }
                 if (locator.Type == GameType.DarkSoulsIII)
                 {
@@ -786,7 +796,7 @@ namespace StudioCore.ParamEditor
                     }
                     if (locator.Type == GameType.DarkSoulsIISOTFS)
                     {
-                        VanillaBank.LoadVParamsDS2();
+                        VanillaBank.LoadVParamsDS2(settings.UseLooseParams);
                     }
                     if (locator.Type == GameType.DarkSoulsIII)
                     {
@@ -822,7 +832,7 @@ namespace StudioCore.ParamEditor
                 }
             });
         }
-        public static void LoadAuxBank(string path, string looseDir, string enemyPath)
+        public static void LoadAuxBank(string path, string looseDir, string enemyPath, ProjectSettings settings)
         {
             // Steal assetlocator
             AssetLocator locator = PrimaryBank.AssetLocator;
@@ -848,7 +858,7 @@ namespace StudioCore.ParamEditor
             }
             else if (locator.Type == GameType.DarkSoulsIISOTFS)
             {
-                newBank.LoadParamsDS2FromFile(new List<string>{looseDir}, path, enemyPath);
+                newBank.LoadParamsDS2FromFile(new List<string>{looseDir}, path, enemyPath, settings.UseLooseParams);
             }
             else if (locator.Type == GameType.DarkSoulsRemastered)
             {

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -597,7 +597,11 @@ namespace StudioCore.ParamEditor
 
                     try
                     {
-                        PARAMDEF def = AssetLocator.GetParamdefForParam(fname);
+                        if (!_paramdefs.TryGetValue(lp.ParamType, out PARAMDEF def))
+                        {
+                            def = AssetLocator.GetParamdefForParam(fname);
+                        }
+
                         lp.ApplyParamdef(def);
                         if (loose)
                         {
@@ -619,7 +623,6 @@ namespace StudioCore.ParamEditor
                     }
                 }
             }
-
         }
 
         private void LoadParamsDS3(bool loose)

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -574,9 +574,9 @@ namespace StudioCore.ParamEditor
             }
             if (EnemyParam != null)
             {
-                PARAMDEF def = AssetLocator.GetParamdefForParam(EnemyParam.ParamType);
                 try
                 {
+                    PARAMDEF def = _paramdefs[EnemyParam.ParamType];
                     EnemyParam.ApplyParamdef(def);
                 }
                 catch (Exception e)
@@ -597,10 +597,7 @@ namespace StudioCore.ParamEditor
 
                     try
                     {
-                        if (!_paramdefs.TryGetValue(lp.ParamType, out PARAMDEF def))
-                        {
-                            def = AssetLocator.GetParamdefForParam(fname);
-                        }
+                        PARAMDEF def = _paramdefs[lp.ParamType];
 
                         lp.ApplyParamdef(def);
                         if (loose)

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -633,7 +633,7 @@ namespace StudioCore.ParamEditor
                             };
                             if (rbrowseDlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
                             {
-                                ParamBank.LoadAuxBank(rbrowseDlg.FileName, null, null);
+                                ParamBank.LoadAuxBank(rbrowseDlg.FileName, null, null, _projectSettings);
                             }
                         }
                         else
@@ -664,7 +664,7 @@ namespace StudioCore.ParamEditor
                                     };
                                     if (rbrowseDlgEnemy.ShowDialog() == System.Windows.Forms.DialogResult.OK)
                                     {
-                                        ParamBank.LoadAuxBank(rbrowseDlgBnd.FileName, rbrowseDlgFolder.SelectedPath, rbrowseDlgEnemy.FileName);
+                                        ParamBank.LoadAuxBank(rbrowseDlgBnd.FileName, rbrowseDlgFolder.SelectedPath, rbrowseDlgEnemy.FileName, _projectSettings);
                                     }
                                 }
                             }


### PR DESCRIPTION
Changes DS2 param loading: loose params will only override regulation params when "loose params" project setting is true.

Makes loose param loading use _defs instead of independently loading them (Significantly improves load time in common circumstances)