### PR TITLE
Entity: if scale is 0 0 0, clamp to min value

### DIFF
--- a/StudioCore/MsbEditor/Entity.cs
+++ b/StudioCore/MsbEditor/Entity.cs
@@ -1433,6 +1433,11 @@ namespace StudioCore.MsbEditor
                     t.Scale.Z = (float)sz;
                 }
             }
+
+            // Prevent zero scale since it won't render
+            if (t.Scale == Vector3.Zero)
+                t.Scale = new Vector3(0.1f);
+
             return t;
         }
 


### PR DESCRIPTION
Done because ds3 has a decent amount of 0 radius spheres. Iffy on whether this is the best solution.