### PR TITLE
Strip and store DS2 row names to external files on save

### DIFF
--- a/StudioCore/AssetLocator.cs
+++ b/StudioCore/AssetLocator.cs
@@ -100,6 +100,11 @@ namespace StudioCore
         /// </summary>
         public string GameModDirectory { get; private set; } = null;
 
+        /// <summary>
+        /// Directory where misc DSMapStudio files associated with a project are stored.
+        /// </summary>
+        public string ProjectMiscDir => @$"{GameModDirectory}\DSMapStudio";
+
         public AssetLocator()
         {
             GameExecutableFilter = new FileFilter { Name = "Game Executable (.EXE, EBOOT.BIN)" };
@@ -766,7 +771,7 @@ namespace StudioCore
         {
             return $@"{GetParamAssetsDir()}\Defs";
         }
-        
+
         public ulong[] GetParamdefPatches()
         {
             if (Directory.Exists($@"{GetParamAssetsDir()}\DefsPatch"))
@@ -790,6 +795,13 @@ namespace StudioCore
         public string GetParamNamesDir()
         {
             return $@"{GetParamAssetsDir()}\Names";
+        }
+
+        public string GetStrippedRowNamesPath(string paramName)
+        {
+            string dir = $@"{ProjectMiscDir}\Stripped Row Names";
+            Directory.CreateDirectory(dir);
+            return $@"{dir}\{paramName}.txt"; ;
         }
 
         public PARAMDEF GetParamdefForParam(string paramType)

--- a/StudioCore/AssetLocator.cs
+++ b/StudioCore/AssetLocator.cs
@@ -800,7 +800,6 @@ namespace StudioCore
         public string GetStrippedRowNamesPath(string paramName)
         {
             string dir = $@"{ProjectMiscDir}\Stripped Row Names";
-            Directory.CreateDirectory(dir);
             return $@"{dir}\{paramName}.txt"; ;
         }
 

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -1136,12 +1136,6 @@ namespace StudioCore
                     "Default: ON\nImports and applies row names from lists stored in Assets folder.\nRow names can be imported at any time in the param editor's Edit menu.");
                 ImGui.SameLine();
                 ImGui.Checkbox("##loadDefaultNames", ref _newProjectOptions.loadDefaultNames);
-                if (_newProjectOptions.settings.UseLooseParams == false
-                    && _newProjectOptions.loadDefaultNames == true
-                    && _newProjectOptions.settings.GameType == GameType.DarkSoulsIISOTFS)
-                {
-                    ImGui.TextColored(new Vector4(1.0f, 0.4f, 0.4f, 1.0f), "Warning: Saving too many row names onto non-loose params will crash the game. It is highly recommended you use loose params with Dark Souls 2.");
-                }
                 ImGui.NewLine();
 
                 if (_newProjectOptions.settings.GameType == GameType.Undefined)

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -45,6 +45,7 @@ namespace StudioCore.ParamEditor
         private Dictionary<string, Param> _params = null;
         private Dictionary<string, HashSet<int>> _vanillaDiffCache = null; //If param != vanillaparam
         private Dictionary<string, HashSet<int>> _primaryDiffCache = null; //If param != primaryparam
+        private Dictionary<string, List<string?>> _storedStrippedRowNames = null;
 
         private bool _pendingUpgrade = false;
 
@@ -571,6 +572,7 @@ namespace StudioCore.ParamEditor
                 enemyFile = $@"{dir}\Param\EnemyParam.param";
             }
             LoadParamsDS2FromFile(looseParams, param, enemyFile, loose);
+            LoadExternalRowNames();
         }
         private void LoadVParamsDS2(bool loose)
         {
@@ -1171,21 +1173,21 @@ namespace StudioCore.ParamEditor
                 paramBnd = BND4.Read(param);
             }
 
-            // If params aren't loose, replace params with edited ones
             if (!loose)
             {
-                // Replace params in paramBND, write remaining params loosely
+                // Save params non-loosely: Replace params regulation and write remaining params loosely.
+
                 if (paramBnd.Files.Find(e => e.Name.EndsWith(".param")) == null)
                 {
                     if (PlatformUtils.Instance.MessageBox("It appears that you are trying to save params non-loosely with an \"enc_regulation.bnd\" that has previously been saved loosely." +
-                                                          "\n\nWould you like to reinsert params into the bnd that were previously stripped out?", "DS2 de-loose param",
+                                                            "\n\nWould you like to reinsert params into the bnd that were previously stripped out?", "DS2 de-loose param",
                         MessageBoxButtons.YesNo) == DialogResult.Yes)
                     {
                         paramBnd.Dispose();
                         param = $@"{dir}\enc_regulation.bnd.dcx";
                         if (!BND4.Is($@"{dir}\enc_regulation.bnd.dcx"))
                         {
-                            // Decrypt the file
+                            // Decrypt the file.
                             paramBnd = SFUtil.DecryptDS2Regulation(param);
 
                             // Since the file is encrypted, check for a backup. If it has none, then make one and write a decrypted one.
@@ -1201,26 +1203,41 @@ namespace StudioCore.ParamEditor
                         }
                     }
                 }
-
-                foreach (var p in _params)
+                try
                 {
-                    var bnd = paramBnd.Files.Find(e => Path.GetFileNameWithoutExtension(e.Name) == p.Key);
-                    if (bnd != null)
+                    // Strip and store row names before saving, as too many row names can cause DS2 to crash.
+                    StripRowNames();
+
+                    foreach (var p in _params)
                     {
-                        bnd.Bytes = p.Value.Write();
-                    }
-                    else
-                    {
-                        Utils.WriteWithBackup(dir, mod, $@"Param\{p.Key}.param", p.Value);
+                        var bnd = paramBnd.Files.Find(e => Path.GetFileNameWithoutExtension(e.Name) == p.Key);
+                        if (bnd != null)
+                        {
+                            // Regulation contains this param, overwrite it.
+                            bnd.Bytes = p.Value.Write();
+                        }
+                        else
+                        {
+                            // Regulation does not contain this param, write param loosely.
+                            Utils.WriteWithBackup(dir, mod, $@"Param\{p.Key}.param", p.Value);
+                        }
                     }
                 }
+                catch
+                {
+                    RestoreStrippedRowNames();
+                    throw;
+                }
+                RestoreStrippedRowNames();
             }
             else
             {
-                // strip all the params from the regulation
+                // Save params loosely: Strip params from regulation and write all params loosely.
+
                 List<BinderFile> newFiles = new List<BinderFile>();
                 foreach (var p in paramBnd.Files)
                 {
+                    // Strip params from regulation bnd
                     if (!p.Name.ToUpper().Contains(".PARAM"))
                     {
                         newFiles.Add(p);
@@ -1228,12 +1245,23 @@ namespace StudioCore.ParamEditor
                 }
                 paramBnd.Files = newFiles;
 
-                // Write all the params out loose
-                foreach (var p in _params)
+                try
                 {
-                    Utils.WriteWithBackup(dir, mod, $@"Param\{p.Key}.param", p.Value);
-                }
+                    // Strip and store row names before saving, as too many row names can cause DS2 to crash.
+                    StripRowNames();
 
+                    // Write params to loose files.
+                    foreach (var p in _params)
+                    {
+                        Utils.WriteWithBackup(dir, mod, $@"Param\{p.Key}.param", p.Value);
+                    }
+                }
+                catch
+                {
+                    RestoreStrippedRowNames();
+                    throw;
+                }
+                RestoreStrippedRowNames();
             }
             Utils.WriteWithBackup(dir, mod, @"enc_regulation.bnd.dcx", paramBnd);
             paramBnd.Dispose();
@@ -1865,6 +1893,80 @@ namespace StudioCore.ParamEditor
             if (allDiffs == null || !allDiffs.ContainsKey(param))
                 return EMPTYSET;
             return allDiffs[param];
+        }
+
+        /// <summary>
+        /// Loads row names from external files and applies them to params.
+        /// Uses indicies rather than IDs.
+        /// </summary>
+        private void LoadExternalRowNames()
+        {
+            int failCount = 0;
+            foreach (var p in _params)
+            {
+                var path = AssetLocator.GetStrippedRowNamesPath(p.Key);
+                if (File.Exists(path))
+                {
+                    var names = File.ReadAllLines(path);
+                    if (names.Length != p.Value.Rows.Count)
+                    {
+                        TaskLogs.AddLog($"External row names could not be applied to {p.Key}, row count does not match",
+                            Microsoft.Extensions.Logging.LogLevel.Warning, TaskLogs.LogPriority.Low);
+                        failCount++;
+                        continue;
+                    }
+
+                    for (var i = 0; i < names.Length; i++)
+                    {
+                        p.Value.Rows[i].Name = names[i];
+                    }
+                }
+            }
+            if (failCount > 0)
+            {
+                TaskLogs.AddLog($"External row names could not be applied to {failCount} params due to non-matching row counts.",
+                    Microsoft.Extensions.Logging.LogLevel.Warning);
+            }
+        }
+
+        /// <summary>
+        /// Strips row names from params, saves them to files, and stores them to be restored after saving params.
+        /// Should always be used in conjunction with RestoreStrippedRowNames().
+        /// </summary>
+        private void StripRowNames()
+        {
+            _storedStrippedRowNames = new();
+            foreach (var p in _params)
+            {
+                _storedStrippedRowNames.TryAdd(p.Key, new());
+                var list = _storedStrippedRowNames[p.Key];
+                foreach (var r in p.Value.Rows)
+                {
+                    list.Add(r.Name);
+                    r.Name = "";
+                }
+                File.WriteAllLines(AssetLocator.GetStrippedRowNamesPath(p.Key), list);
+            }
+        }
+
+        /// <summary>
+        /// Restores stripped row names back to all params.
+        /// Should always be used in conjunction with StripRowNames().
+        /// </summary>
+        private void RestoreStrippedRowNames()
+        {
+            if (_storedStrippedRowNames == null)
+                throw new InvalidOperationException("No stripped row names have been stored.");
+
+            foreach (var p in _params)
+            {
+                var storedNames = _storedStrippedRowNames[p.Key];
+                for (var i = 0; i < p.Value.Rows.Count; i++)
+                {
+                    p.Value.Rows[i].Name = storedNames[i];
+                }
+            }
+            _storedStrippedRowNames = null;
         }
     }
 }

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -1945,7 +1945,9 @@ namespace StudioCore.ParamEditor
                     list.Add(r.Name);
                     r.Name = "";
                 }
-                File.WriteAllLines(AssetLocator.GetStrippedRowNamesPath(p.Key), list);
+                var path = AssetLocator.GetStrippedRowNamesPath(p.Key);
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                File.WriteAllLines(path, list);
             }
         }
 

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -608,11 +608,6 @@ namespace StudioCore.ParamEditor
                 }
                 if (ImGui.BeginMenu("Import row names"))
                 {
-                    if (_projectSettings.GameType == GameType.DarkSoulsIISOTFS && _projectSettings.UseLooseParams == false)
-                    {
-                        ImGui.TextColored(new Vector4(1.0f, 0.4f, 0.4f, 1.0f), "Warning: Saving too many row names onto non-loose params will crash the game.\nIt is highly recommended you use loose params with Dark Souls 2.");
-                    }
-
                     void ImportRowNames(bool currentParamOnly, string title)
                     {
                         const string importRowQuestion = $"Would you like to replace row names with default names defined within DSMapStudio?\n\nSelect \"Yes\" to replace all names, \"No\" to only replace empty names, \"Cancel\" to abort.";


### PR DESCRIPTION
Strips DS2 row names from saved params on param save.
Saves DS2 row names to external files on param save.
Restores external row name files on project load.

Done in part because apparently loose params, like regulation, crash with too many row names. Text that stated this incorrect info was also removed.