### PR TITLE
Allow preferred oodle to use based on compression

### DIFF
--- a/SoulsFormats/SoulsFormats/Formats/DCX.cs
+++ b/SoulsFormats/SoulsFormats/Formats/DCX.cs
@@ -385,7 +385,7 @@ namespace SoulsFormats
 
             var compressed = br.ReadSpanView<byte>((int)compressedSize);
 
-            return Oodle.GetOodleCompressor().Decompress(compressed, uncompressedSize);
+            return Oodle.GetOodleCompressor(compressionLevel).Decompress(compressed, uncompressedSize);
         }
 
         #region Public Compress
@@ -620,7 +620,7 @@ namespace SoulsFormats
 
         private static void CompressDCXKRAK(Span<byte> data, BinaryWriterEx bw, byte compressionLevel = 6)
         {
-            byte[] compressed = Oodle.GetOodleCompressor().Compress(data, Oodle.OodleLZ_Compressor.OodleLZ_Compressor_Kraken, Oodle.OodleLZ_CompressionLevel.OodleLZ_CompressionLevel_Optimal2);
+            byte[] compressed = Oodle.GetOodleCompressor(compressionLevel).Compress(data, Oodle.OodleLZ_Compressor.OodleLZ_Compressor_Kraken, Oodle.OodleLZ_CompressionLevel.OodleLZ_CompressionLevel_Optimal2);
 
             bw.WriteASCII("DCX\0");
             bw.WriteInt32(0x11000);

--- a/SoulsFormats/SoulsFormats/Util/Oodle.cs
+++ b/SoulsFormats/SoulsFormats/Util/Oodle.cs
@@ -14,30 +14,68 @@ public class Oodle
     static bool Oodle6Exists = false;
     static bool Oodle8Exists = false;
 
-    public static IOodleCompressor GetOodleCompressor()
+    private static bool CanUseOodle6()
     {
-        if (Oodle8Exists)
-        {
-            return new Oodle28();
-        }
         if (Oodle6Exists)
         {
-            return new Oodle26();
-        }
-
-        if (Path.Exists($@"{Directory.GetCurrentDirectory()}\oo2core_8_win64.dll"))
-        {
-            Oodle8Exists = true;
-            return new Oodle28();
+            return true;
         }
         if (Path.Exists($@"{Directory.GetCurrentDirectory()}\oo2core_6_win64.dll"))
         {
             Oodle6Exists = true;
-            return new Oodle26();
+            return true;
+        }
+        return false;
+    }
+
+    private static bool CanUseOodle8()
+    {
+        if (Oodle8Exists)
+        {
+            return true;
+        }
+        if (Path.Exists($@"{Directory.GetCurrentDirectory()}\oo2core_8_win64.dll"))
+        {
+            Oodle8Exists = true;
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns oodle class to use for compression and decompression.
+    /// </summary>
+    /// <param name="compressionLevel">Used to determine preferred oodle. If not applicable, any available oodle will be used.</param>
+    public static IOodleCompressor GetOodleCompressor(int compressionLevel = -1)
+    {
+        if (compressionLevel != -1)
+        {
+            // Try to get preferred oodle using compressionLevel.
+            if (compressionLevel == 9)
+            {
+                if (CanUseOodle8())
+                    return new Oodle28();
+                if (CanUseOodle6())
+                    return new Oodle26();
+            }
+            else if (compressionLevel == 6)
+            {
+                if (CanUseOodle6())
+                    return new Oodle26();
+                if (CanUseOodle8())
+                    return new Oodle28();
+            }
+        }
+        else
+        {
+            if (CanUseOodle6())
+                return new Oodle26();
+            if (CanUseOodle8())
+                return new Oodle28();
         }
 
         throw new NoOodleFoundException($"Could not find a supported version of oo2core. "
-            + $"Please copy oo2core_6_win64.dll or oo2core_8_win64.dll into the program directory");
+        + $"Please copy oo2core_6_win64.dll or oo2core_8_win64.dll into the program directory");
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/SoulsFormats/SoulsFormats/Util/Oodle.cs
+++ b/SoulsFormats/SoulsFormats/Util/Oodle.cs
@@ -75,7 +75,7 @@ public class Oodle
         }
 
         throw new NoOodleFoundException($"Could not find a supported version of oo2core. "
-        + $"Please copy oo2core_6_win64.dll or oo2core_8_win64.dll into the program directory");
+            + $"Please copy oo2core_6_win64.dll or oo2core_8_win64.dll into the program directory");
     }
 
     [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
Extremely likely this doesn't matter, but just in case it does this ensures that games will can use the oodle they came with.