### PR TITLE
Avoid doxxing developer paths when throwing exceptions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <PathMap>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=./</PathMap>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
Replaces the absolute path leading up to the project folder in exception track traces with ".", which not only prevents doxxing the respective build compiler's folder structure - which may potentially include their OS profile name - but also makes the exceptions more readable.