### PR TITLE
AC6 param improvements + better paramdef x paramtype logging

### DIFF
--- a/SoulsFormats/SoulsFormats/Util/SoulsFile.cs
+++ b/SoulsFormats/SoulsFormats/Util/SoulsFile.cs
@@ -88,6 +88,30 @@ namespace SoulsFormats
             return ret;
         }
 
+        /// <summary>
+        /// Loads a file from a byte array while ignoring compression.
+        /// </summary>
+        public static TFormat ReadIgnoreCompression(Memory<byte> bytes)
+        {
+            BinaryReaderEx br = new BinaryReaderEx(false, bytes);
+            TFormat file = new TFormat();
+            file.Read(br);
+            return file;
+        }
+
+        /// <summary>
+        /// Loads a file from the specified path while ignoring compression.
+        /// </summary>
+        public static TFormat ReadIgnoreCompression(string path)
+        {
+            using var file = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var accessor = file.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
+            BinaryReaderEx br = new BinaryReaderEx(false, accessor.Memory);
+            TFormat ret = new TFormat();
+            ret.Read(br);
+            return ret;
+        }
+
         private static bool IsRead(BinaryReaderEx br, out TFormat file)
         {
             var test = new TFormat();

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -243,6 +243,7 @@ namespace StudioCore.ParamEditor
 
                 if (AssetLocator.Type == GameType.ArmoredCoreVI)
                 {
+                    _usedTentativeParamTypes = new();
                     p = FSParam.Param.ReadIgnoreCompression(f.Bytes);
                     if (p.ParamType != null)
                     {
@@ -250,6 +251,7 @@ namespace StudioCore.ParamEditor
                         {
                             if (TentativeParamType_AC6.TryGetValue(paramName, out string newParamType))
                             {
+                                _usedTentativeParamTypes.Add(paramName, p.ParamType);
                                 p.ParamType = newParamType;
                                 TaskLogs.AddLog($"Couldn't find ParamDef for {paramName}, but tentative ParamType \"{newParamType}\" exists.");
                             }
@@ -264,6 +266,7 @@ namespace StudioCore.ParamEditor
                     {
                         if (TentativeParamType_AC6.TryGetValue(paramName, out string newParamType))
                         {
+                            _usedTentativeParamTypes.Add(paramName, p.ParamType);
                             p.ParamType = newParamType;
                             TaskLogs.AddLog($"Couldn't read ParamType for {paramName}, but tentative ParamType \"{newParamType}\" exists.");
                         }

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -246,11 +246,11 @@ namespace StudioCore.ParamEditor
                                 p.ParamType = newParamType;
                                 TaskLogs.AddLog($"Couldn't find ParamDef for {paramName}, but tentative ParamType \"{newParamType}\" exists.");
                             }
-                        }
-                        else
-                        {
-                            TaskLogs.AddLog($"Couldn't find ParamDef for param {paramName} and no tentative ParamType exists.",
-                                Microsoft.Extensions.Logging.LogLevel.Error, TaskLogs.LogPriority.High);
+                            else
+                            {
+                                TaskLogs.AddLog($"Couldn't find ParamDef for param {paramName} and no tentative ParamType exists.",
+                                    Microsoft.Extensions.Logging.LogLevel.Error, TaskLogs.LogPriority.High);
+                            }
                         }
                     }
                     else

--- a/StudioCore/Utils.cs
+++ b/StudioCore/Utils.cs
@@ -283,8 +283,6 @@ namespace StudioCore
                 }
                 else if (gameType == GameType.ArmoredCoreVI && item is BND4 bndAC6)
                 {
-                    //TODO AC6: test
-                    Debugger.Break();
                     SFUtil.EncryptAC6Regulation(writepath + ".temp", bndAC6);
                 }
                 else


### PR DESCRIPTION
- Don't check for compression on AC6 param read because some params can pass DCX.Is check after just being resaved.
- Store (and restore write) invalid AC6 paramTypes for params that were given tentative paramtypes on read (better compatibility with other tools and format changes).
- Check AC6 paramdefs to catch future potential garbled paramtypes.
- Log params that are unable to find a corresponding paramdef for all games.