### PR TITLE
TaskManager refactor, passive LiveTasks

### DIFF
--- a/StudioCore/Editor/Action.cs
+++ b/StudioCore/Editor/Action.cs
@@ -220,7 +220,7 @@ namespace StudioCore.Editor
 
             // Refresh diff cache
             TaskManager.Run(new("Param - Check Differences",
-                TaskManager.RequeueTypeEnum.Repeat, true,
+                TaskManager.RequeueType.Repeat, true,
                 TaskLogs.LogPriority.Low,
                 () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
             return ActionEvent.NoEvent;
@@ -283,7 +283,7 @@ namespace StudioCore.Editor
 
             // Refresh diff cache
             TaskManager.Run(new("Param - Check Differences",
-                TaskManager.RequeueTypeEnum.Repeat, true,
+                TaskManager.RequeueType.Repeat, true,
                 TaskLogs.LogPriority.Low,
                 () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
             return ActionEvent.NoEvent;

--- a/StudioCore/Editor/Action.cs
+++ b/StudioCore/Editor/Action.cs
@@ -219,7 +219,10 @@ namespace StudioCore.Editor
             }
 
             // Refresh diff cache
-            TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
+            TaskManager.Run(new("Param - Check Differences",
+                TaskManager.RequeueTypeEnum.Repeat, true,
+                TaskLogs.LogPriority.Low,
+                () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
             return ActionEvent.NoEvent;
         }
 
@@ -279,7 +282,10 @@ namespace StudioCore.Editor
             }
 
             // Refresh diff cache
-            TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
+            TaskManager.Run(new("Param - Check Differences",
+                TaskManager.RequeueTypeEnum.Repeat, true,
+                TaskLogs.LogPriority.Low,
+                () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
             return ActionEvent.NoEvent;
         }
     }

--- a/StudioCore/Editor/AliasBank.cs
+++ b/StudioCore/Editor/AliasBank.cs
@@ -51,7 +51,7 @@ namespace StudioCore.Editor
         }
         public static void ReloadAliases()
         {
-            TaskManager.Run(new("Map - Load Names", TaskManager.RequeueTypeEnum.WaitThenRequeue, false, () =>
+            TaskManager.Run(new("Map - Load Names", TaskManager.RequeueType.WaitThenRequeue, false, () =>
             {
                 _mapNames = new Dictionary<string, string>();
                 IsLoadingAliases = true;

--- a/StudioCore/Editor/AliasBank.cs
+++ b/StudioCore/Editor/AliasBank.cs
@@ -51,7 +51,7 @@ namespace StudioCore.Editor
         }
         public static void ReloadAliases()
         {
-            TaskManager.Run(new("Map - Load Names", true, false, false, () =>
+            TaskManager.Run(new("Map - Load Names", TaskManager.RequeueTypeEnum.WaitThenRequeue, false, () =>
             {
                 _mapNames = new Dictionary<string, string>();
                 IsLoadingAliases = true;

--- a/StudioCore/Editor/TaskManager.cs
+++ b/StudioCore/Editor/TaskManager.cs
@@ -3,125 +3,210 @@ using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Linq;
+using System.Diagnostics;
 
 namespace StudioCore.Editor
 {
     public class TaskManager
     {
-        private static volatile ConcurrentDictionary<string, (bool, Task)> _liveTasks = new ConcurrentDictionary<string, (bool, Task)>();
-        private static int _anonIndex = 0;
+        /// <summary>
+        /// Behavior of a LiveTask added when a task with the same task ID is already running.
+        /// </summary>
+        public enum RequeueTypeEnum
+        {
+            // Don't requeue.
+            None,
+
+            // Wait for first task to finish, then run.
+            WaitThenRequeue,
+
+            // Tell first task to run again after finishing.
+            Repeat
+        }
+
+        private static volatile ConcurrentDictionary<string, LiveTask> _liveTasks = new();
+
+        /// <summary>
+        /// Number of non-passive tasks that are currently running.
+        /// </summary>
+        public static int ActiveTaskNum { get; private set; } = 0;
 
         public class LiveTask
         {
-            public string TaskId;
-            public bool Wait;
-            public bool CanRequeue;
-            public bool SilentFail;
-            public TaskLogs.LogPriority LogPriority;
-            public Action TaskAction;
+            /// <summary>
+            /// Unique identifier for task.
+            /// If more than one LiveTask with the same ID is run, RequeueType is checked.
+            /// </summary>
+            public readonly string TaskId;
+
+            /// <summary>
+            /// Behavior of a LiveTask added when a task with the same task ID is already running.
+            /// </summary>
+            public readonly RequeueTypeEnum RequeueType;
+
+            public readonly TaskLogs.LogPriority LogPriority;
+            public readonly Action TaskAction;
+
+            /// <summary>
+            /// If true, exceptions will be suppressed and logged.
+            /// </summary>
+            public readonly bool SilentFail;
+
+            public Task Task { get; private set; } = null;
+
+            /// <summary>
+            /// If true, task will run again after finishing.
+            /// </summary>
+            public bool HasScheduledRequeue = false;
+
+            /// <summary>
+            /// True for tasks that are intended to be running as long as DSMS is running.
+            /// </summary>
+            public bool PassiveTask = false;
 
             public LiveTask() { }
 
-            public LiveTask(string taskId, bool wait, bool canRequeue, bool silentFail, Action act)
+            public LiveTask(string taskId, RequeueTypeEnum requeueType, bool silentFail, Action act)
             {
                 TaskId = taskId;
-                Wait = wait;
-                CanRequeue = canRequeue;
+                RequeueType = requeueType;
                 SilentFail = silentFail;
                 LogPriority = TaskLogs.LogPriority.Normal;
                 TaskAction = act;
             }
 
-            public LiveTask(string taskId, bool wait, bool canRequeue, bool silentFail, TaskLogs.LogPriority logPriority, Action act)
+            public LiveTask(string taskId, RequeueTypeEnum requeueType, bool silentFail, TaskLogs.LogPriority logPriority, Action act)
             {
                 TaskId = taskId;
-                Wait = wait;
-                CanRequeue = canRequeue;
+                RequeueType = requeueType;
                 SilentFail = silentFail;
                 LogPriority = logPriority;
                 TaskAction = act;
             }
-        }
 
-        public static bool Run(LiveTask liveTask)
-        {
-            bool add = AddTask(liveTask);
-
-            if (!add)
+            public LiveTask(string taskId, bool silentFail, Action act)
             {
-                if (liveTask.Wait)
-                {
-                    (bool, Task) t;
-                    if (_liveTasks.TryGetValue(liveTask.TaskId, out t))
-                    {
-                        t.Item2.Wait();
-                        return AddTask(liveTask);                        
-                    }
-                }
-                if (liveTask.CanRequeue)
-                {
-                    (bool, Task) t;
-                    if (_liveTasks.TryGetValue(liveTask.TaskId, out t))
-                    {
-                        if (t.Item1 == false)
-                            _liveTasks[liveTask.TaskId] = (true, t.Item2);
-                    }
-                    return true;
-                }
+                TaskId = taskId;
+                RequeueType = RequeueTypeEnum.None;
+                SilentFail = silentFail;
+                LogPriority = TaskLogs.LogPriority.Normal;
+                TaskAction = act;
             }
 
-            return true;
-        }
-
-        private static bool AddTask(LiveTask liveTask)
-        {
-            if (liveTask.TaskId == null)
+            public LiveTask(string taskId, bool silentFail, TaskLogs.LogPriority logPriority, Action act)
             {
-                _anonIndex++;
-                liveTask.TaskId = Thread.CurrentThread.Name+":"+_anonIndex;
+                TaskId = taskId;
+                RequeueType = RequeueTypeEnum.None;
+                SilentFail = silentFail;
+                LogPriority = logPriority;
+                TaskAction = act;
             }
 
-            Task t = new Task(() => {
-                try
+            public void Run()
+            {
+                if (_liveTasks.TryGetValue(TaskId, out var oldLiveTask))
                 {
-                    liveTask.TaskAction.Invoke();
-                    TaskLogs.AddLog($"Task Completed: {liveTask.TaskId}",
-                        Microsoft.Extensions.Logging.LogLevel.Information,
-                        liveTask.LogPriority);
-                }
-                catch (Exception e)
-                {
-                    if (liveTask.SilentFail)
+                    if (oldLiveTask.RequeueType == RequeueTypeEnum.WaitThenRequeue)
                     {
-                        TaskLogs.AddLog($"Task Failed: {liveTask.TaskId}",
-                            Microsoft.Extensions.Logging.LogLevel.Error,
-                            liveTask.LogPriority);
+                        oldLiveTask.Task.Wait();
+                    }
+                    else if (oldLiveTask.RequeueType == RequeueTypeEnum.Repeat)
+                    {
+                        oldLiveTask.HasScheduledRequeue = true;
+                        return;
                     }
                     else
                     {
-                        throw;
+                        return;
                     }
                 }
-                (bool, Task) old;
-                _liveTasks.TryRemove(liveTask.TaskId, out old);
-                if (old.Item1 == true)
-                    AddTask(liveTask);
-            });
-            bool add = _liveTasks.TryAdd(liveTask.TaskId, (false, t));
-            if (add)
-                t.Start();
-            return add;
+
+                CreateTask();
+
+                if (!PassiveTask)
+                    ActiveTaskNum++;
+                _liveTasks[TaskId] = this;
+                Task.Start();
+            }
+
+            private void CreateTask()
+            {
+                Task = new(() =>
+                {
+                    if (PassiveTask)
+                    {
+                        TaskLogs.AddLog($"Running passive task: {TaskId}",
+                            Microsoft.Extensions.Logging.LogLevel.Information,
+                            LogPriority);
+                    }
+
+                    try
+                    {
+                        TaskAction.Invoke();
+                        TaskLogs.AddLog($"Task Completed: {TaskId}",
+                            Microsoft.Extensions.Logging.LogLevel.Information,
+                            LogPriority);
+                    }
+                    catch (Exception e)
+                    {
+                        if (SilentFail)
+                        {
+                            TaskLogs.AddLog($"Task Failed: {TaskId}",
+                                Microsoft.Extensions.Logging.LogLevel.Error,
+                                LogPriority);
+                            TaskLogs.AddLog($"   {e.Message}",
+                                Microsoft.Extensions.Logging.LogLevel.Error,
+                                TaskLogs.LogPriority.Low);
+                            TaskLogs.AddLog(e.StackTrace,
+                                Microsoft.Extensions.Logging.LogLevel.Error,
+                                TaskLogs.LogPriority.Low);
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+                    if (HasScheduledRequeue)
+                    {
+                        HasScheduledRequeue = false;
+                        Run();
+                    }
+                    else
+                    {
+                        if (!PassiveTask)
+                            ActiveTaskNum--;
+                        _liveTasks.TryRemove(TaskId, out _);
+                    }
+                });
+            }
+        }
+
+        public static void Run(LiveTask liveTask)
+        {
+            liveTask.Run();
         }
 
         public static void WaitAll()
         {
-            while (_liveTasks.Count > 0)
+            while (GetActiveTasks().Any())
             {
-                var e = _liveTasks.GetEnumerator();
+                var e = GetActiveTasks().GetEnumerator();
                 e.MoveNext();
-                e.Current.Value.Item2.Wait();
+                e.Current.Task.Wait();
             }
         }
+
+        public static IEnumerable<LiveTask> GetActiveTasks()
+        {
+            return _liveTasks.Values.ToList().Where(t => !t.PassiveTask);
+        }
+
+        /// <summary>
+        /// Number of active tasks. Ignores passive tasks.
+        /// </summary>
+        /// <returns></returns>
+        public static bool AnyActiveTasks() => ActiveTaskNum > 0;
 
         public static List<string> GetLiveThreads()
         {
@@ -133,7 +218,7 @@ namespace StudioCore.Editor
             // Allows exceptions in tasks to be caught by crash handler.
             foreach (var task in _liveTasks)
             {
-                var ex = task.Value.Item2.Exception;
+                var ex = task.Value.Task.Exception;
                 if (ex != null)
                 {
                     throw ex;

--- a/StudioCore/Editor/TaskManager.cs
+++ b/StudioCore/Editor/TaskManager.cs
@@ -192,9 +192,8 @@ namespace StudioCore.Editor
         }
 
         /// <summary>
-        /// Number of active tasks. Ignores passive tasks.
+        /// Number of active tasks. Dpes not include passive tasks.
         /// </summary>
-        /// <returns></returns>
         public static bool AnyActiveTasks() => ActiveTaskNum > 0;
 
         public static List<string> GetLiveThreads()

--- a/StudioCore/MapStudioNew.cs
+++ b/StudioCore/MapStudioNew.cs
@@ -262,15 +262,16 @@ namespace StudioCore
 
             if (CFG.Current.EnableSoapstone)
             {
-                TaskManager.LiveTask soapstoneTask = new("Soapstone Server", true,
-                    () => SoapstoneServer.RunAsync(KnownServer.DSMapStudio, _soapstoneService).Wait());
-                soapstoneTask.PassiveTask = true;
-                TaskManager.Run(soapstoneTask);
+                TaskManager.RunPassiveTask(new("Soapstone Server",
+                    TaskManager.RequeueType.None, true,
+                    () => SoapstoneServer.RunAsync(KnownServer.DSMapStudio, _soapstoneService).Wait()));
             }
 
             if (CFG.Current.EnableCheckProgramUpdate)
             {
-                TaskManager.Run(new("Check Program Updates", true, () => CheckProgramUpdate()));
+                TaskManager.Run(new("Check Program Updates",
+                    TaskManager.RequeueType.None, true,
+                    () => CheckProgramUpdate()));
             }
 
             long previousFrameTicks = 0;

--- a/StudioCore/MsbEditor/MtdBank.cs
+++ b/StudioCore/MsbEditor/MtdBank.cs
@@ -35,7 +35,7 @@ namespace StudioCore.MsbEditor
         public static void ReloadMtds()
         {
 
-            TaskManager.Run(new("Resource - Load MTDs", true, false, false, () =>
+            TaskManager.Run(new("Resource - Load MTDs", TaskManager.RequeueTypeEnum.WaitThenRequeue, false, () =>
             {
                 try
                 {

--- a/StudioCore/MsbEditor/MtdBank.cs
+++ b/StudioCore/MsbEditor/MtdBank.cs
@@ -35,7 +35,7 @@ namespace StudioCore.MsbEditor
         public static void ReloadMtds()
         {
 
-            TaskManager.Run(new("Resource - Load MTDs", TaskManager.RequeueTypeEnum.WaitThenRequeue, false, () =>
+            TaskManager.Run(new("Resource - Load MTDs", TaskManager.RequeueType.WaitThenRequeue, false, () =>
             {
                 try
                 {

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -781,13 +781,13 @@ namespace StudioCore.ParamEditor
 
             CacheBank.ClearCaches();
 
-            TaskManager.Run(new("Param - Load Params", true, false, false, () =>
+            TaskManager.Run(new("Param - Load Params", TaskManager.RequeueTypeEnum.WaitThenRequeue, false, () =>
             {
                 if (PrimaryBank.AssetLocator.Type != GameType.Undefined)
                 {
                     List<(string, PARAMDEF)> defPairs = LoadParamdefs(locator);
                     IsDefsLoaded = true;
-                    TaskManager.Run(new("Param - Load Meta", true, false, false, () =>
+                    TaskManager.Run(new("Param - Load Meta", TaskManager.RequeueTypeEnum.WaitThenRequeue, false, () =>
                     {
                         LoadParamMeta(defPairs, locator);
                         IsMetaLoaded = true;
@@ -827,7 +827,7 @@ namespace StudioCore.ParamEditor
 
                 VanillaBank.IsLoadingParams = true;
                 VanillaBank._params = new Dictionary<string, Param>();
-                TaskManager.Run(new("Param - Load Vanilla Params", true, false, false, () =>
+                TaskManager.Run(new("Param - Load Vanilla Params", TaskManager.RequeueTypeEnum.WaitThenRequeue, false, () =>
                 {
                     if (locator.Type == GameType.DemonsSouls)
                     {
@@ -859,7 +859,9 @@ namespace StudioCore.ParamEditor
                     }
                     VanillaBank.IsLoadingParams = false;
 
-                    TaskManager.Run(new("Param - Check Differences", true, false, false, () => PrimaryBank.RefreshParamDiffCaches()));
+                    TaskManager.Run(new("Param - Check Differences",
+                        TaskManager.RequeueTypeEnum.WaitThenRequeue, false,
+                        () => PrimaryBank.RefreshParamDiffCaches()));
                 }));
 
                 if (options != null)

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -781,13 +781,13 @@ namespace StudioCore.ParamEditor
 
             CacheBank.ClearCaches();
 
-            TaskManager.Run(new("Param - Load Params", TaskManager.RequeueTypeEnum.WaitThenRequeue, false, () =>
+            TaskManager.Run(new("Param - Load Params", TaskManager.RequeueType.WaitThenRequeue, false, () =>
             {
                 if (PrimaryBank.AssetLocator.Type != GameType.Undefined)
                 {
                     List<(string, PARAMDEF)> defPairs = LoadParamdefs(locator);
                     IsDefsLoaded = true;
-                    TaskManager.Run(new("Param - Load Meta", TaskManager.RequeueTypeEnum.WaitThenRequeue, false, () =>
+                    TaskManager.Run(new("Param - Load Meta", TaskManager.RequeueType.WaitThenRequeue, false, () =>
                     {
                         LoadParamMeta(defPairs, locator);
                         IsMetaLoaded = true;
@@ -827,7 +827,7 @@ namespace StudioCore.ParamEditor
 
                 VanillaBank.IsLoadingParams = true;
                 VanillaBank._params = new Dictionary<string, Param>();
-                TaskManager.Run(new("Param - Load Vanilla Params", TaskManager.RequeueTypeEnum.WaitThenRequeue, false, () =>
+                TaskManager.Run(new("Param - Load Vanilla Params", TaskManager.RequeueType.WaitThenRequeue, false, () =>
                 {
                     if (locator.Type == GameType.DemonsSouls)
                     {
@@ -860,7 +860,7 @@ namespace StudioCore.ParamEditor
                     VanillaBank.IsLoadingParams = false;
 
                     TaskManager.Run(new("Param - Check Differences",
-                        TaskManager.RequeueTypeEnum.WaitThenRequeue, false,
+                        TaskManager.RequeueType.WaitThenRequeue, false,
                         () => PrimaryBank.RefreshParamDiffCaches()));
                 }));
 

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -288,7 +288,7 @@ namespace StudioCore.ParamEditor
         {
             EditorActionManager.UndoAction();
             TaskManager.Run(new("Param - Check Differences",
-                TaskManager.RequeueTypeEnum.Repeat, true,
+                TaskManager.RequeueType.Repeat, true,
                 TaskLogs.LogPriority.Low,
                 () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
         }
@@ -296,7 +296,7 @@ namespace StudioCore.ParamEditor
         {
             EditorActionManager.RedoAction();
             TaskManager.Run(new("Param - Check Differences",
-                TaskManager.RequeueTypeEnum.Repeat, true,
+                TaskManager.RequeueType.Repeat, true,
                 TaskLogs.LogPriority.Low,
                 () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
         }
@@ -557,7 +557,7 @@ namespace StudioCore.ParamEditor
                                         if (action.HasActions)
                                             EditorActionManager.ExecuteAction(action);
                                         TaskManager.Run(new("Param - Check Differences",
-                                            TaskManager.RequeueTypeEnum.Repeat, true,
+                                            TaskManager.RequeueType.Repeat, true,
                                             TaskLogs.LogPriority.Low,
                                             () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                                     }
@@ -584,7 +584,7 @@ namespace StudioCore.ParamEditor
                                     else
                                         PlatformUtils.Instance.MessageBox(result, "Error", MessageBoxButtons.OK, MessageBoxIcon.None);
                                     TaskManager.Run(new("Param - Check Differences",
-                                        TaskManager.RequeueTypeEnum.Repeat,
+                                        TaskManager.RequeueType.Repeat,
                                         true, TaskLogs.LogPriority.Low,
                                         () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                                 }
@@ -612,7 +612,7 @@ namespace StudioCore.ParamEditor
                                             else
                                                 PlatformUtils.Instance.MessageBox(result, "Error", MessageBoxButtons.OK, MessageBoxIcon.None);
                                             TaskManager.Run(new("Param - Check Differences",
-                                                TaskManager.RequeueTypeEnum.Repeat,
+                                                TaskManager.RequeueType.Repeat,
                                                 true, TaskLogs.LogPriority.Low,
                                                 () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                                         }
@@ -1019,7 +1019,7 @@ namespace StudioCore.ParamEditor
                         _lastMEditRegexInput = _currentMEditRegexInput;
                         _currentMEditRegexInput = "";
                         TaskManager.Run(new("Param - Check Differences",
-                            TaskManager.RequeueTypeEnum.Repeat,
+                            TaskManager.RequeueType.Repeat,
                             true, TaskLogs.LogPriority.Low,
                             () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                     }
@@ -1064,7 +1064,7 @@ namespace StudioCore.ParamEditor
                         if (action.HasActions)
                             EditorActionManager.ExecuteAction(action);
                         TaskManager.Run(new("Param - Check Differences",
-                            TaskManager.RequeueTypeEnum.Repeat, true,
+                            TaskManager.RequeueType.Repeat, true,
                             TaskLogs.LogPriority.Low,
                             () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                     }

--- a/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -287,12 +287,18 @@ namespace StudioCore.ParamEditor
         private void ParamUndo()
         {
             EditorActionManager.UndoAction();
-            TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
+            TaskManager.Run(new("Param - Check Differences",
+                TaskManager.RequeueTypeEnum.Repeat, true,
+                TaskLogs.LogPriority.Low,
+                () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
         }
         private void ParamRedo()
         {
             EditorActionManager.RedoAction();
-            TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
+            TaskManager.Run(new("Param - Check Differences",
+                TaskManager.RequeueTypeEnum.Repeat, true,
+                TaskLogs.LogPriority.Low,
+                () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
         }
 
         private IReadOnlyList<Param.Row> CsvExportGetRows(ParamBank.RowGetType rowType)
@@ -550,7 +556,10 @@ namespace StudioCore.ParamEditor
                                     {
                                         if (action.HasActions)
                                             EditorActionManager.ExecuteAction(action);
-                                        TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
+                                        TaskManager.Run(new("Param - Check Differences",
+                                            TaskManager.RequeueTypeEnum.Repeat, true,
+                                            TaskLogs.LogPriority.Low,
+                                            () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                                     }
                                     else
                                         PlatformUtils.Instance.MessageBox(result, "Error", MessageBoxButtons.OK, MessageBoxIcon.None);
@@ -574,7 +583,10 @@ namespace StudioCore.ParamEditor
                                         EditorActionManager.ExecuteAction(action);
                                     else
                                         PlatformUtils.Instance.MessageBox(result, "Error", MessageBoxButtons.OK, MessageBoxIcon.None);
-                                    TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
+                                    TaskManager.Run(new("Param - Check Differences",
+                                        TaskManager.RequeueTypeEnum.Repeat,
+                                        true, TaskLogs.LogPriority.Low,
+                                        () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                                 }
                             }
                         }
@@ -599,7 +611,10 @@ namespace StudioCore.ParamEditor
                                                 EditorActionManager.ExecuteAction(action);
                                             else
                                                 PlatformUtils.Instance.MessageBox(result, "Error", MessageBoxButtons.OK, MessageBoxIcon.None);
-                                            TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
+                                            TaskManager.Run(new("Param - Check Differences",
+                                                TaskManager.RequeueTypeEnum.Repeat,
+                                                true, TaskLogs.LogPriority.Low,
+                                                () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                                         }
                                     }
                                 }
@@ -1003,7 +1018,10 @@ namespace StudioCore.ParamEditor
                     {
                         _lastMEditRegexInput = _currentMEditRegexInput;
                         _currentMEditRegexInput = "";
-                        TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
+                        TaskManager.Run(new("Param - Check Differences",
+                            TaskManager.RequeueTypeEnum.Repeat,
+                            true, TaskLogs.LogPriority.Low,
+                            () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                     }
                     _mEditRegexResult = r.Information;
                 }
@@ -1045,7 +1063,10 @@ namespace StudioCore.ParamEditor
                     {
                         if (action.HasActions)
                             EditorActionManager.ExecuteAction(action);
-                        TaskManager.Run(new("Param - Check Differences", false, true, true, TaskLogs.LogPriority.Low, () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
+                        TaskManager.Run(new("Param - Check Differences",
+                            TaskManager.RequeueTypeEnum.Repeat, true,
+                            TaskLogs.LogPriority.Low,
+                            () => ParamBank.PrimaryBank.RefreshParamDiffCaches()));
                     }
                     _mEditCSVResult = result;
                 }

--- a/StudioCore/ParamEditor/ParamReloader.cs
+++ b/StudioCore/ParamEditor/ParamReloader.cs
@@ -32,7 +32,7 @@ namespace StudioCore.ParamEditor
 
         public static void ReloadMemoryParams(ParamBank bank, AssetLocator loc, string[] paramNames)
         {
-            TaskManager.Run(new("Param - Hot Reload", TaskManager.RequeueTypeEnum.WaitThenRequeue, true, () =>
+            TaskManager.Run(new("Param - Hot Reload", TaskManager.RequeueType.WaitThenRequeue, true, () =>
             {
                 GameOffsets offsets = GetGameOffsets(loc);
                 var processArray = Process.GetProcessesByName(offsets.exeName);

--- a/StudioCore/ParamEditor/ParamReloader.cs
+++ b/StudioCore/ParamEditor/ParamReloader.cs
@@ -32,7 +32,7 @@ namespace StudioCore.ParamEditor
 
         public static void ReloadMemoryParams(ParamBank bank, AssetLocator loc, string[] paramNames)
         {
-            TaskManager.Run(new("Param - Hot Reload", true, true, true, () =>
+            TaskManager.Run(new("Param - Hot Reload", TaskManager.RequeueTypeEnum.WaitThenRequeue, true, () =>
             {
                 GameOffsets offsets = GetGameOffsets(loc);
                 var processArray = Process.GetProcessesByName(offsets.exeName);

--- a/StudioCore/TextEditor/FMGBank.cs
+++ b/StudioCore/TextEditor/FMGBank.cs
@@ -1019,7 +1019,7 @@ namespace StudioCore.TextEditor
 
         public static void ReloadFMGs(string languageFolder = "")
         {
-            TaskManager.Run(new("FMG - Load Text", true, false, true, () =>
+            TaskManager.Run(new("FMG - Load Text", TaskManager.RequeueTypeEnum.WaitThenRequeue, true, () =>
             {
                 IsLoaded = false;
                 IsLoading = true;

--- a/StudioCore/TextEditor/FMGBank.cs
+++ b/StudioCore/TextEditor/FMGBank.cs
@@ -1019,7 +1019,7 @@ namespace StudioCore.TextEditor
 
         public static void ReloadFMGs(string languageFolder = "")
         {
-            TaskManager.Run(new("FMG - Load Text", TaskManager.RequeueTypeEnum.WaitThenRequeue, true, () =>
+            TaskManager.Run(new("FMG - Load Text", TaskManager.RequeueType.WaitThenRequeue, true, () =>
             {
                 IsLoaded = false;
                 IsLoading = true;


### PR DESCRIPTION
Attempts to simplify usage and improve clarity for TaskManager. Will likely do more regarding this in the future since I don't like some parts of it.

Adds passive LiveTask vs active LiveTask distinction to handle tasks that are expected to run as long as DSMS is running, or potentially other long running background tasks. Only applied to soapstone server task at the moment.