### PR TITLE
Model editor: build cache on category select, fix ER map models

### DIFF
--- a/StudioCore/AssetLocator.cs
+++ b/StudioCore/AssetLocator.cs
@@ -921,6 +921,23 @@ namespace StudioCore
                 ad.AssetArchiveVirtualPath = $@"map/{mapid}/model";
                 ret.Add(ad);
             }
+            else if (Type == GameType.EldenRing)
+            {
+                var mapPath = GameRootDirectory + $@"\map\{mapid[..3]}\{mapid}";
+                if (!Directory.Exists(mapPath))
+                    return ret;
+                var mapfiles = Directory.GetFileSystemEntries(mapPath, @"*.mapbnd.dcx").ToList();
+                foreach (var f in mapfiles)
+                {
+                    var ad = new AssetDescription();
+                    ad.AssetPath = f;
+                    var name = Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(f));
+                    ad.AssetName = name;
+                    ad.AssetArchiveVirtualPath = $@"map/{mapid}/model/{name}";
+                    ad.AssetVirtualPath = $@"map/{mapid}/model/{name}/{name}.flver";
+                    ret.Add(ad);
+                }
+            }
             else
             {
                 if (!Directory.Exists(GameRootDirectory + $@"\map\{mapid}\"))
@@ -1009,6 +1026,10 @@ namespace StudioCore
             {
                 ret.AssetPath = GetAssetPath($@"model\map\{mapid}.mapbhd");
             }
+            else if (Type == GameType.EldenRing)
+            {
+                ret.AssetPath = GetAssetPath($@"map\{mapid[..3]}\{mapid}\{model}.mapbnd.dcx");
+            }
             else
             {
                 ret.AssetPath = GetAssetPath($@"map\{mapid}\{model}.mapbnd.dcx");
@@ -1021,7 +1042,10 @@ namespace StudioCore
             }
             else
             {
-                if (Type != GameType.DarkSoulsPTDE && Type != GameType.DarkSoulsRemastered && Type != GameType.Bloodborne && Type != GameType.DemonsSouls)
+                if (Type is not GameType.DemonsSouls
+                    and not GameType.DarkSoulsPTDE
+                    and not GameType.DarkSoulsRemastered
+                    and not GameType.Bloodborne)
                 {
                     ret.AssetArchiveVirtualPath = $@"map/{mapid}/model/{model}";
                 }

--- a/StudioCore/MsbEditor/AssetBrowser.cs
+++ b/StudioCore/MsbEditor/AssetBrowser.cs
@@ -40,26 +40,18 @@ namespace StudioCore.MsbEditor
             _handler = handler;
         }
 
-        public void RebuildCaches()
+        public void ClearCaches()
         {
             _chrCache = new List<string>();
             _objCache = new List<string>();
             _mapModelCache = new Dictionary<string, List<string>>();
-            _chrCache = _locator.GetChrModels();
-            _objCache = _locator.GetObjModels();
             var mapList = _locator.GetFullMapList();
             foreach (var m in mapList)
             {
                 var adjm = _locator.GetAssetMapID(m);
                 if (!_mapModelCache.ContainsKey(adjm))
                 {
-                    var modelList = _locator.GetMapModels(adjm);
-                    var cache = new List<string>();
-                    foreach (var model in modelList)
-                    {
-                        cache.Add(model.AssetName);
-                    }
-                    _mapModelCache.Add(adjm, cache);
+                    _mapModelCache.Add(adjm, null);
                 }
             }
         }
@@ -72,16 +64,33 @@ namespace StudioCore.MsbEditor
                 ImGui.BeginChild("AssetTypeList");
                 if (ImGui.Selectable("Chr", _selected == "Chr"))
                 {
+                    _chrCache = _locator.GetChrModels();
                     _selected = "Chr";
                 }
-                if (ImGui.Selectable("Obj", _selected == "Obj"))
+                string objLabel = "Obj";
+                if (_locator.Type is GameType.EldenRing)
                 {
+                    objLabel = "Aeg";
+                }
+                if (ImGui.Selectable(objLabel, _selected == "Obj"))
+                {
+                    _objCache = _locator.GetObjModels();
                     _selected = "Obj";
                 }
                 foreach (var m in _mapModelCache.Keys)
                 {
                     if (ImGui.Selectable(m, _selected == m))
                     {
+                        if (_mapModelCache[m] == null)
+                        {
+                            var modelList = _locator.GetMapModels(m);
+                            var cache = new List<string>();
+                            foreach (var model in modelList)
+                            {
+                                cache.Add(model.AssetName);
+                            }
+                            _mapModelCache[m] = cache;
+                        }
                         _selected = m;
                     }
                 }

--- a/StudioCore/MsbEditor/ModelEditorScreen.cs
+++ b/StudioCore/MsbEditor/ModelEditorScreen.cs
@@ -287,7 +287,7 @@ namespace StudioCore.MsbEditor
         {
             if (AssetLocator.Type != GameType.Undefined)
             {
-                _assetBrowser.RebuildCaches();
+                _assetBrowser.ClearCaches();
             }
         }
 


### PR DESCRIPTION
Builds model editor caches upon selecting model category instead of project load (improves DSMS startup time by a decent amount on slower hard drives).