### PR TITLE
Copy columns when cloning FSParam param

### DIFF
--- a/FSParam/Param.cs
+++ b/FSParam/Param.cs
@@ -656,6 +656,7 @@ namespace FSParam
             ParamType = source.ParamType;
             RowSize = source.RowSize;
             _paramData = new StridedByteArray((uint)source._rows.Count, (uint)RowSize, BigEndian);
+            Columns = source.Columns;
             AppliedParamdef = source.AppliedParamdef;
         }
         


### PR DESCRIPTION
Fixes a crash after upgrading params. Same deal as #556 