### PR TITLE
Support BTL v15, implement LightSize

### DIFF
--- a/SoulsFormats/SoulsFormats/Formats/BTL.cs
+++ b/SoulsFormats/SoulsFormats/Formats/BTL.cs
@@ -17,7 +17,7 @@ namespace SoulsFormats
 
         /// <summary>
         /// Indicates size of BTL Light.
-        /// Usually number of bytes, with the exception of DS2's 0xC0 (which has 0xC8)bytes .
+        /// Usually number of bytes, with the exception of DS2's 0xC0 (which has 0xC8 bytes).
         /// </summary>
         public int LightSize { get; set; }
 

--- a/SoulsFormats/SoulsFormats/Formats/BTL.cs
+++ b/SoulsFormats/SoulsFormats/Formats/BTL.cs
@@ -16,7 +16,8 @@ namespace SoulsFormats
         public int Version { get; set; }
 
         /// <summary>
-        /// Indicates size of BTL.Light in bytes.
+        /// Indicates size of BTL Light.
+        /// Usually number of bytes, with the exception of DS2's 0xC0 (which has 0xC8)bytes .
         /// </summary>
         public int LightSize { get; set; }
 

--- a/SoulsFormats/SoulsFormats/Formats/BTL.cs
+++ b/SoulsFormats/SoulsFormats/Formats/BTL.cs
@@ -16,8 +16,7 @@ namespace SoulsFormats
         public int Version { get; set; }
 
         /// <summary>
-        /// Indicates size of BTL Light.
-        /// Usually number of bytes, with the exception of DS2's 0xC0 (which has 0xC8 bytes).
+        /// Indicates size of BTL Light in bytes.
         /// </summary>
         public int LightSize { get; set; }
 


### PR DESCRIPTION
(BTL v15 is used exactly twice in ER)
Created BTL LightSize field, and use it to determine number of fields instead of BTL version.