### PR TITLE
Use TentativeParamType dict for missing AC6 ParamTypes

### DIFF
--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -1592,7 +1592,7 @@ namespace StudioCore.ParamEditor
             {
                 param = $@"{dir}\regulation.bin";
             }
-            BND4 paramBnd = SFUtil.DecryptERRegulation(param);
+            BND4 paramBnd = SFUtil.DecryptAC6Regulation(param);
 
             // Replace params with edited ones
             foreach (var p in paramBnd.Files)

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -1597,11 +1597,10 @@ namespace StudioCore.ParamEditor
             // Replace params with edited ones
             foreach (var p in paramBnd.Files)
             {
-                if (_params.ContainsKey(Path.GetFileNameWithoutExtension(p.Name)))
+                string paramName = Path.GetFileNameWithoutExtension(p.Name);
+                if (_params.TryGetValue(paramName, out Param paramFile))
                 {
-                    Param paramFile = _params[Path.GetFileNameWithoutExtension(p.Name)];
                     IReadOnlyList<Param.Row> backup = paramFile.Rows;
-                    List<Param.Row> changed = new List<Param.Row>();
                     p.Bytes = paramFile.Write();
                     paramFile.Rows = backup;
                 }

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -178,6 +178,39 @@ namespace StudioCore.ParamEditor
             return child;
         }
 
+        /// <summary>
+        /// Dictionary of param file names that contain no ParamType, and the ParamType to be assigned to them.
+        /// ParamType names ending in "_TENTATIVE" did not have official data to reference.
+        /// </summary>
+        public Dictionary<string, string> TentativeParamType_AC6 = new()
+        {
+            {"EquipParamWeapon", "EquipParamWeapon_TENTATIVE"}, //
+            {"EquipParamProtector", "EQUIP_PARAM_PROTECTOR_ST"},
+            {"EquipParamAccessory", "EQUIP_PARAM_ACCESSORY_ST"},
+            {"ReinforceParamProtector", "REINFORCE_PARAM_PROTECTOR_ST"},
+            {"NpcParam", "NPC_PARAM_ST"},
+            {"NpcTransformParam", "NpcTransformParam_TENTATIVE"}, //
+            {"AtkParam_Npc", "ATK_PARAM_ST"},
+            {"WepAbsorpPosParam", "WEP_ABSORP_POS_PARAM_ST"},
+            {"DirectionCameraParam", "DIRECTION_CAMERA_PARAM_ST"},
+            {"MovementAcTypeParam", "MovementAcTypeParam_TENTATIVE"}, //
+            {"MovementRideObjParam", "MovementRideObjParam_TENTATIVE"}, //
+            {"MovementFlyEnemyParam", "MovementFlyEnemyParam_TENTATIVE"}, //
+            {"ChrModelParam", "CHR_MODEL_PARAM_ST"},
+            {"MissionParam", "MissionParam_TENTATIVE"}, //
+            {"MailParam", "MAIL_PARAM_ST"},
+            {"EquipParamBooster", "EquipParamBooster_TENTATIVE"}, //
+            {"EquipParamGenerator", "EquipParamGenerator_TENTATIVE"}, //
+            {"EquipParamFcs", "EquipParamFcs_TENTATIVE"}, //
+            {"RuntimeSoundParam_Npc", "RuntimeSoundParam_TENTATIVE"}, //
+            {"RuntimeSoundParam_Pc", "RuntimeSoundParam_TENTATIVE"}, //
+            {"CutsceneGparamTimeParam", "CUTSCENE_GPARAM_TIME_PARAM_ST"},
+            {"CutsceneTimezoneConvertParam", "CUTSCENE_TIMEZONE_CONVERT_PARAM_ST"},
+            {"CutsceneMapIdParam", "CUTSCENE_MAP_ID_PARAM_ST"},
+            {"MapAreaParam", "MapAreaParam_TENTATIVE"}, //
+            {"RuntimeSoundGlobalParam", "RuntimeSoundGlobalParam_TENTATIVE"}, //
+        };
+
         private void LoadParamFromBinder(IBinder parambnd, ref Dictionary<string, FSParam.Param> paramBank, out ulong version, bool checkVersion = false)
         {
             bool success = ulong.TryParse(parambnd.Version, out version);
@@ -187,7 +220,6 @@ namespace StudioCore.ParamEditor
             }
 
             // Load every param in the regulation
-            // _params = new Dictionary<string, PARAM>();
             foreach (var f in parambnd.Files)
             {
                 if (!f.Name.ToUpper().EndsWith(".PARAM"))
@@ -203,15 +235,19 @@ namespace StudioCore.ParamEditor
 
                 if (AssetLocator.Type == GameType.ArmoredCoreVI)
                 {
-                    if (p.ParamType == "")
+                    if (p.ParamType == "" || p.ParamType == null)
                     {
-                        TaskLogs.AddLog($"Couldn't read ParamType (empty string) for {Path.GetFileNameWithoutExtension(f.Name)}, used file name as ParamType.");
-                        p.ParamType = Path.GetFileNameWithoutExtension(f.Name);
-                    }
-                    else if (p.ParamType == null)
-                    {
-                        TaskLogs.AddLog($"Couldn't read ParamType (null) for {Path.GetFileNameWithoutExtension(f.Name)}, used file name as ParamType.");
-                        p.ParamType = Path.GetFileNameWithoutExtension(f.Name);
+                        string paramName = Path.GetFileNameWithoutExtension(f.Name);
+                        if (TentativeParamType_AC6.TryGetValue(paramName, out string newParamType))
+                        {
+                            p.ParamType = newParamType;
+                            TaskLogs.AddLog($"Couldn't read ParamType for {paramName}, but tentative ParamType \"{newParamType}\" exists.");
+                        }
+                        else
+                        {
+                            TaskLogs.AddLog($"Couldn't read ParamType for {paramName} and no tentative ParamType exists.",
+                                Microsoft.Extensions.Logging.LogLevel.Error, TaskLogs.LogPriority.High);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Makes duplicate defs no longer necessary, and uses ParamTypes from previous games.

The one wrench thrown into all of this is the fact EquipParamWeapon_NPC.param's def is EQUIP_PARAM_WEAPON_ST and is not compatible with EquipParamWeapon.param, which has a missing ParamType.
For now, I made EquipParamWeapon.param use ParamType EquipParamWeapon_TENTATIVE via EquipParamWeapon_PC.xml.
This kinda sucks and I can easily be convinced of alternative ideas.