### PR TITLE
Hotfix: startup tasks never finishing due to soapstone server task

### DIFF
--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -262,7 +262,7 @@ namespace StudioCore
 
             if (CFG.Current.EnableSoapstone)
             {
-                TaskManager.Run(new("Initialize Soapstone Server", false, false, true, () => SoapstoneServer.RunAsync(KnownServer.DSMapStudio, _soapstoneService).Wait()));
+                TaskManager.Run(new("Initialize Soapstone Server", false, false, true, () => SoapstoneServer.RunAsync(KnownServer.DSMapStudio, _soapstoneService)));
             }
 
             if (CFG.Current.EnableCheckProgramUpdate)


### PR DESCRIPTION
Bad fix, but immediately necessary because startup tasks need to finish before DSMS can do certain things.