### PR TITLE
Improve handling of missing MsbEntry refs

### DIFF
--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSB.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSB.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace SoulsFormats
@@ -8,6 +9,19 @@ namespace SoulsFormats
     /// </summary>
     public static partial class MSB
     {
+        public class MissingReferenceException : Exception
+        {
+            public IMsbEntry Referrer;
+            public string ReferreeName;
+
+            public MissingReferenceException(IMsbEntry referrer, string refereeName)
+                : base($"{referrer} references map entity that does not exist: {refereeName}")
+            {
+                Referrer = referrer;
+                ReferreeName = refereeName;
+            }
+        }
+
         internal static void AssertHeader(BinaryReaderEx br)
         {
             br.AssertASCII("MSB ");
@@ -92,6 +106,21 @@ namespace SoulsFormats
                 int result = list.FindIndex(entry => entry.Name == name);
                 if (result == -1)
                     throw new KeyNotFoundException($"Name not found: {name}");
+                return result;
+            }
+        }
+
+        internal static int FindIndex<T>(IMsbEntry referrer, List<T> list, string name) where T : IMsbEntry
+        {
+            if (name == null || name == "")
+            {
+                return -1;
+            }
+            else
+            {
+                int result = list.FindIndex(entry => entry.Name == name);
+                if (result == -1)
+                    throw new MissingReferenceException(referrer, name);
                 return result;
             }
         }

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSB1/EventParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSB1/EventParam.cs
@@ -325,8 +325,8 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(MSB1 msb, Entries entries)
             {
-                PartIndex = MSB.FindIndex(entries.Parts, PartName);
-                RegionIndex = MSB.FindIndex(entries.Regions, RegionName);
+                PartIndex = MSB.FindIndex(this, entries.Parts, PartName);
+                RegionIndex = MSB.FindIndex(this, entries.Regions, RegionName);
             }
 
             /// <summary>
@@ -625,7 +625,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB1 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    TreasurePartIndex = MSB.FindIndex(entries.Parts, TreasurePartName);
+                    TreasurePartIndex = MSB.FindIndex(this, entries.Parts, TreasurePartName);
                 }
             }
 
@@ -891,7 +891,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB1 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    ObjActPartIndex = MSB.FindIndex(entries.Parts, ObjActPartName);
+                    ObjActPartIndex = MSB.FindIndex(this, entries.Parts, ObjActPartName);
                 }
             }
 
@@ -941,7 +941,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB1 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    SpawnPointIndex = MSB.FindIndex(entries.Regions, SpawnPointName);
+                    SpawnPointIndex = MSB.FindIndex(this, entries.Regions, SpawnPointName);
                 }
             }
 
@@ -1028,7 +1028,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB1 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    NavmeshRegionIndex = MSB.FindIndex(entries.Regions, NavmeshRegionName);
+                    NavmeshRegionIndex = MSB.FindIndex(this, entries.Regions, NavmeshRegionName);
                 }
             }
 

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSB1/PartsParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSB1/PartsParam.cs
@@ -455,7 +455,7 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(MSB1 msb, Entries entries)
             {
-                ModelIndex = MSB.FindIndex(entries.Models, ModelName);
+                ModelIndex = MSB.FindIndex(this, entries.Models, ModelName);
             }
 
             /// <summary>
@@ -561,7 +561,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB1 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    CollisionIndex = MSB.FindIndex(entries.Parts, CollisionName);
+                    CollisionIndex = MSB.FindIndex(this, entries.Parts, CollisionName);
                 }
             }
 
@@ -710,11 +710,11 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB1 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    CollisionIndex = MSB.FindIndex(entries.Parts, CollisionName);
+                    CollisionIndex = MSB.FindIndex(this, entries.Parts, CollisionName);
 
                     MovePointIndices = new short[MovePointNames.Length];
                     for (int i = 0; i < MovePointNames.Length; i++)
-                        MovePointIndices[i] = (short)MSB.FindIndex(entries.Regions, MovePointNames[i]);
+                        MovePointIndices[i] = (short)MSB.FindIndex(this, entries.Regions, MovePointNames[i]);
                 }
             }
 
@@ -1048,7 +1048,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB1 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    CollisionIndex = MSB.FindIndex(msb.Parts.Collisions, CollisionName);
+                    CollisionIndex = MSB.FindIndex(this, msb.Parts.Collisions, CollisionName);
                 }
             }
         }

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/EventParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/EventParam.cs
@@ -287,8 +287,8 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(MSB3 msb, Entries entries)
             {
-                PartIndex = MSB.FindIndex(entries.Parts, PartName);
-                PointIndex = MSB.FindIndex(entries.Regions, PointName);
+                PartIndex = MSB.FindIndex(this, entries.Parts, PartName);
+                PointIndex = MSB.FindIndex(this, entries.Regions, PointName);
             }
 
             /// <summary>
@@ -432,7 +432,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB3 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    TreasurePartIndex = MSB.FindIndex(entries.Parts, TreasurePartName);
+                    TreasurePartIndex = MSB.FindIndex(this, entries.Parts, TreasurePartName);
                 }
             }
 
@@ -716,7 +716,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB3 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    ObjActPartIndex = MSB.FindIndex(entries.Parts, ObjActPartName);
+                    ObjActPartIndex = MSB.FindIndex(this, entries.Parts, ObjActPartName);
                 }
             }
 
@@ -941,7 +941,7 @@ namespace SoulsFormats
                     base.GetIndices(msb, entries);
                     WalkPointIndices = new short[WalkPointNames.Length];
                     for (int i = 0; i < WalkPointNames.Length; i++)
-                        WalkPointIndices[i] = (short)MSB.FindIndex(entries.Regions, WalkPointNames[i]);
+                        WalkPointIndices[i] = (short)MSB.FindIndex(this, entries.Regions, WalkPointNames[i]);
                 }
             }
 

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/PartsParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/PartsParam.cs
@@ -531,7 +531,7 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(MSB3 msb, Entries entries)
             {
-                ModelIndex = MSB.FindIndex(entries.Models, ModelName);
+                ModelIndex = MSB.FindIndex(this, entries.Models, ModelName);
             }
 
             /// <summary>
@@ -814,7 +814,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB3 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    CollisionPartIndex = MSB.FindIndex(entries.Parts, CollisionName);
+                    CollisionPartIndex = MSB.FindIndex(this, entries.Parts, CollisionName);
                 }
             }
 
@@ -1037,8 +1037,8 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB3 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    CollisionPartIndex = MSB.FindIndex(entries.Parts, CollisionName);
-                    WalkRouteIndex = (short)MSB.FindIndex(msb.Events.PatrolInfo, WalkRouteName);
+                    CollisionPartIndex = MSB.FindIndex(this, entries.Parts, CollisionName);
+                    WalkRouteIndex = (short)MSB.FindIndex(this, msb.Events.PatrolInfo, WalkRouteName);
                 }
             }
 
@@ -1325,7 +1325,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB3 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    UnkHitIndex = MSB.FindIndex(entries.Parts, UnkHitName);
+                    UnkHitIndex = MSB.FindIndex(this, entries.Parts, UnkHitName);
                 }
             }
 
@@ -1421,7 +1421,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB3 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    CollisionIndex = MSB.FindIndex(msb.Parts.Collisions, CollisionName);
+                    CollisionIndex = MSB.FindIndex(this, msb.Parts.Collisions, CollisionName);
                 }
             }
         }

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/PointParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/PointParam.cs
@@ -507,7 +507,7 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(MSB3 msb, Entries entries)
             {
-                ActivationPartIndex = MSB.FindIndex(entries.Parts, ActivationPartName);
+                ActivationPartIndex = MSB.FindIndex(this, entries.Parts, ActivationPartName);
             }
 
             /// <summary>
@@ -804,7 +804,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB3 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    WindAreaIndex = MSB.FindIndex(entries.Regions, WindAreaName);
+                    WindAreaIndex = MSB.FindIndex(this, entries.Regions, WindAreaName);
                 }
             }
 

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBB/EventParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBB/EventParam.cs
@@ -407,8 +407,8 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(MSBB msb, Entries entries)
             {
-                PartIndex = MSB.FindIndex(entries.Parts, PartName);
-                RegionIndex = MSB.FindIndex(entries.Regions, RegionName);
+                PartIndex = MSB.FindIndex(this, entries.Parts, PartName);
+                RegionIndex = MSB.FindIndex(this, entries.Regions, RegionName);
             }
 
             /// <summary>
@@ -663,7 +663,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBB msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    TreasurePartIndex = MSB.FindIndex(entries.Parts, TreasurePartName);
+                    TreasurePartIndex = MSB.FindIndex(this, entries.Parts, TreasurePartName);
                 }
             }
 
@@ -956,7 +956,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBB msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    ObjActPartIndex = MSB.FindIndex(entries.Parts, ObjActPartName);
+                    ObjActPartIndex = MSB.FindIndex(this, entries.Parts, ObjActPartName);
                 }
             }
 
@@ -1007,7 +1007,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBB msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    SpawnPointIndex = MSB.FindIndex(entries.Regions, SpawnPointName);
+                    SpawnPointIndex = MSB.FindIndex(this, entries.Regions, SpawnPointName);
                 }
             }
 
@@ -1096,7 +1096,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBB msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    NavmeshRegionIndex = MSB.FindIndex(entries.Regions, NavmeshRegionName);
+                    NavmeshRegionIndex = MSB.FindIndex(this, entries.Regions, NavmeshRegionName);
                 }
             }
 
@@ -1227,7 +1227,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBB msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    WindRegionIndex = MSB.FindIndex(entries.Regions, WindRegionName);
+                    WindRegionIndex = MSB.FindIndex(this, entries.Regions, WindRegionName);
                 }
             }
 
@@ -1298,7 +1298,7 @@ namespace SoulsFormats
                     base.GetIndices(msb, entries);
                     WalkPointIndices = new short[WalkPointNames.Length];
                     for (int i = 0; i < WalkPointNames.Length; i++)
-                        WalkPointIndices[i] = (short)MSB.FindIndex(entries.Regions, WalkPointNames[i]);
+                        WalkPointIndices[i] = (short)MSB.FindIndex(this, entries.Regions, WalkPointNames[i]);
                 }
             }
 

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBB/PartsParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBB/PartsParam.cs
@@ -563,7 +563,7 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(MSBB msb, Entries entries)
             {
-                ModelIndex = MSB.FindIndex(entries.Models, ModelName);
+                ModelIndex = MSB.FindIndex(this, entries.Models, ModelName);
             }
 
             /// <summary>
@@ -894,7 +894,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBB msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    CollisionIndex = MSB.FindIndex(entries.Parts, CollisionName);
+                    CollisionIndex = MSB.FindIndex(this, entries.Parts, CollisionName);
                 }
             }
 
@@ -1056,11 +1056,11 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBB msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    CollisionIndex = MSB.FindIndex(entries.Parts, CollisionName);
+                    CollisionIndex = MSB.FindIndex(this, entries.Parts, CollisionName);
 
                     MovePointIndices = new short[MovePointNames.Length];
                     for (int i = 0; i < MovePointNames.Length; i++)
-                        MovePointIndices[i] = (short)MSB.FindIndex(entries.Regions, MovePointNames[i]);
+                        MovePointIndices[i] = (short)MSB.FindIndex(this, entries.Regions, MovePointNames[i]);
                 }
             }
 
@@ -1383,7 +1383,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBB msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    CollisionIndex = MSB.FindIndex(msb.Parts.Collisions, CollisionName);
+                    CollisionIndex = MSB.FindIndex(this, msb.Parts.Collisions, CollisionName);
                 }
             }
 

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBD/EventParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBD/EventParam.cs
@@ -265,8 +265,8 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(MSBD msb, Entries entries)
             {
-                PartIndex = MSB.FindIndex(entries.Parts, PartName);
-                RegionIndex = MSB.FindIndex(entries.Regions, RegionName);
+                PartIndex = MSB.FindIndex(this, entries.Parts, PartName);
+                RegionIndex = MSB.FindIndex(this, entries.Regions, RegionName);
             }
 
             /// <summary>
@@ -569,7 +569,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBD msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    TreasurePartIndex = MSB.FindIndex(entries.Parts, TreasurePartName);
+                    TreasurePartIndex = MSB.FindIndex(this, entries.Parts, TreasurePartName);
                 }
             }
 

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBD/PartsParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBD/PartsParam.cs
@@ -478,7 +478,7 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(MSBD msb, Entries entries)
             {
-                ModelIndex = MSB.FindIndex(entries.Models, ModelName);
+                ModelIndex = MSB.FindIndex(this, entries.Models, ModelName);
             }
 
             /// <summary>
@@ -728,11 +728,11 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBD msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    CollisionIndex = MSB.FindIndex(entries.Parts, CollisionName);
+                    CollisionIndex = MSB.FindIndex(this, entries.Parts, CollisionName);
 
                     MovePointIndices = new short[MovePointNames.Length];
                     for (int i = 0; i < MovePointNames.Length; i++)
-                        MovePointIndices[i] = (short)MSB.FindIndex(entries.Regions, MovePointNames[i]);
+                        MovePointIndices[i] = (short)MSB.FindIndex(this, entries.Regions, MovePointNames[i]);
                 }
             }
 
@@ -1151,7 +1151,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBD msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    CollisionIndex = MSB.FindIndex(msb.Parts.Collisions, CollisionName);
+                    CollisionIndex = MSB.FindIndex(this, msb.Parts.Collisions, CollisionName);
                 }
             }
         }

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/EventParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/EventParam.cs
@@ -389,8 +389,8 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(MSBE msb, Entries entries)
             {
-                PartIndex = MSB.FindIndex(entries.Parts, PartName);
-                RegionIndex = MSB.FindIndex(entries.Regions, RegionName);
+                PartIndex = MSB.FindIndex(this, entries.Parts, PartName);
+                RegionIndex = MSB.FindIndex(this, entries.Regions, RegionName);
             }
 
             /// <summary>
@@ -500,7 +500,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBE msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    TreasurePartIndex = MSB.FindIndex(entries.Parts, TreasurePartName);
+                    TreasurePartIndex = MSB.FindIndex(this, entries.Parts, TreasurePartName);
                 }
             }
 
@@ -739,7 +739,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBE msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    ObjActPartIndex = MSB.FindIndex(entries.Parts, ObjActPartName);
+                    ObjActPartIndex = MSB.FindIndex(this, entries.Parts, ObjActPartName);
                 }
             }
 
@@ -790,7 +790,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBE msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    NavmeshRegionIndex = MSB.FindIndex(entries.Regions, NavmeshRegionName);
+                    NavmeshRegionIndex = MSB.FindIndex(this, entries.Regions, NavmeshRegionName);
                 }
             }
 
@@ -1030,7 +1030,7 @@ namespace SoulsFormats
                     base.GetIndices(msb, entries);
                     WalkRegionIndices = new short[WalkRegionNames.Length];
                     for (int i = 0; i < WalkRegionNames.Length; i++)
-                        WalkRegionIndices[i] = (short)MSB.FindIndex(entries.Regions, WalkRegionNames[i]);
+                        WalkRegionIndices[i] = (short)MSB.FindIndex(this, entries.Regions, WalkRegionNames[i]);
                 }
             }
 
@@ -1089,8 +1089,8 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBE msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    RiderPartIndex = MSB.FindIndex(entries.Parts, RiderPartName);
-                    MountPartIndex = MSB.FindIndex(entries.Parts, MountPartName);
+                    RiderPartIndex = MSB.FindIndex(this, entries.Parts, RiderPartName);
+                    MountPartIndex = MSB.FindIndex(this, entries.Parts, MountPartName);
                 }
             }
 
@@ -1149,7 +1149,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBE msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    SignPartIndex = MSB.FindIndex(entries.Parts, SignPartName);
+                    SignPartIndex = MSB.FindIndex(this, entries.Parts, SignPartName);
                 }
             }
 
@@ -1220,8 +1220,8 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBE msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    RetryPartIndex = MSB.FindIndex(entries.Parts, RetryPartName);
-                    RetryRegionIndex = (short)MSB.FindIndex(entries.Regions, RetryRegionName);
+                    RetryPartIndex = MSB.FindIndex(this, entries.Parts, RetryPartName);
+                    RetryRegionIndex = (short)MSB.FindIndex(this, entries.Regions, RetryRegionName);
                 }
             }
 

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PartsParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PartsParam.cs
@@ -722,7 +722,7 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(MSBE msb, Entries entries)
             {
-                ModelIndex = MSB.FindIndex(entries.Models, ModelName);
+                ModelIndex = MSB.FindIndex(this, entries.Models, ModelName);
             }
 
             /// <summary>
@@ -1738,8 +1738,8 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBE msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    CollisionPartIndex = MSB.FindIndex(entries.Parts, CollisionPartName);
-                    WalkRouteIndex = (short)MSB.FindIndex(msb.Events.PatrolInfo, WalkRouteName);
+                    CollisionPartIndex = MSB.FindIndex(this, entries.Parts, CollisionPartName);
+                    WalkRouteIndex = (short)MSB.FindIndex(this, msb.Events.PatrolInfo, WalkRouteName);
                 }
             }
 
@@ -2379,7 +2379,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBE msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    CollisionIndex = MSB.FindIndex(msb.Parts.Collisions, CollisionName);
+                    CollisionIndex = MSB.FindIndex(this, msb.Parts.Collisions, CollisionName);
                 }
             }
 

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PointParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PointParam.cs
@@ -749,7 +749,7 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(Entries entries)
             {
-                ActivationPartIndex = MSB.FindIndex(entries.Parts, ActivationPartName);
+                ActivationPartIndex = MSB.FindIndex(this, entries.Parts, ActivationPartName);
                 if (Shape is MSB.Shape.Composite composite)
                     composite.GetIndices(entries.Regions);
             }
@@ -1100,7 +1100,7 @@ namespace SoulsFormats
                 internal override void GetIndices(Entries entries)
                 {
                     base.GetIndices(entries);
-                    WindAreaIndex = MSB.FindIndex(entries.Regions, WindAreaName);
+                    WindAreaIndex = MSB.FindIndex(this, entries.Regions, WindAreaName);
                 }
             }
 

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBN/MSBN.PartsSection.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBN/MSBN.PartsSection.cs
@@ -248,7 +248,7 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(MSBN msb, Entries entries)
             {
-                modelIndex = MSB.FindIndex(entries.Models, ModelName);
+                modelIndex = MSB.FindIndex(this, entries.Models, ModelName);
             }
 
             /// <summary>

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBS/EventParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBS/EventParam.cs
@@ -359,8 +359,8 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(MSBS msb, Entries entries)
             {
-                PartIndex = MSB.FindIndex(entries.Parts, PartName);
-                RegionIndex = MSB.FindIndex(entries.Regions, RegionName);
+                PartIndex = MSB.FindIndex(this, entries.Parts, PartName);
+                RegionIndex = MSB.FindIndex(this, entries.Regions, RegionName);
             }
 
             /// <summary>
@@ -468,7 +468,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBS msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    TreasurePartIndex = MSB.FindIndex(entries.Parts, TreasurePartName);
+                    TreasurePartIndex = MSB.FindIndex(this, entries.Parts, TreasurePartName);
                 }
             }
 
@@ -706,7 +706,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBS msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    ObjActPartIndex = MSB.FindIndex(entries.Parts, ObjActPartName);
+                    ObjActPartIndex = MSB.FindIndex(this, entries.Parts, ObjActPartName);
                 }
             }
 
@@ -836,10 +836,10 @@ namespace SoulsFormats
                     base.GetIndices(msb, entries);
                     WalkRegionIndices = new short[WalkRegionNames.Length];
                     for (int i = 0; i < WalkRegionNames.Length; i++)
-                        WalkRegionIndices[i] = (short)MSB.FindIndex(entries.Regions, WalkRegionNames[i]);
+                        WalkRegionIndices[i] = (short)MSB.FindIndex(this, entries.Regions, WalkRegionNames[i]);
 
                     foreach (WREntry wrEntry in WREntries)
-                        wrEntry.GetIndices(entries);
+                        wrEntry.GetIndices(this, entries);
                 }
 
                 /// <summary>
@@ -898,9 +898,9 @@ namespace SoulsFormats
                         RegionName = MSB.FindName(entries.Regions, RegionIndex);
                     }
 
-                    internal void GetIndices(Entries entries)
+                    internal void GetIndices(IMsbEntry entry, Entries entries)
                     {
-                        RegionIndex = (short)MSB.FindIndex(entries.Regions, RegionName);
+                        RegionIndex = (short)MSB.FindIndex(entry, entries.Regions, RegionName);
                     }
                 }
             }
@@ -1319,8 +1319,8 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBS msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    AutoDrawGroupPointIndex = MSB.FindIndex(msb.Regions.AutoDrawGroupPoints, AutoDrawGroupPointName);
-                    OwningCollisionIndex = MSB.FindIndex(msb.Parts.Collisions, OwningCollisionName);
+                    AutoDrawGroupPointIndex = MSB.FindIndex(this, msb.Regions.AutoDrawGroupPoints, AutoDrawGroupPointName);
+                    OwningCollisionIndex = MSB.FindIndex(this, msb.Parts.Collisions, OwningCollisionName);
                 }
             }
 

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBS/PartsParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBS/PartsParam.cs
@@ -616,7 +616,7 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(MSBS msb, Entries entries)
             {
-                ModelIndex = MSB.FindIndex(entries.Models, ModelName);
+                ModelIndex = MSB.FindIndex(this, entries.Models, ModelName);
             }
 
             /// <summary>
@@ -1153,9 +1153,9 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBS msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    ObjPartIndex1 = MSB.FindIndex(entries.Parts, ObjPartName1);
-                    ObjPartIndex2 = MSB.FindIndex(entries.Parts, ObjPartName2);
-                    ObjPartIndex3 = MSB.FindIndex(entries.Parts, ObjPartName3);
+                    ObjPartIndex1 = MSB.FindIndex(this, entries.Parts, ObjPartName1);
+                    ObjPartIndex2 = MSB.FindIndex(this, entries.Parts, ObjPartName2);
+                    ObjPartIndex3 = MSB.FindIndex(this, entries.Parts, ObjPartName3);
                 }
             }
 
@@ -1406,7 +1406,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBS msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    CollisionPartIndex = MSB.FindIndex(entries.Parts, CollisionPartName);
+                    CollisionPartIndex = MSB.FindIndex(this, entries.Parts, CollisionPartName);
                 }
             }
 
@@ -1821,7 +1821,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBS msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    CollisionIndex = MSB.FindIndex(msb.Parts.Collisions, CollisionName);
+                    CollisionIndex = MSB.FindIndex(this, msb.Parts.Collisions, CollisionName);
                 }
             }
         }

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBS/PointParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBS/PointParam.cs
@@ -506,7 +506,7 @@ namespace SoulsFormats
 
             internal virtual void GetIndices(Entries entries)
             {
-                ActivationPartIndex = MSB.FindIndex(entries.Parts, ActivationPartName);
+                ActivationPartIndex = MSB.FindIndex(this, entries.Parts, ActivationPartName);
                 if (Shape is MSB.Shape.Composite composite)
                     composite.GetIndices(entries.Regions);
             }
@@ -836,7 +836,7 @@ namespace SoulsFormats
                 internal override void GetIndices(Entries entries)
                 {
                     base.GetIndices(entries);
-                    WindAreaIndex = MSB.FindIndex(entries.Regions, WindAreaName);
+                    WindAreaIndex = MSB.FindIndex(this, entries.Regions, WindAreaName);
                 }
             }
 

--- a/StudioCore/MsbEditor/MsbEditorScreen.cs
+++ b/StudioCore/MsbEditor/MsbEditorScreen.cs
@@ -1154,7 +1154,7 @@ namespace StudioCore.MsbEditor
             }
         }
 
-        private void HandleMissingRef(SavingFailedException e)
+        private void HandleSaveException(SavingFailedException e)
         {
             if (e.Wrapped is MSB.MissingReferenceException eRef)
             {
@@ -1195,7 +1195,7 @@ namespace StudioCore.MsbEditor
             }
             catch (SavingFailedException e)
             {
-                HandleMissingRef(e);
+                HandleSaveException(e);
             }
         }
 
@@ -1207,7 +1207,7 @@ namespace StudioCore.MsbEditor
             }
             catch (SavingFailedException e)
             {
-                HandleMissingRef(e);
+                HandleSaveException(e);
             }
         }
 

--- a/StudioCore/MsbEditor/MsbEditorScreen.cs
+++ b/StudioCore/MsbEditor/MsbEditorScreen.cs
@@ -1176,7 +1176,7 @@ namespace StudioCore.MsbEditor
                             }
                         }
                     }
-                    TaskManager.warningList.TryAdd("MSB missing referrer not found", $"Unable to find map entity: {eRef.Referrer.Name}");
+                    TaskManager.warningList.TryAdd($"MsbMissingReferrer {eRef.Referrer.Name}", $"Unable to find map entity: {eRef.Referrer.Name}");
                 }
             }
             else

--- a/StudioCore/MsbEditor/SceneTree.cs
+++ b/StudioCore/MsbEditor/SceneTree.cs
@@ -377,7 +377,7 @@ namespace StudioCore.MsbEditor
                 {
                     // Select Range
                     var entList = e.Container.Objects;
-                    var i1 = entList.IndexOf((MapEntity)_selection.GetSelection().FirstOrDefault(fe => ((MapEntity)fe).Container == e.Container && fe != e.Container.RootObject));
+                    var i1 = entList.IndexOf((MapEntity)_selection.GetFilteredSelection<MapEntity>().FirstOrDefault(fe => ((MapEntity)fe).Container == e.Container && fe != e.Container.RootObject));
                     var i2 = entList.IndexOf((MapEntity)e);
 
                     if (i1 != -1 && i2 != -1)

--- a/StudioCore/MsbEditor/Universe.cs
+++ b/StudioCore/MsbEditor/Universe.cs
@@ -1375,7 +1375,7 @@ namespace StudioCore.MsbEditor
                 {
                     File.Delete(mapPath + ".temp");
                 }
-                
+
                 msb.Write(mapPath + ".temp", compressionType);
 
                 // Make a copy of the previous map


### PR DESCRIPTION
When a missing reference is found, tell user referring entity's name and prompt to automatically select it in editor.

(Also fixes a crash in SceneTree)