### PR TITLE
Fix autofill menu duplication

### DIFF
--- a/StudioCore/ParamEditor/AutoFill.cs
+++ b/StudioCore/ParamEditor/AutoFill.cs
@@ -138,7 +138,7 @@ namespace StudioCore.ParamEditor
         {
             ImGui.SameLine();
             ImGui.Button($@"{ForkAwesome.CaretDown}");
-            if (ImGui.BeginPopupContextItem("##rsbautoinputoapopup", ImGuiPopupFlags.MouseButtonLeft))
+            if (ImGui.BeginPopupContextItem("##psbautoinputoapopup", ImGuiPopupFlags.MouseButtonLeft))
             {
                 ImGui.TextColored(HINTCOLOUR, "Select params...");
                 var result = autoFillPse.Menu(true, false, "", null, null);


### PR DESCRIPTION
Looks like there was a typo and one always had the wrong id, but the issue didn't appear because they were inside different parent IDs. That changed, and the param menu got mixed with the row menu.