### PR TITLE
Loading Optimizations

### DIFF
--- a/SoulsFormats/SoulsFormats/Binder/BND3/BND3Reader.cs
+++ b/SoulsFormats/SoulsFormats/Binder/BND3/BND3Reader.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using DotNext.IO.MemoryMappedFiles;
 
 namespace SoulsFormats
 {
@@ -22,18 +25,18 @@ namespace SoulsFormats
         /// </summary>
         public BND3Reader(string path)
         {
-            FileStream fs = File.OpenRead(path);
-            var br = new BinaryReaderEx(false, fs);
+            _mappedFile = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            _mappedAccessor = _mappedFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            var br = new BinaryReaderEx(false, _mappedAccessor.Memory);
             Read(br);
         }
 
         /// <summary>
         /// Reads a BND3 from the given bytes, decompressing if necessary.
         /// </summary>
-        public BND3Reader(byte[] bytes)
+        public BND3Reader(Memory<byte> bytes)
         {
-            var ms = new MemoryStream(bytes);
-            var br = new BinaryReaderEx(false, ms);
+            var br = new BinaryReaderEx(false, bytes);
             Read(br);
         }
 

--- a/SoulsFormats/SoulsFormats/Binder/BND4/BND4Reader.cs
+++ b/SoulsFormats/SoulsFormats/Binder/BND4/BND4Reader.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using DotNext.IO.MemoryMappedFiles;
 
 namespace SoulsFormats
 {
@@ -37,18 +40,18 @@ namespace SoulsFormats
         /// </summary>
         public BND4Reader(string path)
         {
-            FileStream fs = File.OpenRead(path);
-            var br = new BinaryReaderEx(false, fs);
+            _mappedFile = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            _mappedAccessor = _mappedFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            var br = new BinaryReaderEx(false, _mappedAccessor.Memory);
             Read(br);
         }
 
         /// <summary>
         /// Reads a BND4 from the given bytes, decompressing if necessary.
         /// </summary>
-        public BND4Reader(byte[] bytes)
+        public BND4Reader(Memory<byte> bytes)
         {
-            var ms = new MemoryStream(bytes);
-            var br = new BinaryReaderEx(false, ms);
+            var br = new BinaryReaderEx(false, bytes);
             Read(br);
         }
 

--- a/SoulsFormats/SoulsFormats/Binder/BXF3/BXF3.cs
+++ b/SoulsFormats/SoulsFormats/Binder/BXF3/BXF3.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.MemoryMappedFiles;
+using DotNext.IO.MemoryMappedFiles;
 
 namespace SoulsFormats
 {
@@ -13,7 +15,7 @@ namespace SoulsFormats
         /// <summary>
         /// Returns true if the bytes appear to be a BXF3 header file.
         /// </summary>
-        public static bool IsBHD(byte[] bytes)
+        public static bool IsBHD(Memory<byte> bytes)
         {
             BinaryReaderEx br = new BinaryReaderEx(false, bytes);
             return IsBHD(SFUtil.GetDecompressedBR(br, out _));
@@ -24,17 +26,16 @@ namespace SoulsFormats
         /// </summary>
         public static bool IsBHD(string path)
         {
-            using (FileStream fs = System.IO.File.OpenRead(path))
-            {
-                BinaryReaderEx br = new BinaryReaderEx(false, fs);
-                return IsBHD(SFUtil.GetDecompressedBR(br, out _));
-            }
+            using var file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var accessor = file.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            BinaryReaderEx br = new BinaryReaderEx(false, accessor.Memory);
+            return IsBHD(SFUtil.GetDecompressedBR(br, out _));
         }
 
         /// <summary>
         /// Returns true if the file appears to be a BXF3 data file.
         /// </summary>
-        public static bool IsBDT(byte[] bytes)
+        public static bool IsBDT(Memory<byte> bytes)
         {
             BinaryReaderEx br = new BinaryReaderEx(false, bytes);
             return IsBDT(SFUtil.GetDecompressedBR(br, out _));
@@ -45,11 +46,10 @@ namespace SoulsFormats
         /// </summary>
         public static bool IsBDT(string path)
         {
-            using (FileStream fs = System.IO.File.OpenRead(path))
-            {
-                BinaryReaderEx br = new BinaryReaderEx(false, fs);
-                return IsBDT(SFUtil.GetDecompressedBR(br, out _));
-            }
+            using var file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var accessor = file.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            BinaryReaderEx br = new BinaryReaderEx(false, accessor.Memory);
+            return IsBDT(SFUtil.GetDecompressedBR(br, out _));
         }
         #endregion
 
@@ -57,7 +57,7 @@ namespace SoulsFormats
         /// <summary>
         /// Reads two arrays of bytes as the BHD and BDT.
         /// </summary>
-        public static BXF3 Read(byte[] bhdBytes, byte[] bdtBytes)
+        public static BXF3 Read(Memory<byte> bhdBytes, Memory<byte> bdtBytes)
         {
             BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes);
             BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes);
@@ -67,27 +67,25 @@ namespace SoulsFormats
         /// <summary>
         /// Reads an array of bytes as the BHD and a file as the BDT.
         /// </summary>
-        public static BXF3 Read(byte[] bhdBytes, string bdtPath)
+        public static BXF3 Read(Memory<byte> bhdBytes, string bdtPath)
         {
-            using (FileStream bdtStream = System.IO.File.OpenRead(bdtPath))
-            {
-                BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes);
-                BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream);
-                return new BXF3(bhdReader, bdtReader);
-            }
+            using MemoryMappedFile dataFile = MemoryMappedFile.CreateFromFile(bdtPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using IMappedMemoryOwner fsData = dataFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes);
+            BinaryReaderEx bdtReader = new BinaryReaderEx(false, fsData.Memory);
+            return new BXF3(bhdReader, bdtReader);
         }
 
         /// <summary>
         /// Reads a file as the BHD and an array of bytes as the BDT.
         /// </summary>
-        public static BXF3 Read(string bhdPath, byte[] bdtBytes)
+        public static BXF3 Read(string bhdPath, Memory<byte> bdtBytes)
         {
-            using (FileStream bhdStream = System.IO.File.OpenRead(bhdPath))
-            {
-                BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream);
-                BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes);
-                return new BXF3(bhdReader, bdtReader);
-            }
+            using MemoryMappedFile headerFile = MemoryMappedFile.CreateFromFile(bhdPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using IMappedMemoryOwner fsHeader = headerFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            BinaryReaderEx bhdReader = new BinaryReaderEx(false, fsHeader.Memory);
+            BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes);
+            return new BXF3(bhdReader, bdtReader);
         }
 
         /// <summary>
@@ -95,13 +93,13 @@ namespace SoulsFormats
         /// </summary>
         public static BXF3 Read(string bhdPath, string bdtPath)
         {
-            using (FileStream bhdStream = System.IO.File.OpenRead(bhdPath))
-            using (FileStream bdtStream = System.IO.File.OpenRead(bdtPath))
-            {
-                BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream);
-                BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream);
-                return new BXF3(bhdReader, bdtReader);
-            }
+            using MemoryMappedFile headerFile = MemoryMappedFile.CreateFromFile(bhdPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read),
+                dataFile = MemoryMappedFile.CreateFromFile(bdtPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using IMappedMemoryOwner fsHeader = headerFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read),
+                fsData = dataFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            BinaryReaderEx bhdReader = new BinaryReaderEx(false, fsHeader.Memory);
+            BinaryReaderEx bdtReader = new BinaryReaderEx(false, fsData.Memory);
+            return new BXF3(bhdReader, bdtReader);
         }
         #endregion
 

--- a/SoulsFormats/SoulsFormats/Binder/BXF3/BXF3Reader.cs
+++ b/SoulsFormats/SoulsFormats/Binder/BXF3/BXF3Reader.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using DotNext.IO.MemoryMappedFiles;
 
 namespace SoulsFormats
 {
@@ -12,55 +15,47 @@ namespace SoulsFormats
         /// </summary>
         public BXF3Reader(string bhdPath, string bdtPath)
         {
-            using (FileStream fsHeader = File.OpenRead(bhdPath))
-            {
-                FileStream fsData = File.OpenRead(bdtPath);
-                var brHeader = new BinaryReaderEx(false, fsHeader);
-                var brData = new BinaryReaderEx(false, fsData);
-                Read(brHeader, brData);
-            }
+            using MemoryMappedFile headerFile = MemoryMappedFile.CreateFromFile(bhdPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            _mappedFile = MemoryMappedFile.CreateFromFile(bdtPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using IMappedMemoryOwner fsHeader = headerFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            _mappedAccessor = _mappedFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            var brHeader = new BinaryReaderEx(false, fsHeader.Memory);
+            var brData = new BinaryReaderEx(false, _mappedAccessor.Memory);
+            Read(brHeader, brData);
         }
 
         /// <summary>
         /// Reads a BXF3 from the given BHD path and BDT bytes.
         /// </summary>
-        public BXF3Reader(string bhdPath, byte[] bdtBytes)
+        public BXF3Reader(string bhdPath, Memory<byte> bdtBytes)
         {
-            using (FileStream fsHeader = File.OpenRead(bhdPath))
-            {
-                var msData = new MemoryStream(bdtBytes);
-                var brHeader = new BinaryReaderEx(false, fsHeader);
-                var brData = new BinaryReaderEx(false, msData);
-                Read(brHeader, brData);
-            }
+            using MemoryMappedFile headerFile = MemoryMappedFile.CreateFromFile(bhdPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using IMappedMemoryOwner fsHeader = headerFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            var brHeader = new BinaryReaderEx(false, fsHeader.Memory);
+            var brData = new BinaryReaderEx(false, bdtBytes);
+            Read(brHeader, brData);
         }
 
         /// <summary>
         /// Reads a BXF3 from the given BHD bytes and BDT path.
         /// </summary>
-        public BXF3Reader(byte[] bhdBytes, string bdtPath)
+        public BXF3Reader(Memory<byte> bhdBytes, string bdtPath)
         {
-            using (var msHeader = new MemoryStream(bhdBytes))
-            {
-                FileStream fsData = File.OpenRead(bdtPath);
-                var brHeader = new BinaryReaderEx(false, msHeader);
-                var brData = new BinaryReaderEx(false, fsData);
-                Read(brHeader, brData);
-            }
+            _mappedFile = MemoryMappedFile.CreateFromFile(bdtPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            _mappedAccessor = _mappedFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            var brHeader = new BinaryReaderEx(false, bhdBytes);
+            var brData = new BinaryReaderEx(false, _mappedAccessor.Memory);
+            Read(brHeader, brData);
         }
 
         /// <summary>
         /// Reads a BXF3 from the given BHD and BDT bytes.
         /// </summary>
-        public BXF3Reader(byte[] bhdBytes, byte[] bdtBytes)
+        public BXF3Reader(Memory<byte> bhdBytes, Memory<byte> bdtBytes)
         {
-            using (var msHeader = new MemoryStream(bhdBytes))
-            {
-                var msData = new MemoryStream(bdtBytes);
-                var brHeader = new BinaryReaderEx(false, msHeader);
-                var brData = new BinaryReaderEx(false, msData);
-                Read(brHeader, brData);
-            }
+            var brHeader = new BinaryReaderEx(false, bhdBytes);
+            var brData = new BinaryReaderEx(false, bdtBytes);
+            Read(brHeader, brData);
         }
 
         private void Read(BinaryReaderEx brHeader, BinaryReaderEx brData)

--- a/SoulsFormats/SoulsFormats/Binder/BXF4/BXF4.cs
+++ b/SoulsFormats/SoulsFormats/Binder/BXF4/BXF4.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.MemoryMappedFiles;
+using DotNext.IO.MemoryMappedFiles;
 
 namespace SoulsFormats
 {
@@ -13,7 +15,7 @@ namespace SoulsFormats
         /// <summary>
         /// Returns true if the bytes appear to be a BXF3 header file.
         /// </summary>
-        public static bool IsBHD(byte[] bytes)
+        public static bool IsBHD(Memory<byte> bytes)
         {
             BinaryReaderEx br = new BinaryReaderEx(false, bytes);
             return IsBHD(SFUtil.GetDecompressedBR(br, out _));
@@ -24,17 +26,16 @@ namespace SoulsFormats
         /// </summary>
         public static bool IsBHD(string path)
         {
-            using (FileStream fs = System.IO.File.OpenRead(path))
-            {
-                BinaryReaderEx br = new BinaryReaderEx(false, fs);
-                return IsBHD(SFUtil.GetDecompressedBR(br, out _));
-            }
+            using var file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var accessor = file.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            BinaryReaderEx br = new BinaryReaderEx(false, accessor.Memory);
+            return IsBHD(SFUtil.GetDecompressedBR(br, out _));
         }
 
         /// <summary>
         /// Returns true if the file appears to be a BXF3 data file.
         /// </summary>
-        public static bool IsBDT(byte[] bytes)
+        public static bool IsBDT(Memory<byte> bytes)
         {
             BinaryReaderEx br = new BinaryReaderEx(false, bytes);
             return IsBDT(SFUtil.GetDecompressedBR(br, out _));
@@ -45,11 +46,10 @@ namespace SoulsFormats
         /// </summary>
         public static bool IsBDT(string path)
         {
-            using (FileStream fs = System.IO.File.OpenRead(path))
-            {
-                BinaryReaderEx br = new BinaryReaderEx(false, fs);
-                return IsBDT(SFUtil.GetDecompressedBR(br, out _));
-            }
+            using var file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var accessor = file.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            BinaryReaderEx br = new BinaryReaderEx(false, accessor.Memory);
+            return IsBDT(SFUtil.GetDecompressedBR(br, out _));
         }
         #endregion
 
@@ -57,7 +57,7 @@ namespace SoulsFormats
         /// <summary>
         /// Reads two arrays of bytes as the BHD and BDT.
         /// </summary>
-        public static BXF4 Read(byte[] bhdBytes, byte[] bdtBytes)
+        public static BXF4 Read(Memory<byte> bhdBytes, Memory<byte> bdtBytes)
         {
             BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes);
             BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes);
@@ -67,27 +67,25 @@ namespace SoulsFormats
         /// <summary>
         /// Reads an array of bytes as the BHD and a file as the BDT.
         /// </summary>
-        public static BXF4 Read(byte[] bhdBytes, string bdtPath)
+        public static BXF4 Read(Memory<byte> bhdBytes, string bdtPath)
         {
-            using (FileStream bdtStream = System.IO.File.OpenRead(bdtPath))
-            {
-                BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes);
-                BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream);
-                return new BXF4(bhdReader, bdtReader);
-            }
+            using MemoryMappedFile dataFile = MemoryMappedFile.CreateFromFile(bdtPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using IMappedMemoryOwner fsData = dataFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes);
+            BinaryReaderEx bdtReader = new BinaryReaderEx(false, fsData.Memory);
+            return new BXF4(bhdReader, bdtReader);
         }
 
         /// <summary>
         /// Reads a file as the BHD and an array of bytes as the BDT.
         /// </summary>
-        public static BXF4 Read(string bhdPath, byte[] bdtBytes)
+        public static BXF4 Read(string bhdPath, Memory<byte> bdtBytes)
         {
-            using (FileStream bhdStream = System.IO.File.OpenRead(bhdPath))
-            {
-                BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream);
-                BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes);
-                return new BXF4(bhdReader, bdtReader);
-            }
+            using MemoryMappedFile headerFile = MemoryMappedFile.CreateFromFile(bhdPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using IMappedMemoryOwner fsHeader = headerFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            BinaryReaderEx bhdReader = new BinaryReaderEx(false, fsHeader.Memory);
+            BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes);
+            return new BXF4(bhdReader, bdtReader);
         }
 
         /// <summary>
@@ -95,13 +93,13 @@ namespace SoulsFormats
         /// </summary>
         public static BXF4 Read(string bhdPath, string bdtPath)
         {
-            using (FileStream bhdStream = System.IO.File.OpenRead(bhdPath))
-            using (FileStream bdtStream = System.IO.File.OpenRead(bdtPath))
-            {
-                BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdStream);
-                BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtStream);
-                return new BXF4(bhdReader, bdtReader);
-            }
+            using MemoryMappedFile headerFile = MemoryMappedFile.CreateFromFile(bhdPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read),
+                dataFile = MemoryMappedFile.CreateFromFile(bdtPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using IMappedMemoryOwner fsHeader = headerFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read),
+                fsData = dataFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            BinaryReaderEx bhdReader = new BinaryReaderEx(false, fsHeader.Memory);
+            BinaryReaderEx bdtReader = new BinaryReaderEx(false, fsData.Memory);
+            return new BXF4(bhdReader, bdtReader);
         }
         #endregion
 

--- a/SoulsFormats/SoulsFormats/Binder/BinderFile.cs
+++ b/SoulsFormats/SoulsFormats/Binder/BinderFile.cs
@@ -1,4 +1,5 @@
-﻿using static SoulsFormats.Binder;
+﻿using System;
+using static SoulsFormats.Binder;
 
 namespace SoulsFormats
 {
@@ -25,7 +26,7 @@ namespace SoulsFormats
         /// <summary>
         /// Raw file data.
         /// </summary>
-        public byte[] Bytes { get; set; }
+        public Memory<byte> Bytes { get; set; }
 
         /// <summary>
         /// If compressed, which type of compression to use.
@@ -55,7 +56,7 @@ namespace SoulsFormats
         /// <summary>
         /// Creates a new file.
         /// </summary>
-        public BinderFile(FileFlags flags, int id, string name, byte[] bytes)
+        public BinderFile(FileFlags flags, int id, string name, Memory<byte> bytes)
         {
             Flags = flags;
             ID = id;

--- a/SoulsFormats/SoulsFormats/Binder/BinderReader.cs
+++ b/SoulsFormats/SoulsFormats/Binder/BinderReader.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO.MemoryMappedFiles;
+using DotNext.IO.MemoryMappedFiles;
 
 namespace SoulsFormats
 {
@@ -38,10 +40,13 @@ namespace SoulsFormats
         /// </summary>
         protected BinaryReaderEx DataBR;
 
+        protected MemoryMappedFile _mappedFile;
+        protected IMappedMemoryOwner _mappedAccessor;
+
         /// <summary>
         /// Reads file data according to the header at the given index in Files.
         /// </summary>
-        public byte[] ReadFile(int index)
+        public Memory<byte> ReadFile(int index)
         {
             return ReadFile(Files[index]);
         }
@@ -49,7 +54,7 @@ namespace SoulsFormats
         /// <summary>
         /// Reads file data according to the given header.
         /// </summary>
-        public byte[] ReadFile(BinderFileHeader fileHeader)
+        public Memory<byte> ReadFile(BinderFileHeader fileHeader)
         {
             BinderFile file = fileHeader.ReadFileData(DataBR);
             return file.Bytes;
@@ -67,7 +72,8 @@ namespace SoulsFormats
             {
                 if (disposing)
                 {
-                    DataBR?.Stream?.Dispose();
+                    _mappedAccessor?.Dispose();
+                    _mappedFile?.Dispose();
                 }
 
                 disposedValue = true;

--- a/SoulsFormats/SoulsFormats/Formats/BHD5.cs
+++ b/SoulsFormats/SoulsFormats/Formats/BHD5.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -38,9 +39,9 @@ namespace SoulsFormats
         /// <summary>
         /// Read a dvdbnd header from the given stream, formatted for the given game. Must already be decrypted, if applicable.
         /// </summary>
-        public static BHD5 Read(Stream bhdStream, Game game)
+        public static BHD5 Read(Memory<byte> bytes, Game game)
         {
-            var br = new BinaryReaderEx(false, bhdStream);
+            var br = new BinaryReaderEx(false, bytes);
             return new BHD5(br, game);
         }
 

--- a/SoulsFormats/SoulsFormats/Formats/EMEVD/Instruction.cs
+++ b/SoulsFormats/SoulsFormats/Formats/EMEVD/Instruction.cs
@@ -289,36 +289,33 @@ namespace SoulsFormats
             public List<object> UnpackArgs(IEnumerable<ArgType> argStruct, bool bigEndian = false)
             {
                 var result = new List<object>();
-                using (var ms = new MemoryStream(ArgData))
+                var br = new BinaryReaderEx(bigEndian, ArgData);
+                foreach (ArgType arg in argStruct)
                 {
-                    var br = new BinaryReaderEx(bigEndian, ms);
-                    foreach (ArgType arg in argStruct)
+                    switch (arg)
                     {
-                        switch (arg)
-                        {
-                            case ArgType.Byte:
-                                result.Add(br.ReadByte()); break;
-                            case ArgType.UInt16:
-                                br.Pad(2);
-                                result.Add(br.ReadUInt16()); break;
-                            case ArgType.UInt32:
-                                br.Pad(4);
-                                result.Add(br.ReadUInt32()); break;
-                            case ArgType.SByte:
-                                result.Add(br.ReadSByte()); break;
-                            case ArgType.Int16:
-                                br.Pad(2);
-                                result.Add(br.ReadInt16()); break;
-                            case ArgType.Int32:
-                                br.Pad(4);
-                                result.Add(br.ReadInt32()); break;
-                            case ArgType.Single:
-                                br.Pad(4);
-                                result.Add(br.ReadSingle()); break;
+                        case ArgType.Byte:
+                            result.Add(br.ReadByte()); break;
+                        case ArgType.UInt16:
+                            br.Pad(2);
+                            result.Add(br.ReadUInt16()); break;
+                        case ArgType.UInt32:
+                            br.Pad(4);
+                            result.Add(br.ReadUInt32()); break;
+                        case ArgType.SByte:
+                            result.Add(br.ReadSByte()); break;
+                        case ArgType.Int16:
+                            br.Pad(2);
+                            result.Add(br.ReadInt16()); break;
+                        case ArgType.Int32:
+                            br.Pad(4);
+                            result.Add(br.ReadInt32()); break;
+                        case ArgType.Single:
+                            br.Pad(4);
+                            result.Add(br.ReadSingle()); break;
 
-                            default:
-                                throw new NotImplementedException($"Unimplemented argument type: {arg}");
-                        }
+                        default:
+                            throw new NotImplementedException($"Unimplemented argument type: {arg}");
                     }
                 }
 

--- a/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/FLVER2.cs
+++ b/SoulsFormats/SoulsFormats/Formats/FLVER/FLVER2/FLVER2.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.IO;
+using System.IO.MemoryMappedFiles;
+using DotNext.IO.MemoryMappedFiles;
 
 namespace SoulsFormats
 {
@@ -74,7 +76,7 @@ namespace SoulsFormats
         /// <summary>
         /// Creates a FLVER with a preset cache
         /// </summary>
-        public static FLVER2 Read(byte[] bytes, FlverCache cache)
+        public static FLVER2 Read(Memory<byte> bytes, FlverCache cache)
         {
             BinaryReaderEx br = new BinaryReaderEx(false, bytes);
             FLVER2 file = new FLVER2();
@@ -91,17 +93,16 @@ namespace SoulsFormats
         /// </summary>
         public static FLVER2 Read(string path, FlverCache cache)
         {
-            using (FileStream stream = File.OpenRead(path))
-            {
-                BinaryReaderEx br = new BinaryReaderEx(false, stream);
-                FLVER2 file = new FLVER2();
-                file.Cache = cache;
-                DCX.Type ctype;
-                br = SFUtil.GetDecompressedBR(br, out ctype);
-                file.Compression = ctype;
-                file.Read(br);
-                return file;
-            }
+            using var file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var accessor = file.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            BinaryReaderEx br = new BinaryReaderEx(false, accessor.Memory);
+            FLVER2 ret = new FLVER2();
+            ret.Cache = cache;
+            DCX.Type ctype;
+            br = SFUtil.GetDecompressedBR(br, out ctype);
+            ret.Compression = ctype;
+            ret.Read(br);
+            return ret;
         }
 
         /// <summary>

--- a/SoulsFormats/SoulsFormats/Formats/HKX/HKX.cs
+++ b/SoulsFormats/SoulsFormats/Formats/HKX/HKX.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.IO;
+using System.IO.MemoryMappedFiles;
 using System.Numerics;
+using DotNext.IO.MemoryMappedFiles;
 
 namespace SoulsFormats
 {
@@ -110,21 +112,20 @@ namespace SoulsFormats
 
         public static HKX Read(string path, HKXVariation variation, bool deserializeObjects = true)
         {
-            using (FileStream stream = File.OpenRead(path))
-            {
-                BinaryReaderEx br = new BinaryReaderEx(false, stream);
-                HKX file = new HKX();
-                file.Variation = variation;
-                file.DeserializeObjects = deserializeObjects;
-                DCX.Type ctype;
-                br = SFUtil.GetDecompressedBR(br, out ctype);
-                file.Compression = ctype;
-                file.Read(br);
-                return file;
-            }
+            using var file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var accessor = file.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            BinaryReaderEx br = new BinaryReaderEx(false, accessor.Memory);
+            HKX ret = new HKX();
+            ret.Variation = variation;
+            ret.DeserializeObjects = deserializeObjects;
+            DCX.Type ctype;
+            br = SFUtil.GetDecompressedBR(br, out ctype);
+            ret.Compression = ctype;
+            ret.Read(br);
+            return ret;
         }
 
-        public static HKX Read(byte[] data, HKXVariation variation, bool deserializeObjects = true)
+        public static HKX Read(Memory<byte> data, HKXVariation variation, bool deserializeObjects = true)
         {
             BinaryReaderEx br = new BinaryReaderEx(false, data);
             HKX file = new HKX();
@@ -142,7 +143,7 @@ namespace SoulsFormats
             return Read(path, HKXVariation.HKXDS3, deserializeObjects);
         }
 
-        public static HKX Read(byte[] data, bool deserializeObjects = true)
+        public static HKX Read(Memory<byte> data, bool deserializeObjects = true)
         {
             return Read(data, HKXVariation.HKXDS3, deserializeObjects);
         }

--- a/SoulsFormats/SoulsFormats/Formats/PARAM/PARAM/PARAM.cs
+++ b/SoulsFormats/SoulsFormats/Formats/PARAM/PARAM/PARAM.cs
@@ -73,7 +73,7 @@ namespace SoulsFormats
             br.Position = 0;
 
             // Make a private copy of the file to read row data from later
-            byte[] copy = br.GetBytes(0, (int)br.Stream.Length);
+            byte[] copy = br.GetBytes(0, (int)br.Length);
             RowReader = new BinaryReaderEx(BigEndian, copy);
 
             // The strings offset in the header is highly unreliable; only use it as a last resort

--- a/SoulsFormats/SoulsFormats/Formats/TAE/TAE.cs
+++ b/SoulsFormats/SoulsFormats/Formats/TAE/TAE.cs
@@ -1026,46 +1026,43 @@ namespace SoulsFormats
                 {
                     parameterValues = new Dictionary<string, object>();
                     Template = template;
-                    using (var memStream = new System.IO.MemoryStream(paramData))
+                    var br = new BinaryReaderEx(bigEndian, paramData);
+                    int i = 0;
+                    foreach (var paramKvp in Template)
                     {
-                        var br = new BinaryReaderEx(bigEndian, memStream);
-                        int i = 0;
-                        foreach (var paramKvp in Template)
+                        var p = paramKvp.Value;
+                        if (p.ValueToAssert != null)
                         {
-                            var p = paramKvp.Value;
-                            if (p.ValueToAssert != null)
+                            try
                             {
-                                try
-                                {
-                                    p.AssertValue(br);
-                                }
-                                catch (System.IO.InvalidDataException ex)
-                                {
-                                    var txtField = p.Name != null ? $"'{p.Name}'" : $"{(i + 1)} of {Template.Count}";
-                                    var txtEventType = Template.Name != null ? $"'{Template.Name}'" : Template.ID.ToString();
-
-                                    throw new Exception($"Animation {animID}\nEvent[{eventIndex}] (Type: {txtEventType})" +
-                                            $"\n  -> Assert failed on field {txtField} (Type: {p.Type})", ex);
-                                }
+                                p.AssertValue(br);
                             }
-                            else
+                            catch (System.IO.InvalidDataException ex)
                             {
-                                
-                                try
-                                {
-                                    parameterValues.Add(p.Name, p.ReadValue(br));
-                                }
-                                catch (Exception ex)
-                                {
-                                    var txtField = p.Name != null ? $"'{p.Name}'" : $"{(i + 1)} of {Template.Count}";
-                                    var txtEventType = Template.Name != null ? $"'{Template.Name}'" : Template.ID.ToString();
+                                var txtField = p.Name != null ? $"'{p.Name}'" : $"{(i + 1)} of {Template.Count}";
+                                var txtEventType = Template.Name != null ? $"'{Template.Name}'" : Template.ID.ToString();
 
-                                    throw new Exception($"Animation {animID}\nEvent[{eventIndex}] (Type: {txtEventType})" +
-                                            $"\n  -> Failed to read value of field {txtField} (Type: {p.Type})", ex);
-                                }
+                                throw new Exception($"Animation {animID}\nEvent[{eventIndex}] (Type: {txtEventType})" +
+                                                    $"\n  -> Assert failed on field {txtField} (Type: {p.Type})", ex);
                             }
-                            i++;
                         }
+                        else
+                        {
+                                
+                            try
+                            {
+                                parameterValues.Add(p.Name, p.ReadValue(br));
+                            }
+                            catch (Exception ex)
+                            {
+                                var txtField = p.Name != null ? $"'{p.Name}'" : $"{(i + 1)} of {Template.Count}";
+                                var txtEventType = Template.Name != null ? $"'{Template.Name}'" : Template.ID.ToString();
+
+                                throw new Exception($"Animation {animID}\nEvent[{eventIndex}] (Type: {txtEventType})" +
+                                                    $"\n  -> Failed to read value of field {txtField} (Type: {p.Type})", ex);
+                            }
+                        }
+                        i++;
                     }
                 }
 
@@ -1073,45 +1070,42 @@ namespace SoulsFormats
                 {
                     parameterValues = new Dictionary<string, object>();
                     Template = template;
-                    using (var memStream = new System.IO.MemoryStream(paramData))
+                    var br = new BinaryReaderEx(bigEndian, paramData);
+                    int i = 0;
+                    foreach (var paramKvp in Template)
                     {
-                        var br = new BinaryReaderEx(bigEndian, memStream);
-                        int i = 0;
-                        foreach (var paramKvp in Template)
+                        var p = paramKvp.Value;
+                        if (p.ValueToAssert != null)
                         {
-                            var p = paramKvp.Value;
-                            if (p.ValueToAssert != null)
+                            try
                             {
-                                try
-                                {
-                                    p.AssertValue(br);
-                                }
-                                catch (System.IO.InvalidDataException ex)
-                                {
-                                    var txtField = p.Name != null ? $"'{p.Name}'" : $"{(i + 1)} of {Template.Count}";
-                                    var txtEventType = Template.Name != null ? $"'{Template.Name}'" : Template.ID.ToString();
-
-                                    throw new Exception($"Event Type: {txtEventType}" +
-                                            $"\n  -> Assert failed on field {txtField}", ex);
-                                }
+                                p.AssertValue(br);
                             }
-                            else
+                            catch (System.IO.InvalidDataException ex)
                             {
-                                try
-                                {
-                                    parameterValues.Add(p.Name, p.ReadValue(br));
-                                }
-                                catch (Exception ex)
-                                {
-                                    var txtField = p.Name != null ? $"'{p.Name}'" : $"{(i + 1)} of {Template.Count}";
-                                    var txtEventType = Template.Name != null ? $"'{Template.Name}'" : Template.ID.ToString();
+                                var txtField = p.Name != null ? $"'{p.Name}'" : $"{(i + 1)} of {Template.Count}";
+                                var txtEventType = Template.Name != null ? $"'{Template.Name}'" : Template.ID.ToString();
 
-                                    throw new Exception($"Event Type: {txtEventType}" +
-                                            $"\n  -> Failed to read value of field {txtField} (Type: {p.Type})", ex);
-                                }
+                                throw new Exception($"Event Type: {txtEventType}" +
+                                                    $"\n  -> Assert failed on field {txtField}", ex);
                             }
-                            i++;
                         }
+                        else
+                        {
+                            try
+                            {
+                                parameterValues.Add(p.Name, p.ReadValue(br));
+                            }
+                            catch (Exception ex)
+                            {
+                                var txtField = p.Name != null ? $"'{p.Name}'" : $"{(i + 1)} of {Template.Count}";
+                                var txtEventType = Template.Name != null ? $"'{Template.Name}'" : Template.ID.ToString();
+
+                                throw new Exception($"Event Type: {txtEventType}" +
+                                                    $"\n  -> Failed to read value of field {txtField} (Type: {p.Type})", ex);
+                            }
+                        }
+                        i++;
                     }
                 }
 

--- a/SoulsFormats/SoulsFormats/Formats/TPF/DDS.cs
+++ b/SoulsFormats/SoulsFormats/Formats/TPF/DDS.cs
@@ -39,7 +39,7 @@ namespace SoulsFormats
         /// <summary>
         /// Read a DDS header from an array of bytes.
         /// </summary>
-        public DDS(byte[] bytes)
+        public DDS(Memory<byte> bytes)
         {
             var br = new BinaryReaderEx(false, bytes);
 
@@ -68,7 +68,7 @@ namespace SoulsFormats
         /// <summary>
         /// Write a DDS file from this header object and given pixel data.
         /// </summary>
-        public byte[] Write(byte[] pixelData)
+        public byte[] Write(Span<byte> pixelData)
         {
             var bw = new BinaryWriterEx(false);
 

--- a/SoulsFormats/SoulsFormats/Formats/TPF/TPF.cs
+++ b/SoulsFormats/SoulsFormats/Formats/TPF/TPF.cs
@@ -147,7 +147,7 @@ namespace SoulsFormats
             /// <summary>
             /// The raw data of the texture.
             /// </summary>
-            public byte[] Bytes { get; set; }
+            public Memory<byte> Bytes { get; set; }
 
             /// <summary>
             /// Extended metadata present in headerless console TPF textures.
@@ -311,18 +311,18 @@ namespace SoulsFormats
             {
                 bw.FillUInt32($"FileData{index}", (uint)bw.Position);
 
-                byte[] bytes = Bytes;
+                Memory<byte> bytes = Bytes;
                 if (Flags1 == 2 || Flags1 == 3)
-                    bytes = DCX.Compress(bytes, DCX.Type.DCP_EDGE);
+                    bytes = DCX.Compress(bytes.Span, DCX.Type.DCP_EDGE);
 
                 bw.FillInt32($"FileSize{index}", bytes.Length);
-                bw.WriteBytes(bytes);
+                bw.WriteBytes(bytes.Span);
             }
 
             /// <summary>
             /// Attempt to create a full DDS file from headerless console textures. Very very very poor support at the moment.
             /// </summary>
-            public byte[] Headerize()
+            public Memory<byte> Headerize()
             {
                 return Headerizer.Headerize(this);
             }

--- a/SoulsFormats/SoulsFormats/SoulsFormats.csproj
+++ b/SoulsFormats/SoulsFormats/SoulsFormats.csproj
@@ -20,6 +20,9 @@
 
   <ItemGroup>
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
+    <PackageReference Include="DotNext.IO" Version="4.12.4" />
+    <PackageReference Include="DotNext.Unsafe" Version="4.12.4" />
+    <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/SoulsFormats/SoulsFormats/Util/SFUtil.cs
+++ b/SoulsFormats/SoulsFormats/Util/SFUtil.cs
@@ -18,7 +18,7 @@ namespace SoulsFormats
         /// <summary>
         /// Guesses the extension of a file based on its contents.
         /// </summary>
-        public static string GuessExtension(byte[] bytes, bool bigEndian = false)
+        public static string GuessExtension(Memory<byte> bytes, bool bigEndian = false)
         {
             bool dcx = false;
             if (DCX.Is(bytes))
@@ -70,80 +70,81 @@ namespace SoulsFormats
                         return i < br.Length - 2 && br.GetASCII(i + 1, 2) == "\r\n";
                     }
                 }
+
                 return false;
             }
 
             string ext = "";
-            using (var ms = new MemoryStream(bytes))
-            {
-                var br = new BinaryReaderEx(bigEndian, ms);
-                string magic = null;
-                if (br.Length >= 4)
-                    magic = br.ReadASCII(4);
 
-                if (magic == "AISD")
-                    ext = ".aisd";
-                else if (magic == "BDF3" || magic == "BDF4")
-                    ext = ".bdt";
-                else if (magic == "BHF3" || magic == "BHF4")
-                    ext = ".bhd";
-                else if (magic == "BND3" || magic == "BND4")
-                    ext = ".bnd";
-                else if (magic == "DDS ")
-                    ext = ".dds";
-                // ESD or FFX
-                else if (magic != null && magic.ToUpper() == "DLSE")
-                    ext = ".dlse";
-                else if (bigEndian && magic == "\0BRD" || !bigEndian && magic == "DRB\0")
-                    ext = ".drb";
-                else if (magic == "EDF\0")
-                    ext = ".edf";
-                else if (magic == "ELD\0")
-                    ext = ".eld";
-                else if (magic == "ENFL")
-                    ext = ".entryfilelist";
-                else if (magic != null && magic.ToUpper() == "FSSL")
-                    ext = ".esd";
-                else if (magic == "EVD\0")
-                    ext = ".evd";
-                else if (br.Length >= 3 && br.GetASCII(0, 3) == "FEV" || br.Length >= 0x10 && br.GetASCII(8, 8) == "FEV FMT ")
-                    ext = ".fev";
-                else if (br.Length >= 6 && br.GetASCII(0, 6) == "FLVER\0")
-                    ext = ".flver";
-                else if (br.Length >= 3 && br.GetASCII(0, 3) == "FSB")
-                    ext = ".fsb";
-                else if (br.Length >= 3 && br.GetASCII(0, 3) == "GFX")
-                    ext = ".gfx";
-                else if (br.Length >= 0x19 && br.GetASCII(0xC, 0xE) == "ITLIMITER_INFO")
-                    ext = ".itl";
-                else if (br.Length >= 4 && br.GetASCII(1, 3) == "Lua")
-                    ext = ".lua";
-                else if (checkMsb(br))
-                    ext = ".msb";
-                else if (br.Length >= 0x30 && br.GetASCII(0x2C, 4) == "MTD ")
-                    ext = ".mtd";
-                else if (magic == "DFPN")
-                    ext = ".nfd";
-                else if (checkParam(br))
-                    ext = ".param";
-                else if (br.Length >= 4 && br.GetASCII(1, 3) == "PNG")
-                    ext = ".png";
-                else if (br.Length >= 0x2C && br.GetASCII(0x28, 4) == "SIB ")
-                    ext = ".sib";
-                else if (magic == "TAE ")
-                    ext = ".tae";
-                else if (checkTdf(br))
-                    ext = ".tdf";
-                else if (magic == "TPF\0")
-                    ext = ".tpf";
-                else if (magic == "#BOM")
-                    ext = ".txt";
-                else if (br.Length >= 5 && br.GetASCII(0, 5) == "<?xml")
-                    ext = ".xml";
-                // This is pretty sketchy
-                else if (br.Length >= 0xC && br.GetByte(0) == 0 && br.GetByte(3) == 0 && br.GetInt32(4) == br.Length && br.GetInt16(0xA) == 0)
-                    ext = ".fmg";
-            }
+            var br = new BinaryReaderEx(bigEndian, bytes);
+            string magic = null;
+            if (br.Length >= 4)
+                magic = br.ReadASCII(4);
+
+            if (magic == "AISD")
+                ext = ".aisd";
+            else if (magic == "BDF3" || magic == "BDF4")
+                ext = ".bdt";
+            else if (magic == "BHF3" || magic == "BHF4")
+                ext = ".bhd";
+            else if (magic == "BND3" || magic == "BND4")
+                ext = ".bnd";
+            else if (magic == "DDS ")
+                ext = ".dds";
+            // ESD or FFX
+            else if (magic != null && magic.ToUpper() == "DLSE")
+                ext = ".dlse";
+            else if (bigEndian && magic == "\0BRD" || !bigEndian && magic == "DRB\0")
+                ext = ".drb";
+            else if (magic == "EDF\0")
+                ext = ".edf";
+            else if (magic == "ELD\0")
+                ext = ".eld";
+            else if (magic == "ENFL")
+                ext = ".entryfilelist";
+            else if (magic != null && magic.ToUpper() == "FSSL")
+                ext = ".esd";
+            else if (magic == "EVD\0")
+                ext = ".evd";
+            else if (br.Length >= 3 && br.GetASCII(0, 3) == "FEV" ||
+                     br.Length >= 0x10 && br.GetASCII(8, 8) == "FEV FMT ")
+                ext = ".fev";
+            else if (br.Length >= 6 && br.GetASCII(0, 6) == "FLVER\0")
+                ext = ".flver";
+            else if (br.Length >= 3 && br.GetASCII(0, 3) == "FSB")
+                ext = ".fsb";
+            else if (br.Length >= 3 && br.GetASCII(0, 3) == "GFX")
+                ext = ".gfx";
+            else if (br.Length >= 0x19 && br.GetASCII(0xC, 0xE) == "ITLIMITER_INFO")
+                ext = ".itl";
+            else if (br.Length >= 4 && br.GetASCII(1, 3) == "Lua")
+                ext = ".lua";
+            else if (checkMsb(br))
+                ext = ".msb";
+            else if (br.Length >= 0x30 && br.GetASCII(0x2C, 4) == "MTD ")
+                ext = ".mtd";
+            else if (magic == "DFPN")
+                ext = ".nfd";
+            else if (checkParam(br))
+                ext = ".param";
+            else if (br.Length >= 4 && br.GetASCII(1, 3) == "PNG")
+                ext = ".png";
+            else if (br.Length >= 0x2C && br.GetASCII(0x28, 4) == "SIB ")
+                ext = ".sib";
+            else if (magic == "TAE ")
+                ext = ".tae";
+            else if (checkTdf(br))
+                ext = ".tdf";
+            else if (magic == "TPF\0")
+                ext = ".tpf";
+            else if (magic == "#BOM")
+                ext = ".txt";
+            else if (br.Length >= 5 && br.GetASCII(0, 5) == "<?xml")
+                ext = ".xml";
+            // This is pretty sketchy
+            else if (br.Length >= 0xC && br.GetByte(0) == 0 && br.GetByte(3) == 0 && br.GetInt32(4) == br.Length &&
+                     br.GetInt16(0xA) == 0)
+                ext = ".fmg";
 
             if (dcx)
                 return ext + ".dcx";
@@ -208,7 +209,7 @@ namespace SoulsFormats
         {
             if (DCX.Is(br))
             {
-                byte[] bytes = DCX.Decompress(br, out compression);
+                Memory<byte> bytes = DCX.Decompress(br, out compression);
                 return new BinaryReaderEx(false, bytes);
             }
             else
@@ -290,18 +291,19 @@ namespace SoulsFormats
         /// <summary>
         /// Compresses data and writes it to a BinaryWriterEx with Zlib wrapper.
         /// </summary>
-        public static int WriteZlib(BinaryWriterEx bw, byte formatByte, byte[] input)
+        public static int WriteZlib(BinaryWriterEx bw, byte formatByte, Span<byte> input)
         {
             long start = bw.Position;
             bw.WriteByte(0x78);
             bw.WriteByte(formatByte);
 
+            var data = input.ToArray();
             using (var deflateStream = new DeflateStream(bw.Stream, CompressionMode.Compress, true))
             {
-                deflateStream.Write(input, 0, input.Length);
+                deflateStream.Write(data, 0, input.Length);
             }
 
-            bw.WriteUInt32(Adler32(input));
+            bw.WriteUInt32(Adler32(data));
             return (int)(bw.Position - start);
         }
 

--- a/SoulsFormats/SoulsFormats/Util/SoulsFile.cs
+++ b/SoulsFormats/SoulsFormats/Util/SoulsFile.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.IO.MemoryMappedFiles;
+using DotNext.IO.MemoryMappedFiles;
 
 namespace SoulsFormats
 {
@@ -40,15 +42,14 @@ namespace SoulsFormats
         /// </summary>
         public static bool Is(string path)
         {
-            using (FileStream stream = File.OpenRead(path))
-            {
-                if (stream.Length == 0)
-                    return false;
+            using var file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var accessor = file.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            if (accessor.Size == 0)
+                return false;
 
-                BinaryReaderEx br = new BinaryReaderEx(false, stream);
-                var dummy = new TFormat();
-                return dummy.Is(SFUtil.GetDecompressedBR(br, out _));
-            }
+            BinaryReaderEx br = new BinaryReaderEx(false, accessor.Memory);
+            var dummy = new TFormat();
+            return dummy.Is(SFUtil.GetDecompressedBR(br, out _));
         }
 
         /// <summary>
@@ -62,7 +63,7 @@ namespace SoulsFormats
         /// <summary>
         /// Loads a file from a byte array, automatically decompressing it if necessary.
         /// </summary>
-        public static TFormat Read(byte[] bytes)
+        public static TFormat Read(Memory<byte> bytes)
         {
             BinaryReaderEx br = new BinaryReaderEx(false, bytes);
             TFormat file = new TFormat();
@@ -77,15 +78,14 @@ namespace SoulsFormats
         /// </summary>
         public static TFormat Read(string path)
         {
-            using (FileStream stream = File.OpenRead(path))
-            {
-                BinaryReaderEx br = new BinaryReaderEx(false, stream);
-                TFormat file = new TFormat();
-                br = SFUtil.GetDecompressedBR(br, out DCX.Type compression);
-                file.Compression = compression;
-                file.Read(br);
-                return file;
-            }
+            using var file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var accessor = file.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            BinaryReaderEx br = new BinaryReaderEx(false, accessor.Memory);
+            TFormat ret = new TFormat();
+            br = SFUtil.GetDecompressedBR(br, out DCX.Type compression);
+            ret.Compression = compression;
+            ret.Read(br);
+            return ret;
         }
 
         private static bool IsRead(BinaryReaderEx br, out TFormat file)
@@ -119,13 +119,12 @@ namespace SoulsFormats
         /// <summary>
         /// Returns whether the file appears to be a file of this type and reads it if so.
         /// </summary>
-        public static bool IsRead(string path, out TFormat file)
+        public static bool IsRead(string path, out TFormat ret)
         {
-            using (FileStream fs = File.OpenRead(path))
-            {
-                var br = new BinaryReaderEx(false, fs);
-                return IsRead(br, out file);
-            }
+            using var file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var accessor = file.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            var br = new BinaryReaderEx(false, accessor.Memory);
+            return IsRead(br, out ret);
         }
 
         /// <summary>

--- a/StudioCore/Resource/FlverResource.cs
+++ b/StudioCore/Resource/FlverResource.cs
@@ -17,7 +17,9 @@ using System.ComponentModel.DataAnnotations;
 using StudioCore.MsbEditor;
 using StudioCore.Scene;
 using System.Data;
+using System.IO.MemoryMappedFiles;
 using System.Threading.Tasks.Dataflow;
+using DotNext.IO.MemoryMappedFiles;
 
 namespace StudioCore.Resource
 {
@@ -594,15 +596,15 @@ namespace StudioCore.Resource
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void FillVertex(ref Vector3 dest, BinaryReaderEx br, FLVER.LayoutType type)
+        private unsafe void FillVertex(Vector3 *dest, BinaryReaderEx br, FLVER.LayoutType type)
         {
             if (type == FLVER.LayoutType.Float3)
             {
-                dest = br.ReadVector3();
+                *dest = br.ReadVector3();
             }
             else if (type == FLVER.LayoutType.Float4)
             {
-                dest = br.ReadVector3();
+                *dest = br.ReadVector3();
                 br.AssertSingle(0);
             }
             else
@@ -628,16 +630,16 @@ namespace StudioCore.Resource
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe void FillNormalSNorm8(sbyte* dest, BinaryReaderEx br, FLVER.LayoutType type, ref Vector3 n)
+        private unsafe void FillNormalSNorm8(sbyte* dest, BinaryReaderEx br, FLVER.LayoutType type, Vector3 *n)
         {
             int nw = 0;
             if (type == FLVER.LayoutType.Float3)
             {
-                n = br.ReadVector3();
+                *n = br.ReadVector3();
             }
             else if (type == FLVER.LayoutType.Float4)
             {
-                n = br.ReadVector3();
+                *n = br.ReadVector3();
                 float w = br.ReadSingle();
                 nw = (int)w;
                 if (w != nw)
@@ -645,46 +647,46 @@ namespace StudioCore.Resource
             }
             else if (type == FLVER.LayoutType.Byte4A)
             {
-                n = FLVER.Vertex.ReadByteNormXYZ(br);
+                *n = FLVER.Vertex.ReadByteNormXYZ(br);
                 nw = br.ReadByte();
             }
             else if (type == FLVER.LayoutType.Byte4B)
             {
-                n = FLVER.Vertex.ReadByteNormXYZ(br);
+                *n = FLVER.Vertex.ReadByteNormXYZ(br);
                 nw = br.ReadByte();
             }
             else if (type == FLVER.LayoutType.Short2toFloat2)
             {
                 nw = br.ReadByte();
-                n = FLVER.Vertex.ReadSByteNormZYX(br);
+                *n = FLVER.Vertex.ReadSByteNormZYX(br);
             }
             else if (type == FLVER.LayoutType.Byte4C)
             {
-                n = FLVER.Vertex.ReadByteNormXYZ(br);
+                *n = FLVER.Vertex.ReadByteNormXYZ(br);
                 nw = br.ReadByte();
             }
             else if (type == FLVER.LayoutType.Short4toFloat4A)
             {
-                n = FLVER.Vertex.ReadShortNormXYZ(br);
+                *n = FLVER.Vertex.ReadShortNormXYZ(br);
                 nw = br.ReadInt16();
             }
             else if (type == FLVER.LayoutType.Short4toFloat4B)
             {
                 //Normal = ReadUShortNormXYZ(br);
-                n = FLVER.Vertex.ReadFloat16NormXYZ(br);
+                *n = FLVER.Vertex.ReadFloat16NormXYZ(br);
                 nw = br.ReadInt16();
             }
             else if (type == FLVER.LayoutType.Byte4E)
             {
-                n = FLVER.Vertex.ReadByteNormXYZ(br);
+                *n = FLVER.Vertex.ReadByteNormXYZ(br);
                 nw = br.ReadByte();
             }
             else
                 throw new NotImplementedException($"Read not implemented for {type} normal.");
 
-            dest[0] = (sbyte)(n.X * 127.0f);
-            dest[1] = (sbyte)(n.Y * 127.0f);
-            dest[2] = (sbyte)(n.Z * 127.0f);
+            dest[0] = (sbyte)(n->X * 127.0f);
+            dest[1] = (sbyte)(n->Y * 127.0f);
+            dest[2] = (sbyte)(n->Z * 127.0f);
             dest[3] = (sbyte)nw;
         }
 
@@ -794,7 +796,7 @@ namespace StudioCore.Resource
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe void FillBinormalBitangentSNorm8(sbyte* destBinorm, sbyte* destBitan, ref Vector3 n, BinaryReaderEx br, FLVER.LayoutType type)
+        private unsafe void FillBinormalBitangentSNorm8(sbyte* destBinorm, sbyte* destBitan, Vector3* n, BinaryReaderEx br, FLVER.LayoutType type)
         {
             Vector4 tan;
             if (type == FLVER.LayoutType.Float4)
@@ -832,7 +834,7 @@ namespace StudioCore.Resource
             destBitan[2] = (sbyte)(t.Z * 127.0f);
             destBitan[3] = (sbyte)(tan.W * 127.0f);
 
-            var bn = Vector3.Cross(Vector3.Normalize(n), Vector3.Normalize(new Vector3(t.X, t.Y, t.Z))) * tan.W;
+            var bn = Vector3.Cross(Vector3.Normalize(*n), Vector3.Normalize(new Vector3(t.X, t.Y, t.Z))) * tan.W;
             destBinorm[0] = (sbyte)(bn.X * 127.0f);
             destBinorm[1] = (sbyte)(bn.Y * 127.0f);
             destBinorm[2] = (sbyte)(bn.Z * 127.0f);
@@ -912,12 +914,12 @@ namespace StudioCore.Resource
                             continue;
                         if (l.semantic == FLVER.LayoutSemantic.Position)
                         {
-                            FillVertex(ref (*v).Position, br, l.type);
+                            FillVertex(&(*v).Position, br, l.type);
                             posfilled = true;
                         }
                         else if (l.semantic == FLVER.LayoutSemantic.Normal)
                         {
-                            FillNormalSNorm8((*v).Normal, br, l.type, ref n);
+                            FillNormalSNorm8((*v).Normal, br, l.type, &n);
                         }
                         else
                         {
@@ -968,52 +970,54 @@ namespace StudioCore.Resource
             }
         }
 
-        unsafe private void FillVerticesStandard(BinaryReaderEx br, ref FlverVertexBuffer buffer, Span<FlverBufferLayoutMember> layouts, Span<Vector3> pickingVerts, IntPtr vertBuffer, float uvFactor)
+        private unsafe void FillVerticesStandard(BinaryReaderEx br, ref FlverVertexBuffer buffer,
+            Span<FlverBufferLayoutMember> layouts, Span<Vector3> pickingVerts, IntPtr vertBuffer, float uvFactor)
         {
-            Span<FlverLayout> verts = new Span<FlverLayout>(vertBuffer.ToPointer(), buffer.vertexCount);
             br.StepIn(buffer.bufferOffset);
+            FlverLayout* pverts = (FlverLayout*)vertBuffer;
+
             for (int i = 0; i < buffer.vertexCount; i++)
             {
-                fixed (FlverLayout* v = &verts[i])
+                FlverLayout* v = &pverts[i];
+                Vector3 n = Vector3.UnitX;
+                FillUVShortZero((*v).Uv1);
+                FillBinormalBitangentSNorm8Zero((*v).Binormal, (*v).Bitangent);
+                bool posfilled = false;
+                foreach (var l in layouts)
                 {
-                    Vector3 n = Vector3.UnitX;
-                    FillUVShortZero((*v).Uv1);
-                    FillBinormalBitangentSNorm8Zero((*v).Binormal, (*v).Bitangent);
-                    bool posfilled = false;
-                    foreach (var l in layouts)
+                    // ER meme
+                    if (l.unk00 == -2147483647)
+                        continue;
+                    if (l.semantic == FLVER.LayoutSemantic.Position)
                     {
-                        // ER meme
-                        if (l.unk00 == -2147483647)
-                            continue;
-                        if (l.semantic == FLVER.LayoutSemantic.Position)
-                        {
-                            FillVertex(ref (*v).Position, br, l.type);
-                            posfilled = true;
-                        }
-                        else if (l.semantic == FLVER.LayoutSemantic.Normal)
-                        {
-                            FillNormalSNorm8((*v).Normal, br, l.type, ref n);
-                        }
-                        else if (l.semantic == FLVER.LayoutSemantic.UV && l.index == 0)
-                        {
-                            bool hasv2;
-                            FillUVShort((*v).Uv1, br, l.type, uvFactor, false, out hasv2);
-                        }
-                        else if (l.semantic == FLVER.LayoutSemantic.Tangent && l.index == 0)
-                        {
-                            FillBinormalBitangentSNorm8((*v).Binormal, (*v).Bitangent, ref n, br, l.type);
-                        }
-                        else
-                        {
-                            EatVertex(br, l.type);
-                        }
+                        FillVertex(&(*v).Position, br, l.type);
+                        posfilled = true;
                     }
-                    if (!posfilled)
+                    else if (l.semantic == FLVER.LayoutSemantic.Normal)
                     {
-                        (*v).Position = new Vector3(0, 0, 0);
+                        FillNormalSNorm8((*v).Normal, br, l.type, &n);
                     }
-                    pickingVerts[i] = (*v).Position;
+                    else if (l.semantic == FLVER.LayoutSemantic.UV && l.index == 0)
+                    {
+                        bool hasv2;
+                        FillUVShort((*v).Uv1, br, l.type, uvFactor, false, out hasv2);
+                    }
+                    else if (l.semantic == FLVER.LayoutSemantic.Tangent && l.index == 0)
+                    {
+                        FillBinormalBitangentSNorm8((*v).Binormal, (*v).Bitangent, &n, br, l.type);
+                    }
+                    else
+                    {
+                        EatVertex(br, l.type);
+                    }
                 }
+
+                if (!posfilled)
+                {
+                    (*v).Position = new Vector3(0, 0, 0);
+                }
+
+                pickingVerts[i] = (*v).Position;
             }
             br.StepOut();
         }
@@ -1021,14 +1025,15 @@ namespace StudioCore.Resource
         unsafe private void FillVerticesStandard(FLVER2.Mesh mesh, Span<Vector3> pickingVerts, IntPtr vertBuffer)
         {
             Span<FlverLayout> verts = new Span<FlverLayout>(vertBuffer.ToPointer(), mesh.VertexCount);
-            for (int i = 0; i < mesh.VertexCount; i++)
+            fixed (FlverLayout* pverts = verts)
             {
-                var vert = mesh.Vertices[i];
-
-                verts[i] = new FlverLayout();
-                pickingVerts[i] = new Vector3(vert.Position.X, vert.Position.Y, vert.Position.Z);
-                fixed (FlverLayout* v = &verts[i])
+                for (int i = 0; i < mesh.VertexCount; i++)
                 {
+                    FlverLayout* v = &pverts[i];
+                    var vert = mesh.Vertices[i];
+
+                    verts[i] = new FlverLayout();
+                    pickingVerts[i] = new Vector3(vert.Position.X, vert.Position.Y, vert.Position.Z);
                     FillVertex(ref (*v).Position, ref vert);
                     FillNormalSNorm8((*v).Normal, ref vert);
                     if (vert.UVCount > 0)
@@ -1039,6 +1044,7 @@ namespace StudioCore.Resource
                     {
                         FillUVShortZero((*v).Uv1);
                     }
+
                     if (vert.TangentCount > 0)
                     {
                         FillBinormalBitangentSNorm8((*v).Binormal, (*v).Bitangent, ref vert, 0);
@@ -1054,14 +1060,15 @@ namespace StudioCore.Resource
         unsafe private void FillVerticesStandard(FLVER0.Mesh mesh, Span<Vector3> pickingVerts, IntPtr vertBuffer)
         {
             Span<FlverLayout> verts = new Span<FlverLayout>(vertBuffer.ToPointer(), mesh.Vertices.Count);
-            for (int i = 0; i < mesh.Vertices.Count; i++)
+            fixed (FlverLayout* pverts = verts)
             {
-                var vert = mesh.Vertices[i];
-
-                verts[i] = new FlverLayout();
-                pickingVerts[i] = new Vector3(vert.Position.X, vert.Position.Y, vert.Position.Z);
-                fixed (FlverLayout* v = &verts[i])
+                for (int i = 0; i < mesh.Vertices.Count; i++)
                 {
+                    FlverLayout* v = &pverts[i];
+                    var vert = mesh.Vertices[i];
+
+                    verts[i] = new FlverLayout();
+                    pickingVerts[i] = new Vector3(vert.Position.X, vert.Position.Y, vert.Position.Z);
                     FillVertex(ref (*v).Position, ref vert);
                     FillNormalSNorm8((*v).Normal, ref vert);
                     if (vert.UVCount > 0)
@@ -1072,6 +1079,7 @@ namespace StudioCore.Resource
                     {
                         FillUVShortZero((*v).Uv1);
                     }
+
                     if (vert.TangentCount > 0)
                     {
                         FillBinormalBitangentSNorm8((*v).Binormal, (*v).Bitangent, ref vert, 0);
@@ -1084,14 +1092,15 @@ namespace StudioCore.Resource
             }
         }
 
-        unsafe private void FillVerticesUV2(BinaryReaderEx br, ref FlverVertexBuffer buffer, Span<FlverBufferLayoutMember> layouts, Span<Vector3> pickingVerts, IntPtr vertBuffer, float uvFactor)
+        private unsafe void FillVerticesUV2(BinaryReaderEx br, ref FlverVertexBuffer buffer, Span<FlverBufferLayoutMember> layouts, Span<Vector3> pickingVerts, IntPtr vertBuffer, float uvFactor)
         {
             Span<FlverLayoutUV2> verts = new Span<FlverLayoutUV2>(vertBuffer.ToPointer(), buffer.vertexCount);
             br.StepIn(buffer.bufferOffset);
-            for (int i = 0; i < buffer.vertexCount; i++)
+            fixed (FlverLayoutUV2* pverts = verts)
             {
-                fixed (FlverLayoutUV2* v = &verts[i])
+                for (int i = 0; i < buffer.vertexCount; i++)
                 {
+                    FlverLayoutUV2* v = &pverts[i];
                     Vector3 n = Vector3.UnitX;
                     FillBinormalBitangentSNorm8Zero((*v).Binormal, (*v).Bitangent);
                     int uvsfilled = 0;
@@ -1102,11 +1111,11 @@ namespace StudioCore.Resource
                             continue;
                         if (l.semantic == FLVER.LayoutSemantic.Position)
                         {
-                            FillVertex(ref (*v).Position, br, l.type);
+                            FillVertex(&(*v).Position, br, l.type);
                         }
                         else if (l.semantic == FLVER.LayoutSemantic.Normal)
                         {
-                            FillNormalSNorm8((*v).Normal, br, l.type, ref n);
+                            FillNormalSNorm8((*v).Normal, br, l.type, &n);
                         }
                         else if (l.semantic == FLVER.LayoutSemantic.UV && uvsfilled < 2)
                         {
@@ -1116,30 +1125,33 @@ namespace StudioCore.Resource
                         }
                         else if (l.semantic == FLVER.LayoutSemantic.Tangent && l.index == 0)
                         {
-                            FillBinormalBitangentSNorm8((*v).Binormal, (*v).Bitangent, ref n, br, l.type);
+                            FillBinormalBitangentSNorm8((*v).Binormal, (*v).Bitangent, &n, br, l.type);
                         }
                         else
                         {
                             EatVertex(br, l.type);
                         }
                     }
+
                     pickingVerts[i] = (*v).Position;
                 }
             }
+
             br.StepOut();
         }
 
         unsafe private void FillVerticesUV2(FLVER2.Mesh mesh, Span<Vector3> pickingVerts, IntPtr vertBuffer)
         {
             Span<FlverLayoutUV2> verts = new Span<FlverLayoutUV2>(vertBuffer.ToPointer(), mesh.VertexCount);
-            for (int i = 0; i < mesh.VertexCount; i++)
+            fixed (FlverLayoutUV2* pverts = verts)
             {
-                var vert = mesh.Vertices[i];
-
-                verts[i] = new FlverLayoutUV2();
-                pickingVerts[i] = new Vector3(vert.Position.X, vert.Position.Y, vert.Position.Z);
-                fixed (FlverLayoutUV2* v = &verts[i])
+                for (int i = 0; i < mesh.VertexCount; i++)
                 {
+                    var vert = mesh.Vertices[i];
+
+                    verts[i] = new FlverLayoutUV2();
+                    pickingVerts[i] = new Vector3(vert.Position.X, vert.Position.Y, vert.Position.Z);
+                    FlverLayoutUV2* v = &pverts[i];
                     FillVertex(ref (*v).Position, ref vert);
                     FillNormalSNorm8((*v).Normal, ref vert);
                     FillUVShort((*v).Uv1, ref vert, 0);
@@ -1159,14 +1171,15 @@ namespace StudioCore.Resource
         unsafe private void FillVerticesUV2(FLVER0.Mesh mesh, Span<Vector3> pickingVerts, IntPtr vertBuffer)
         {
             Span<FlverLayoutUV2> verts = new Span<FlverLayoutUV2>(vertBuffer.ToPointer(), mesh.Vertices.Count);
-            for (int i = 0; i < mesh.Vertices.Count; i++)
+            fixed (FlverLayoutUV2* pverts = verts)
             {
-                var vert = mesh.Vertices[i];
-
-                verts[i] = new FlverLayoutUV2();
-                pickingVerts[i] = new Vector3(vert.Position.X, vert.Position.Y, vert.Position.Z);
-                fixed (FlverLayoutUV2* v = &verts[i])
+                for (int i = 0; i < mesh.Vertices.Count; i++)
                 {
+                    var vert = mesh.Vertices[i];
+
+                    verts[i] = new FlverLayoutUV2();
+                    pickingVerts[i] = new Vector3(vert.Position.X, vert.Position.Y, vert.Position.Z);
+                    FlverLayoutUV2* v = &pverts[i];
                     FillVertex(ref (*v).Position, ref vert);
                     FillNormalSNorm8((*v).Normal, ref vert);
                     FillUVShort((*v).Uv1, ref vert, 0);
@@ -2103,7 +2116,7 @@ namespace StudioCore.Resource
             return true;
         }
 
-        public bool _Load(byte[] bytes, AccessLevel al, GameType type)
+        public bool _Load(Memory<byte> bytes, AccessLevel al, GameType type)
         {
             bool ret;
             if (type == GameType.DemonsSouls)
@@ -2131,30 +2144,29 @@ namespace StudioCore.Resource
             return ret;
         }
 
-        public bool _Load(string file, AccessLevel al, GameType type)
+        public bool _Load(string path, AccessLevel al, GameType type)
         {
             bool ret;
             if (type == GameType.DemonsSouls)
             {
-                FlverDeS = FLVER0.Read(file);
+                FlverDeS = FLVER0.Read(path);
                 ret = LoadInternalDeS(al, type);
             }
             else
             {
                 if (al == AccessLevel.AccessGPUOptimizedOnly && type != GameType.DarkSoulsRemastered && type != GameType.DarkSoulsPTDE)
                 {
-                    using (FileStream stream = File.OpenRead(file))
-                    {
-                        BinaryReaderEx br = new BinaryReaderEx(false, stream);
-                        DCX.Type ctype;
-                        br = SFUtil.GetDecompressedBR(br, out ctype);
-                        ret = LoadInternalFast(br, type);
-                    }
+                    using var file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+                    using var accessor = file.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+                    BinaryReaderEx br = new BinaryReaderEx(false, accessor.Memory);
+                    DCX.Type ctype;
+                    br = SFUtil.GetDecompressedBR(br, out ctype);
+                    ret = LoadInternalFast(br, type);
                 }
                 else
                 {
                     var cache = (al == AccessLevel.AccessGPUOptimizedOnly) ? GetCache() : null;
-                    Flver = FLVER2.Read(file, cache);
+                    Flver = FLVER2.Read(path, cache);
                     ret = LoadInternal(al, type);
                     ReleaseCache(cache);
                 }

--- a/StudioCore/Resource/HavokCollisionResource.cs
+++ b/StudioCore/Resource/HavokCollisionResource.cs
@@ -610,7 +610,7 @@ namespace StudioCore.Resource
             return true;
         }
 
-        public bool _Load(byte[] bytes, AccessLevel al, GameType type)
+        public bool _Load(Memory<byte> bytes, AccessLevel al, GameType type)
         {
             
             if (type == GameType.Bloodborne)

--- a/StudioCore/Resource/HavokNavmeshResource.cs
+++ b/StudioCore/Resource/HavokNavmeshResource.cs
@@ -9,7 +9,9 @@ using Veldrid.Utilities;
 using SoulsFormats;
 using HKX2;
 using System.IO;
+using System.IO.MemoryMappedFiles;
 using System.Threading.Tasks.Dataflow;
+using DotNext.IO.MemoryMappedFiles;
 
 namespace StudioCore.Resource
 {
@@ -249,7 +251,7 @@ namespace StudioCore.Resource
             return true;
         }
 
-        public bool _Load(byte[] bytes, AccessLevel al, GameType type)
+        public bool _Load(Memory<byte> bytes, AccessLevel al, GameType type)
         {
             BinaryReaderEx br = new BinaryReaderEx(false, bytes);
             var des = new HKX2.PackFileDeserializer();
@@ -257,13 +259,13 @@ namespace StudioCore.Resource
             return LoadInternal(al);
         }
 
-        public bool _Load(string file, AccessLevel al, GameType type)
+        public bool _Load(string path, AccessLevel al, GameType type)
         {
-            using (var s = File.OpenRead(file))
-            {
-                var des = new HKX2.PackFileDeserializer();
-                HkxRoot = (hkRootLevelContainer)des.Deserialize(new BinaryReaderEx(false, s));
-            }
+            using var file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var accessor = file.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            var des = new HKX2.PackFileDeserializer();
+            HkxRoot = (hkRootLevelContainer)des.Deserialize(new BinaryReaderEx(false, accessor.Memory));
+
             return LoadInternal(al);
         }
 

--- a/StudioCore/Resource/IResource.cs
+++ b/StudioCore/Resource/IResource.cs
@@ -8,7 +8,7 @@ namespace StudioCore.Resource
 {
     public interface IResource
     {
-        public bool _Load(byte[] bytes, AccessLevel al, GameType type);
+        public bool _Load(Memory<byte> bytes, AccessLevel al, GameType type);
         public bool _Load(string file, AccessLevel al, GameType type);
     }
 }

--- a/StudioCore/Resource/NVMNavmeshResource.cs
+++ b/StudioCore/Resource/NVMNavmeshResource.cs
@@ -145,7 +145,7 @@ namespace StudioCore.Resource
             return true;
         }
 
-        public bool _Load(byte[] bytes, AccessLevel al, GameType type)
+        public bool _Load(Memory<byte> bytes, AccessLevel al, GameType type)
         {
             Nvm = NVM.Read(bytes);
             return LoadInternal(al);

--- a/StudioCore/Resource/ResourceLoadPipeline.cs
+++ b/StudioCore/Resource/ResourceLoadPipeline.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks.Dataflow;
 
 public readonly record struct LoadByteResourceRequest(
     string VirtualPath, 
-    byte[] Data, 
+    Memory<byte> Data, 
     AccessLevel AccessLevel, 
     GameType GameType);
 
@@ -51,7 +51,7 @@ public class ResourceLoadPipeline<T> : IResourceLoadPipeline where T : class, IR
     public ResourceLoadPipeline(ITargetBlock<ResourceLoadedReply> target)
     {
         var options = new ExecutionDataflowBlockOptions();
-        options.MaxDegreeOfParallelism = 6;
+        options.MaxDegreeOfParallelism = DataflowBlockOptions.Unbounded;
         _loadedResources = target;
         _loadByteResourcesTransform = new ActionBlock<LoadByteResourceRequest>(r =>
         {
@@ -96,7 +96,7 @@ public class TextureLoadPipeline : IResourceLoadPipeline
     public TextureLoadPipeline(ITargetBlock<ResourceLoadedReply> target)
     {
         var options = new ExecutionDataflowBlockOptions();
-        options.MaxDegreeOfParallelism = 6;
+        options.MaxDegreeOfParallelism = DataflowBlockOptions.Unbounded;
         _loadedResources = target;
         _loadTPFResourcesTransform = new ActionBlock<LoadTPFTextureResourceRequest>(r =>
         {

--- a/StudioCore/Resource/ResourceManager.cs
+++ b/StudioCore/Resource/ResourceManager.cs
@@ -133,16 +133,16 @@ namespace StudioCore.Resource
             public BinderReader Binder = null;
             public bool PopulateResourcesOnly = false;
             public HashSet<int> BinderLoadMask = null;
-            public List<Task> LoadingTasks = new List<Task>();
-            public List<int> TaskSizes = new List<int>();
-            public List<int> TaskProgress = new List<int>();
+            public List<Task> LoadingTasks = new();
+            public List<int> TaskSizes = new();
+            public List<int> TaskProgress = new();
             public int TotalSize = 0;
             public HashSet<string> AssetWhitelist = null;
             public ResourceType ResourceMask = ResourceType.All;
             public AccessLevel AccessLevel = AccessLevel.AccessGPUOptimizedOnly;
 
-            public List<Tuple<IResourceLoadPipeline, string, BinderFileHeader>> PendingResources = new List<Tuple<IResourceLoadPipeline, string, BinderFileHeader>>();
-            public List<Tuple<string, BinderFileHeader>> PendingTPFs = new List<Tuple<string, BinderFileHeader>>();
+            public List<Tuple<IResourceLoadPipeline, string, BinderFileHeader>> PendingResources = new();
+            public List<Tuple<string, BinderFileHeader>> PendingTPFs = new();
 
             public readonly object ProgressLock = new object();
 

--- a/StudioCore/Resource/TextureResource.cs
+++ b/StudioCore/Resource/TextureResource.cs
@@ -102,7 +102,7 @@ namespace StudioCore.Resource
             GC.SuppressFinalize(this);
         }
 
-        bool IResource._Load(byte[] bytes, AccessLevel al, GameType type)
+        bool IResource._Load(Memory<byte> bytes, AccessLevel al, GameType type)
         {
             return _LoadTexture(al);
         }

--- a/StudioCore/Scene/Renderable.cs
+++ b/StudioCore/Scene/Renderable.cs
@@ -46,6 +46,8 @@ namespace StudioCore.Scene
 
         private int _topIndex = 0;
 
+        private Stack<int> _freeIndices = new Stack<int>(100);
+
         public int RenderableSystemIndex { get; protected set; }
 
         /// <summary>
@@ -57,14 +59,13 @@ namespace StudioCore.Scene
 
         protected int GetNextInvalidIndex()
         {
-            for (int i = 0; i < SYSTEM_SIZE; i++)
-            {
-                if (!cVisible[i]._valid)
-                {
-                    return i;
-                }
-            }
-            throw new Exception("Renderable system full.\n\nTry increasing renderables limit in settings.\n");
+            if (_freeIndices.Count > 0)
+                return _freeIndices.Pop();
+            
+            if (_topIndex >= SYSTEM_SIZE)
+                throw new Exception("Renderable system full.\n\nTry increasing renderables limit in settings.\n");
+
+            return _topIndex++;
         }
 
         protected int AllocateValidAndVisibleRenderable()
@@ -81,6 +82,7 @@ namespace StudioCore.Scene
         public void RemoveRenderable(int renderable)
         {
             cVisible[renderable]._valid = false;
+            _freeIndices.Push(renderable);
         }
     }
 

--- a/StudioCore/Scene/TexturePool.cs
+++ b/StudioCore/Scene/TexturePool.cs
@@ -439,10 +439,8 @@ namespace StudioCore.Scene
                         var mipInfo = GetMipInfo(format, (int)dds.dwWidth, (int)dds.dwHeight, (int)level, false);
                         //paddedSize = mipInfo.ByteCount;
                         paddedSize = mipInfo;
-                        fixed (void* data = &bytes[copyOffset])
-                        {
-                            Unsafe.CopyBlock(map.Data.ToPointer(), data, (uint)paddedSize);
-                        }
+                        var dest = new Span<byte>(map.Data.ToPointer(), paddedSize);
+                        bytes.Span.Slice(copyOffset, paddedSize).CopyTo(dest);
                         copyOffset += paddedSize;
                     }
                 }
@@ -697,7 +695,7 @@ namespace StudioCore.Scene
                         //{
                         //Unsafe.CopyBlock(map.Data.ToPointer(), data, (uint)paddedSize);
                         DeswizzleDDSBytesPS4((int)currentWidth, (int)currentHeight, tex.Format, (int)blockSize,
-                            (int)paddedWidth, new Span<byte>(tex.Bytes, (int)copyOffset, (int)paddedSize),
+                            (int)paddedWidth, tex.Bytes.Span.Slice((int)copyOffset, (int)paddedSize),
                             new Span<byte>(map.Data.ToPointer(), (int)mipInfo));
                         //}
                         copyOffset += paddedSize;

--- a/StudioCore/StudioCore.csproj
+++ b/StudioCore/StudioCore.csproj
@@ -423,16 +423,18 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DotNext.IO" Version="4.12.4" />
+    <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
     <PackageReference Include="NativeLibraryLoader" Version="1.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Octokit" Version="6.0.0" />
+    <PackageReference Include="Octokit" Version="6.1.0" />
     <PackageReference Include="ProcessMemoryUtilities.Net" Version="1.3.4" />
     <PackageReference Include="Silk.NET.OpenGL" Version="2.17.1" />
     <PackageReference Include="Silk.NET.SDL" Version="2.17.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
     <PackageReference Include="Vortice.ShaderCompiler" Version="1.7.1" />
-    <PackageReference Include="Vortice.Vulkan" Version="1.6.7" />
-    <PackageReference Include="Vortice.VulkanMemoryAllocator" Version="1.3.0" />
+    <PackageReference Include="Vortice.Vulkan" Version="1.6.8" />
+    <PackageReference Include="Vortice.VulkanMemoryAllocator" Version="1.3.1" />
     <PackageReference Include="Vortice.Win32" Version="1.9.34" />
   </ItemGroup>
 

--- a/StudioCore/Tests/BTLTests.cs
+++ b/StudioCore/Tests/BTLTests.cs
@@ -53,7 +53,7 @@ namespace StudioCore.Tests
                     btl = BTL.Read(decompressed);
 
                     var written = btl.Write(DCX.Type.None);
-                    if (!decompressed.SequenceEqual(written))
+                    if (!decompressed.Span.SequenceEqual(written))
                     {
                         noWrite.Add(file.AssetName);
 

--- a/StudioCore/Tests/MSBReadWrite.cs
+++ b/StudioCore/Tests/MSBReadWrite.cs
@@ -20,7 +20,7 @@ namespace StudioCore.Tests
                 var decompressed = DCX.Decompress(bytes);
                 MSBE m = MSBE.Read(decompressed);
                 var written = m.Write(DCX.Type.None);
-                if (!decompressed.SequenceEqual(written))
+                if (!decompressed.Span.SequenceEqual(written))
                 {
                     var basepath = Path.GetDirectoryName(path.AssetPath);
                     if (!Directory.Exists($@"{basepath}\mismatches"))

--- a/Veldrid/Veldrid.csproj
+++ b/Veldrid/Veldrid.csproj
@@ -13,12 +13,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
     <PackageReference Include="NativeLibraryLoader" Version="1.0.13" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageReference Include="Vortice.Vulkan" Version="1.6.7" />
-    <PackageReference Include="Vortice.VulkanMemoryAllocator" Version="1.3.0" />
+    <PackageReference Include="Vortice.Vulkan" Version="1.6.8" />
+    <PackageReference Include="Vortice.VulkanMemoryAllocator" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Fixed an accidental O(n^2) in the renderable allocation
* Use mapped File IO instead of streams
* Rework BinaryReaderEx and Soulsformats to work around Memory<T> and Span<T> and get rid of lots of unnecessary allocations and copies