### PR TITLE
Implement task log priority. Restructure TaskManager a bit.

### DIFF
--- a/StudioCore/Editor/Action.cs
+++ b/StudioCore/Editor/Action.cs
@@ -219,7 +219,7 @@ namespace StudioCore.Editor
             }
 
             // Refresh diff cache
-            TaskManager.Run("Param - Check Differences", false, true, true, () => ParamBank.PrimaryBank.RefreshParamDiffCaches());
+            TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
             return ActionEvent.NoEvent;
         }
 
@@ -279,7 +279,7 @@ namespace StudioCore.Editor
             }
 
             // Refresh diff cache
-            TaskManager.Run("Param - Check Differences", false, true, true, () => ParamBank.PrimaryBank.RefreshParamDiffCaches());
+            TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
             return ActionEvent.NoEvent;
         }
     }

--- a/StudioCore/Editor/AliasBank.cs
+++ b/StudioCore/Editor/AliasBank.cs
@@ -51,7 +51,7 @@ namespace StudioCore.Editor
         }
         public static void ReloadAliases()
         {
-            TaskManager.Run("Map - Load Names", true, false, false, () =>
+            TaskManager.Run(new("Map - Load Names", true, false, false, () =>
             {
                 _mapNames = new Dictionary<string, string>();
                 IsLoadingAliases = true;
@@ -60,7 +60,7 @@ namespace StudioCore.Editor
                     LoadMapNames();
                 }
                 IsLoadingAliases = false;
-            });
+            }));
         }
 
         public static void SetAssetLocator(AssetLocator l)

--- a/StudioCore/MsbEditor/MtdBank.cs
+++ b/StudioCore/MsbEditor/MtdBank.cs
@@ -35,7 +35,7 @@ namespace StudioCore.MsbEditor
         public static void ReloadMtds()
         {
 
-            TaskManager.Run("Resource - Load MTDs", true, false, false, () =>
+            TaskManager.Run(new("Resource - Load MTDs", true, false, false, () =>
             {
                 try
                 {
@@ -89,7 +89,7 @@ namespace StudioCore.MsbEditor
                     _mtds = new Dictionary<string, MTD>();
                     _matbins = new Dictionary<string, MATBIN>();
                 }
-            });
+            }));
         }
 
         public static void LoadMtds(AssetLocator l)

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -739,18 +739,18 @@ namespace StudioCore.ParamEditor
 
             CacheBank.ClearCaches();
 
-            TaskManager.Run("Param - Load Params", true, false, false, () =>
+            TaskManager.Run(new("Param - Load Params", true, false, false, () =>
             {
                 if (PrimaryBank.AssetLocator.Type != GameType.Undefined)
                 {
                     List<(string, PARAMDEF)> defPairs = LoadParamdefs(locator);
                     IsDefsLoaded = true;
-                    TaskManager.Run("Param - Load Meta", true, false, false, () =>
+                    TaskManager.Run(new("Param - Load Meta", true, false, false, () =>
                     {
                         IsMetaLoaded = false;
                         LoadParamMeta(defPairs, locator);
                         IsMetaLoaded = true;
-                    });
+                    }));
                 }
                 if (locator.Type == GameType.DemonsSouls)
                 {
@@ -786,7 +786,7 @@ namespace StudioCore.ParamEditor
 
                 VanillaBank.IsLoadingParams = true;
                 VanillaBank._params = new Dictionary<string, Param>();
-                TaskManager.Run("Param - Load Vanilla Params", true, false, false, () =>
+                TaskManager.Run(new("Param - Load Vanilla Params", true, false, false, () =>
                 {
                     if (locator.Type == GameType.DemonsSouls)
                     {
@@ -818,8 +818,8 @@ namespace StudioCore.ParamEditor
                     }
                     VanillaBank.IsLoadingParams = false;
 
-                    TaskManager.Run("Param - Check Differences", true, false, false, () => PrimaryBank.RefreshParamDiffCaches());
-                });
+                    TaskManager.Run(new("Param - Check Differences", true, false, false, () => PrimaryBank.RefreshParamDiffCaches()));
+                }));
 
                 if (options != null)
                 {
@@ -836,7 +836,7 @@ namespace StudioCore.ParamEditor
                         }
                     }
                 }
-            });
+            }));
         }
         public static void LoadAuxBank(string path, string looseDir, string enemyPath, ProjectSettings settings)
         {

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -902,7 +902,7 @@ namespace StudioCore.ParamEditor
                     MassEditResult r = MassParamEditCSV.PerformMassEdit(ParamBank.PrimaryBank, _currentMEditCSVInput, EditorActionManager, _activeView._selection.getActiveParam(), _mEditCSVAppendOnly, _mEditCSVAppendOnly && _mEditCSVReplaceRows, CFG.Current.Param_Export_Delimiter[0]);
                     if (r.Type == MassEditResultType.SUCCESS)
                     {
-                        TaskManager.Run(new( "Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
+                        TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                     }
                     _mEditCSVResult = r.Information;
                 }

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -287,12 +287,12 @@ namespace StudioCore.ParamEditor
         private void ParamUndo()
         {
             EditorActionManager.UndoAction();
-            TaskManager.Run("Param - Check Differences", false, true, true, () => ParamBank.PrimaryBank.RefreshParamDiffCaches());
+            TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
         }
         private void ParamRedo()
         {
             EditorActionManager.RedoAction();
-            TaskManager.Run("Param - Check Differences", false, true, true, () => ParamBank.PrimaryBank.RefreshParamDiffCaches());
+            TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
         }
 
         public void DrawEditorMenu()
@@ -438,7 +438,7 @@ namespace StudioCore.ParamEditor
                                 {
                                     MassEditResult r = MassParamEditCSV.PerformMassEdit(ParamBank.PrimaryBank, csv, EditorActionManager, _activeView._selection.getActiveParam(), false, false, CFG.Current.Param_Export_Delimiter[0]);
                                     if (r.Type == MassEditResultType.SUCCESS)
-                                        TaskManager.Run("Param - Check Differences", false, true, true, () => ParamBank.PrimaryBank.RefreshParamDiffCaches());
+                                        TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                                     else
                                         PlatformUtils.Instance.MessageBox(r.Information, "Error", MessageBoxButtons.OK, MessageBoxIcon.None);
                                 }
@@ -461,7 +461,7 @@ namespace StudioCore.ParamEditor
                                         EditorActionManager.ExecuteAction(a);
                                     else
                                         PlatformUtils.Instance.MessageBox(r.Information, "Error", MessageBoxButtons.OK, MessageBoxIcon.None);
-                                    TaskManager.Run("Param - Check Differences", false, true, true, () => ParamBank.PrimaryBank.RefreshParamDiffCaches());
+                                    TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                                 }
                             }
                         }
@@ -486,7 +486,7 @@ namespace StudioCore.ParamEditor
                                                 EditorActionManager.ExecuteAction(a);
                                             else
                                                 PlatformUtils.Instance.MessageBox(r.Information, "Error", MessageBoxButtons.OK, MessageBoxIcon.None);
-                                            TaskManager.Run("Param - Check Differences", false, true, true, () => ParamBank.PrimaryBank.RefreshParamDiffCaches());
+                                            TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                                         }
                                     }
                                 }
@@ -862,7 +862,7 @@ namespace StudioCore.ParamEditor
                     {
                         _lastMEditRegexInput = _currentMEditRegexInput;
                         _currentMEditRegexInput = "";
-                        TaskManager.Run("Param - Check Differences", false, true, true, () => ParamBank.PrimaryBank.RefreshParamDiffCaches());
+                        TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                     }
                     _mEditRegexResult = r.Information;
                 }
@@ -902,7 +902,7 @@ namespace StudioCore.ParamEditor
                     MassEditResult r = MassParamEditCSV.PerformMassEdit(ParamBank.PrimaryBank, _currentMEditCSVInput, EditorActionManager, _activeView._selection.getActiveParam(), _mEditCSVAppendOnly, _mEditCSVAppendOnly && _mEditCSVReplaceRows, CFG.Current.Param_Export_Delimiter[0]);
                     if (r.Type == MassEditResultType.SUCCESS)
                     {
-                        TaskManager.Run("Param - Check Differences", false, true, true, () => ParamBank.PrimaryBank.RefreshParamDiffCaches());
+                        TaskManager.Run(new( "Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                     }
                     _mEditCSVResult = r.Information;
                 }

--- a/StudioCore/ParamEditor/ParamReloader.cs
+++ b/StudioCore/ParamEditor/ParamReloader.cs
@@ -32,7 +32,7 @@ namespace StudioCore.ParamEditor
 
         public static void ReloadMemoryParams(ParamBank bank, AssetLocator loc, string[] paramNames)
         {
-            TaskManager.Run("Param - Hot Reload", true, true, true, () =>
+            TaskManager.Run(new("Param - Hot Reload", true, true, true, () =>
             {
                 GameOffsets offsets = GetGameOffsets(loc);
                 var processArray = Process.GetProcessesByName(offsets.exeName);
@@ -52,7 +52,7 @@ namespace StudioCore.ParamEditor
                 {
                     throw new Exception("Unable to find running game");
                 }
-            });
+            }));
         }
         private static GameOffsets GetCorrectPTDEOffsets(GameOffsets offsets, SoulsMemoryHandler memoryHandler)
         {

--- a/StudioCore/Resource/ResourceManager.cs
+++ b/StudioCore/Resource/ResourceManager.cs
@@ -787,7 +787,6 @@ namespace StudioCore.Resource
         }
 
         private static bool TaskWindowOpen = true;
-        private static bool ResourceListWindowOpen = true;
         public static void OnGuiDrawTasks(float w, float h)
         {
             float scale = MapStudioNew.GetUIScale();
@@ -824,7 +823,7 @@ namespace StudioCore.Resource
 
         public static void OnGuiDrawResourceList()
         {
-            if (!ImGui.Begin("Resource List", ref ResourceListWindowOpen))
+            if (!ImGui.Begin("Resource List"))
             {
                 ImGui.End();
                 return;

--- a/StudioCore/TaskLogs.cs
+++ b/StudioCore/TaskLogs.cs
@@ -195,7 +195,7 @@ namespace StudioCore
                     0.4f + 0.5f * mult,
                     alpha);
             }
-            else if (level is LogLevel.Warning or LogLevel.Error or LogLevel.Critical)
+            else if (level is LogLevel.Warning)
             {
                 return new Vector4(
                     1.0f - 0.1f * mult,

--- a/StudioCore/TextEditor/FMGBank.cs
+++ b/StudioCore/TextEditor/FMGBank.cs
@@ -1011,7 +1011,7 @@ namespace StudioCore.TextEditor
 
         public static void ReloadFMGs(string languageFolder = "")
         {
-            TaskManager.Run("FMG - Load Text", true, false, true, () =>
+            TaskManager.Run(new("FMG - Load Text", true, false, true, () =>
             {
                 IsLoaded = false;
                 IsLoading = true;
@@ -1054,7 +1054,7 @@ namespace StudioCore.TextEditor
 
                 IsLoaded = true;
                 IsLoading = false;
-            });
+            }));
         }
 
         private static bool ReloadDS2FMGs()


### PR DESCRIPTION
Lets TaskLogs store log priority, currently affecting whether they will appear in the main menu bar (and in the future, filterable in the full log window)

And because this required another variable passed through TaskManager funcs, it was restructured to use the new LiveTask class to keep things a bit more organized and easier to modify in the future.

(Also removes close window X from "Resource List", in ResourceManager.cs)