### PR TITLE
De-duplicate paramdef names

### DIFF
--- a/SoulsFormats/SoulsFormats/Formats/PARAM/PARAMDEF/XmlSerializer.cs
+++ b/SoulsFormats/SoulsFormats/Formats/PARAM/PARAMDEF/XmlSerializer.cs
@@ -133,6 +133,15 @@ namespace SoulsFormats
                     field.FirstRegulationVersion = firstVersion;
                     field.RemovedRegulationVersion = removedVersion;
                 }
+
+                // Check same name, and if version aware, check they aren't replacing eachother
+                bool matchingFieldTest(Field ifield) => string.Equals(field.InternalName, ifield.InternalName)
+                    && (!versionAware || (
+                        (field.RemovedRegulationVersion == 0 || field.RemovedRegulationVersion > ifield.FirstRegulationVersion)
+                        && (ifield.RemovedRegulationVersion == 0 || field.FirstRegulationVersion < ifield.RemovedRegulationVersion)));
+                Field field2 = def.Fields.Find(matchingFieldTest);
+                if (field2 != null)
+                    throw new Exception("Repeated field name found in paramdef: " + def.ParamType + ", name: " + field.InternalName);
                 
                 return field;
             }

--- a/StudioCore/Assets/Paramdex/DS2S/Defs/AREA_PARAM.xml
+++ b/StudioCore/Assets/Paramdex/DS2S/Defs/AREA_PARAM.xml
@@ -23,9 +23,9 @@
     <Field Def="u8 Unk07" />
     <Field Def="u8 Unk08" />
     
-    <Field Def="f32 Unk05" />
+    <Field Def="f32 Unk09" />
     
-    <Field Def="f32 Unk06" />
+    <Field Def="f32 Unk10" />
     
     <Field Def="s32 mimicry_map_object_1" />
     <Field Def="s32 mimicry_map_object_2" />

--- a/StudioCore/Assets/Paramdex/DS3/Defs/ATK_PARAM_ST.xml
+++ b/StudioCore/Assets/Paramdex/DS3/Defs/ATK_PARAM_ST.xml
@@ -84,8 +84,8 @@
     <Field Def="u8 isChargeAtk:1" />
     <Field Def="u8 isShareHitList:1" />
     <Field Def="u8 isCheckObjPenetration:1" />
-    <Field Def="u8 0x81:1" />
-    <Field Def="u8 0x81:1" />
+    <Field Def="u8 0x81_0:1" />
+    <Field Def="u8 0x81_1:1" />
     <Field Def="u8 pad1" />
     <Field Def="u8 regainableSlotId" />
     <Field Def="s32 deathCauseId" />
@@ -179,12 +179,12 @@
     <Field Def="s16 atkDark" />
     <Field Def="u8 IsChargeAtk2:1" />
     <Field Def="u8 IsChargeAtk3:1 = 1" />
-    <Field Def="u8 0x18A:1" />
-    <Field Def="u8 0x18A:1" />
-    <Field Def="u8 0x18A:1" />
-    <Field Def="u8 0x18A:1" />
-    <Field Def="u8 0x18A:1" />
-    <Field Def="u8 0x18A:1" />
+    <Field Def="u8 0x18A_0:1" />
+    <Field Def="u8 0x18A_1:1" />
+    <Field Def="u8 0x18A_2:1" />
+    <Field Def="u8 0x18A_3:1" />
+    <Field Def="u8 0x18A_4:1" />
+    <Field Def="u8 0x18A_5:1" />
     <Field Def="u8 0x18B" />
     <Field Def="s16 physSpCorrection = 100" />
     <Field Def="s16 magSpCorrection = 100" />

--- a/StudioCore/Assets/Paramdex/DS3/Defs/ATTACK_ELEMENT_CORRECT_PARAM_ST.xml
+++ b/StudioCore/Assets/Paramdex/DS3/Defs/ATTACK_ELEMENT_CORRECT_PARAM_ST.xml
@@ -6,38 +6,38 @@
   <Unicode>True</Unicode>
   <Version>201</Version>
   <Fields>
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
-    <Field Def="u32 0x00:1" />
+    <Field Def="u32 0x00_0:1" />
+    <Field Def="u32 0x00_1:1" />
+    <Field Def="u32 0x00_2:1" />
+    <Field Def="u32 0x00_3:1" />
+    <Field Def="u32 0x00_4:1" />
+    <Field Def="u32 0x00_5:1" />
+    <Field Def="u32 0x00_6:1" />
+    <Field Def="u32 0x00_7:1" />
+    <Field Def="u32 0x00_8:1" />
+    <Field Def="u32 0x00_9:1" />
+    <Field Def="u32 0x00_10:1" />
+    <Field Def="u32 0x00_11:1" />
+    <Field Def="u32 0x00_12:1" />
+    <Field Def="u32 0x00_13:1" />
+    <Field Def="u32 0x00_14:1" />
+    <Field Def="u32 0x00_15:1" />
+    <Field Def="u32 0x00_16:1" />
+    <Field Def="u32 0x00_17:1" />
+    <Field Def="u32 0x00_18:1" />
+    <Field Def="u32 0x00_19:1" />
+    <Field Def="u32 0x00_20:1" />
+    <Field Def="u32 0x00_21:1" />
+    <Field Def="u32 0x00_22:1" />
+    <Field Def="u32 0x00_23:1" />
+    <Field Def="u32 0x00_24:1" />
+    <Field Def="u32 0x00_25:1" />
+    <Field Def="u32 0x00_26:1" />
+    <Field Def="u32 0x00_27:1" />
+    <Field Def="u32 0x00_28:1" />
+    <Field Def="u32 0x00_29:1" />
+    <Field Def="u32 0x00_30:1" />
+    <Field Def="u32 0x00_31:1" />
     <Field Def="s16 addRate0 = -1" />
     <Field Def="s16 addRate1 = -1" />
     <Field Def="s16 addRate2 = -1" />

--- a/StudioCore/Assets/Paramdex/DS3/Defs/NETWORK_PARAM_ST.xml
+++ b/StudioCore/Assets/Paramdex/DS3/Defs/NETWORK_PARAM_ST.xml
@@ -33,7 +33,7 @@
       <UnkC0>NET_COMMON_PARAM</UnkC0>
       <UnkC8>共通</UnkC8>
     </Field>
-    <Field Def="dummy8 pad[4]">
+    <Field Def="dummy8 pad_0[4]">
       <DisplayName>予約</DisplayName>
       <SortID>3</SortID>
       <UnkB8>common</UnkB8>
@@ -50,7 +50,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="f32 keyGuideHeight = 1">
+    <Field Def="f32 keyGuideHeight_0 = 1">
       <DisplayName>キーガイド垂直範囲[m]</DisplayName>
       <Minimum>1</Minimum>
       <Maximum>1000</Maximum>
@@ -80,7 +80,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="u32 reloadSignTotalCount = 1">
+    <Field Def="u32 reloadSignTotalCount_0 = 1">
       <DisplayName>召喚サイン所持可能数上限(全体)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -91,7 +91,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="u32 reloadSignCellCount = 1">
+    <Field Def="u32 reloadSignCellCount_0 = 1">
       <DisplayName>召喚サイン所持可能数上限(セル)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -112,7 +112,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveRange = 1">
+    <Field Def="f32 basicExclusiveRange_0 = 1">
       <DisplayName>召喚サイン間描画排他水平範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -122,7 +122,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveHeight = 1">
+    <Field Def="f32 basicExclusiveHeight_0 = 1">
       <DisplayName>召喚サイン間描画排他垂直範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -142,7 +142,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="f32 signVisibleRange = 1">
+    <Field Def="f32 signVisibleRange_0 = 1">
       <DisplayName>召喚サインPC間描画距離[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -152,7 +152,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupHorizontalRange = 1">
+    <Field Def="u32 cellGroupHorizontalRange_0 = 1">
       <DisplayName>召喚サイン取得セル範囲(水平)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -162,7 +162,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupTopRange = 1">
+    <Field Def="u32 cellGroupTopRange_0 = 1">
       <DisplayName>召喚サイン取得セル範囲(上方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -172,7 +172,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupBottomRange = 1">
+    <Field Def="u32 cellGroupBottomRange_0 = 1">
       <DisplayName>召喚サイン取得セル範囲(下方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -309,7 +309,7 @@
       <UnkC0>NET_BREAKIN_PARAM</UnkC0>
       <UnkC8>乱入</UnkC8>
     </Field>
-    <Field Def="dummy8 pad[4]">
+    <Field Def="dummy8 pad_1[4]">
       <DisplayName>予約</DisplayName>
       <DisplayFormat>%f</DisplayFormat>
       <EditFlags>Wrap</EditFlags>
@@ -328,7 +328,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 keyGuideHeight = 1">
+    <Field Def="f32 keyGuideHeight_1 = 1">
       <DisplayName>キーガイド垂直範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -338,7 +338,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 reloadSignTotalCount = 1">
+    <Field Def="u32 reloadSignTotalCount_1 = 1">
       <DisplayName>血文字取得数(全体)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -371,7 +371,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 maxSignTotalCount = 1">
+    <Field Def="u32 maxSignTotalCount_0 = 1">
       <DisplayName>血文字所持可能数上限(全体)</DisplayName>
       <Description>本当はu16くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -382,7 +382,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 maxSignCellCount = 1">
+    <Field Def="u32 maxSignCellCount_0 = 1">
       <DisplayName>血文字所持可能数上限(セル)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -393,7 +393,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveRange = 1">
+    <Field Def="f32 basicExclusiveRange_1 = 1">
       <DisplayName>血文字間描画排他水平範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -403,7 +403,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveHeight = 1">
+    <Field Def="f32 basicExclusiveHeight_1 = 1">
       <DisplayName>血文字間描画排他垂直範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -413,7 +413,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 signVisibleRange = 1">
+    <Field Def="f32 signVisibleRange_1 = 1">
       <DisplayName>血文字PC間描画距離[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -443,7 +443,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 reloadSignIntervalTime = 1">
+    <Field Def="f32 reloadSignIntervalTime_0 = 1">
       <DisplayName>血文字再取得待機時間[秒]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -453,7 +453,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupHorizontalRange = 1">
+    <Field Def="u32 cellGroupHorizontalRange_1 = 1">
       <DisplayName>血文字取得セル範囲(水平)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -463,7 +463,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupTopRange = 1">
+    <Field Def="u32 cellGroupTopRange_1 = 1">
       <DisplayName>血文字取得セル範囲(上方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -473,7 +473,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupBottomRange = 1">
+    <Field Def="u32 cellGroupBottomRange_1 = 1">
       <DisplayName>血文字取得セル範囲(下方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -483,7 +483,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 lifeTime = 1">
+    <Field Def="u32 lifeTime_0 = 1">
       <DisplayName>血文字データ保持期間上限[秒]</DisplayName>
       <Description>本当はu16くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -494,7 +494,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 downloadSpan">
+    <Field Def="f32 downloadSpan_0">
       <DisplayName>血文字ダウンロード間隔</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>10000</Maximum>
@@ -514,7 +514,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="dummy8 pad[4]">
+    <Field Def="dummy8 pad_2[4]">
       <DisplayName>予約</DisplayName>
       <SortID>319</SortID>
       <UnkB8>bloodMessage</UnkB8>
@@ -532,7 +532,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 keyGuideHeight = 1">
+    <Field Def="f32 keyGuideHeight_2 = 1">
       <DisplayName>キーガイド垂直範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -562,7 +562,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 reloadSignTotalCount = 1">
+    <Field Def="u32 reloadSignTotalCount_2 = 1">
       <DisplayName>血痕取得数(全体)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -572,7 +572,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 reloadSignCellCount = 1">
+    <Field Def="u32 reloadSignCellCount_1 = 1">
       <DisplayName>血痕取得数(セル)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -582,7 +582,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 maxSignTotalCount = 1">
+    <Field Def="u32 maxSignTotalCount_1 = 1">
       <DisplayName>血痕所持可能数上限(全体)</DisplayName>
       <Description>本当はu16くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -592,7 +592,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 maxSignCellCount = 1">
+    <Field Def="u32 maxSignCellCount_1 = 1">
       <DisplayName>血痕所持可能数上限(セル)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -602,7 +602,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 reloadSignIntervalTime = 1">
+    <Field Def="f32 reloadSignIntervalTime_1 = 1">
       <DisplayName>血痕再取得待機時間[秒]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -612,7 +612,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 signVisibleRange = 1">
+    <Field Def="f32 signVisibleRange_2 = 1">
       <DisplayName>血痕PC間描画距離[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -622,7 +622,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveRange = 1">
+    <Field Def="f32 basicExclusiveRange_2 = 1">
       <DisplayName>血痕間描画排他水平範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -632,7 +632,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveHeight = 1">
+    <Field Def="f32 basicExclusiveHeight_2 = 1">
       <DisplayName>血痕間描画排他垂直範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -642,7 +642,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupHorizontalRange = 1">
+    <Field Def="u32 cellGroupHorizontalRange_2 = 1">
       <DisplayName>血痕取得セル範囲(水平)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -652,7 +652,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupTopRange = 1">
+    <Field Def="u32 cellGroupTopRange_2 = 1">
       <DisplayName>血痕取得セル範囲(上方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -662,7 +662,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupBottomRange = 1">
+    <Field Def="u32 cellGroupBottomRange_2 = 1">
       <DisplayName>血痕取得セル範囲(下方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -672,7 +672,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 lifeTime = 1">
+    <Field Def="u32 lifeTime_1 = 1">
       <DisplayName>血痕データ保持期間上限[秒]</DisplayName>
       <Description>本当はu16くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -704,7 +704,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 downloadSpan">
+    <Field Def="f32 downloadSpan_1">
       <DisplayName>血痕ダウンロード間隔</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>10000</Maximum>
@@ -908,7 +908,7 @@
       <UnkC0>NET_GHOST_PARAM</UnkC0>
       <UnkC8>幻影</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupHorizontalRange = 1">
+    <Field Def="u32 cellGroupHorizontalRange_3 = 1">
       <DisplayName>幻影取得セル範囲(水平)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -918,7 +918,7 @@
       <UnkC0>NET_GHOST_PARAM</UnkC0>
       <UnkC8>幻影</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupTopRange = 1">
+    <Field Def="u32 cellGroupTopRange_3 = 1">
       <DisplayName>幻影取得セル範囲(上方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -1440,7 +1440,7 @@
       <UnkC0>VISITOR</UnkC0>
       <UnkC8>訪問</UnkC8>
     </Field>
-    <Field Def="f32 DownloadSpan = 1">
+    <Field Def="f32 DownloadSpan_2 = 1">
       <DisplayName>訪問者リストダウンロード間隔[秒]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>10000</Maximum>
@@ -1513,14 +1513,14 @@
       <UnkC0>YELLOW_MONK_PARAM</UnkC0>
       <UnkC8>黄衣の翁</UnkC8>
     </Field>
-    <Field Def="dummy8 pad14[4]">
+    <Field Def="dummy8 pad14_0[4]">
       <DisplayName>予約</DisplayName>
       <SortID>2030</SortID>
       <UnkB8>YellowMonk</UnkB8>
       <UnkC0>YELLOW_MONK_PARAM</UnkC0>
       <UnkC8>黄衣の翁</UnkC8>
     </Field>
-    <Field Def="dummy8 pad14[8]">
+    <Field Def="dummy8 pad14_1[8]">
       <DisplayName>予約</DisplayName>
       <SortID>2031</SortID>
     </Field>

--- a/StudioCore/Assets/Paramdex/DS3/Meta/ATK_PARAM_ST.xml
+++ b/StudioCore/Assets/Paramdex/DS3/Meta/ATK_PARAM_ST.xml
@@ -88,7 +88,7 @@ atkElementCorrectId,Blowing Correction,AtkPhysCorrection,AtkMagCorrection,AtkFir
 AtkPhys,AtkMag,AtkFire,AtkThun,atkDark,AtkStam,AtkSuperArmor,AtkThrowEscape,AtkObj,-,
 GuardAtkRateCorrection,GuardBreakCorrection,GuardAtkRate,GuardBreakRate,GuardStaminaCutRate,GuardRate,GuardCutCancelRate,-,
 physSpCorrection,magSpCorrection,fireSpCorrection,thunSpCorrection,darkSpCorrection,-,
-ThrowTypeID,damageLevel,0x18B,pad1,damageLevelParameter,mapHitType,AtkAttribute,spAttribute,atkType,HitSourceType,ThrowFlag,disableGuard,disableStaminaAttack,disableHitSpEffect,IgnoreNotifyMissSwingForAI,IsArrowAtk,IsGhostAtk,isDisableNoDamage,opposeTarget,friendlyTarget,selfTarget,isChargeAtk,IsChargeAtk2,IsChargeAtk3,0x18A,0x195,isShareHitList,isCheckObjPenetration,regainableSlotId,deathCauseId,decalId1,decalId2,spawnAiSoundId,HitAiSoundId,RumbleId0,RumbleId1,RumbleId2,RumbleId3,repeatHitSfx,atkPowForSfxSe,atkDirForSfxSe,atkMaterial,atkSize,DefMaterial,DefSfxMaterial,defMaterialVal0,defMaterialVal1,defMaterialVal2,-,
+ThrowTypeID,damageLevel,0x18B,pad1,damageLevelParameter,mapHitType,AtkAttribute,spAttribute,atkType,HitSourceType,ThrowFlag,disableGuard,disableStaminaAttack,disableHitSpEffect,IgnoreNotifyMissSwingForAI,IsArrowAtk,IsGhostAtk,isDisableNoDamage,opposeTarget,friendlyTarget,selfTarget,isChargeAtk,IsChargeAtk2,IsChargeAtk3,0x18A_0,0x195,isShareHitList,isCheckObjPenetration,regainableSlotId,deathCauseId,decalId1,decalId2,spawnAiSoundId,HitAiSoundId,RumbleId0,RumbleId1,RumbleId2,RumbleId3,repeatHitSfx,atkPowForSfxSe,atkDirForSfxSe,atkMaterial,atkSize,DefMaterial,DefSfxMaterial,defMaterialVal0,defMaterialVal1,defMaterialVal2,-,
 Hit0_Radius,Hit0_DmyPoly1,Hit0_DmyPoly2,Hit0_hitType,Hit0_VfxId,Hit0_DummyPolyId0,Hit0_DummyPolyId1,hit0_Priority,Hit1_Radius,Hit1_DmyPoly1,Hit1_DmyPoly2,Hit1_hitType,Hit1_VfxId1,Hit1_DummyPolyId0,Hit1_DummyPolyId1,hit1_Priority,Hit2_Radius,Hit2_DmyPoly1,Hit2_DmyPoly2,Hit2_hitType,Hit2_VfxId,Hit2_DummyPolyId0,Hit2_DummyPolyId1,hit2_Priority,Hit3_Radius,Hit3_DmyPoly1,Hit3_DmyPoly2,Hit3_hitType,Hit3_VfxId,Hit3_DummyPolyId0,Hit3_DummyPolyId1,hit3_Priority,Hit4_Radius,Hit4_DmyPoly1,Hit4_DmyPoly2,Hit4_hitType,Hit4_VfxId,Hit4_DummyPolyId0,Hit4_DummyPolyId1,Hit5_Radius,Hit5_DmyPoly1,Hit5_DmyPoly2,Hit5_hitType,Hit5_VfxId,Hit5_DummyPolyId0,Hit5_DummyPolyId1,Hit6_Radius,Hit6_DmyPoly1,Hit6_DmyPoly2,Hit6_hitType,Hit6_VfxId,Hit6_DummyPolyId0,Hit6_DummyPolyId1,Hit7_Radius,Hit7_DmyPoly1,Hit7_DmyPoly2,Hit7_hitType,Hit7_VfxId,Hit7_DummyPolyId0,Hit7_DummyPolyId1,Hit8_Radius,Hit8_DmyPoly1,Hit8_DmyPoly2,Hit8_hitType,Hit9_Radius,Hit9_DmyPoly1,Hit9_DmyPoly2,Hit9_hitType,Hit10_Radius,Hit10_DmyPoly1,Hit10_DmyPoly2,Hit10_hitType,Hit11_Radius,Hit11_DmyPoly1,Hit11_DmyPoly2,Hit11_hitType,Hit12_Radius,Hit12_DmyPoly1,Hit12_DmyPoly2,Hit12_hitType,Hit13_Radius,Hit13_DmyPoly1,Hit13_DmyPoly2,Hit13_hitType,Hit14_Radius,Hit14_DmyPoly1,Hit14_DmyPoly2,Hit14_hitType,Hit15_Radius,Hit15_DmyPoly1,Hit15_DmyPoly2,Hit15_hitType,-" />
   <Field>
     <Hit0_Radius AltName="Hit 0: Radius" Wiki="Radius of sphere/capsule hitbox." />
@@ -169,8 +169,8 @@ Hit0_Radius,Hit0_DmyPoly1,Hit0_DmyPoly2,Hit0_hitType,Hit0_VfxId,Hit0_DummyPolyId
     <isChargeAtk AltName="Is Charge Attack" IsBool="" />
     <isShareHitList AltName="Is Hit List Shared" IsBool="" />
     <isCheckObjPenetration AltName="Is Object Penetration Checked" IsBool="" />
-	<_0x81 AltName="Unknown" />
-	<_0x81 AltName="Unknown" />
+	<_0x81_0 AltName="Unknown" />
+	<_0x81_1 AltName="Unknown" />
     <spawnAiSoundId AltName="Appear AI Sound ID" Refs="AiSoundParam"/>
 	<HitAiSoundId AltName="Hit AI Sound ID" Refs="AiSoundParam"/>
 	<Hit0_VfxId AltName="Blade Trail [0] VFX ID" />
@@ -255,12 +255,12 @@ Hit0_Radius,Hit0_DmyPoly1,Hit0_DmyPoly2,Hit0_hitType,Hit0_VfxId,Hit0_DummyPolyId
     <atkDark AltName="Damage: Dark" />
     <IsChargeAtk2 AltName="Unknown" IsBool="" />
     <IsChargeAtk3 AltName="Disable Parry" IsBool="" />
-	<_0x18A AltName="Disable 2H Bonus" IsBool="" Wiki="Does not factor in 1.5x STR bonus from 2H"/>
-	<_0x18A AltName="Unknown" />
-	<_0x18A AltName="Unknown" />
-	<_0x18A AltName="Unknown" />
-	<_0x18A AltName="Unknown" />
-	<_0x18A AltName="Unknown" />
+	<_0x18A_0 AltName="Disable 2H Bonus" IsBool="" Wiki="Does not factor in 1.5x STR bonus from 2H"/>
+	<_0x18A_1 AltName="Unknown" />
+	<_0x18A_2 AltName="Unknown" />
+	<_0x18A_3 AltName="Unknown" />
+	<_0x18A_4 AltName="Unknown" />
+	<_0x18A_5 AltName="Unknown" />
     <physSpCorrection AltName="Status Effect Correction" Wiki="Magnification correction is performed for the abnormal state attack power of special effects." />
     <magSpCorrection AltName="Attack Correction - By SpEffect Point" Wiki="Magnification correction is performed for the special effect ~ ~ attack power [point]." />
     <fireSpCorrection AltName="Attack Correction - By SpEffect Power" Wiki="Magnification is corrected for the special effect's attack power multiplier." />

--- a/StudioCore/Assets/Paramdex/DS3/Meta/ATTACK_ELEMENT_CORRECT_PARAM_ST.xml
+++ b/StudioCore/Assets/Paramdex/DS3/Meta/ATTACK_ELEMENT_CORRECT_PARAM_ST.xml
@@ -1,38 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PARAMMETA XmlVersion="0">
   <Field>
-    <_0x00 AltName="Physical Correction: STR" IsBool="" />
-    <_0x00 AltName="Physical Correction: DEX" IsBool="" />
-    <_0x00 AltName="Physical Correction: INT" IsBool="" />
-    <_0x00 AltName="Physical Correction: FTH" IsBool="" />
-    <_0x00 AltName="Physical Correction: LCK" IsBool="" />
-	<_0x00 AltName="Magic Correction: STR" IsBool="" />
-    <_0x00 AltName="Magic Correction: DEX" IsBool="" />
-    <_0x00 AltName="Magic Correction: INT" IsBool="" />
-    <_0x00 AltName="Magic Correction: FTH" IsBool="" />
-    <_0x00 AltName="Magic Correction: LCK" IsBool="" />
-    <_0x00 AltName="Fire Correction: STR" IsBool="" />
-    <_0x00 AltName="Fire Correction: DEX" IsBool="" />
-    <_0x00 AltName="Fire Correction: INT" IsBool="" />
-    <_0x00 AltName="Fire Correction: FTH" IsBool="" />
-    <_0x00 AltName="Fire Correction: LCK" IsBool="" />
-    <_0x00 AltName="Lightning Correction: STR" IsBool="" />
-    <_0x00 AltName="Lightning Correction: DEX" IsBool="" />
-    <_0x00 AltName="Lightning Correction: INT" IsBool="" />
-    <_0x00 AltName="Lightning Correction: FTH" IsBool="" />
-    <_0x00 AltName="Lightning Correction: LCK" IsBool="" />
-    <_0x00 AltName="Dark Correction: STR" IsBool="" />
-    <_0x00 AltName="Dark Correction: DEX" IsBool="" />
-    <_0x00 AltName="Dark Correction: INT" IsBool="" />
-    <_0x00 AltName="Dark Correction: FTH" IsBool="" />
-    <_0x00 AltName="Dark Correction: LCK" IsBool="" />
-	<_0x00 AltName="Unk1" />
-	<_0x00 AltName="Unk2" />
-	<_0x00 AltName="Unk3" />
-	<_0x00 AltName="Unk4" />
-	<_0x00 AltName="Unk5" />
-	<_0x00 AltName="Unk6" />
-	<_0x00 AltName="Unk7" />
+    <_0x00_0 AltName="Physical Correction: STR" IsBool="" />
+    <_0x00_1 AltName="Physical Correction: DEX" IsBool="" />
+    <_0x00_2 AltName="Physical Correction: INT" IsBool="" />
+    <_0x00_3 AltName="Physical Correction: FTH" IsBool="" />
+    <_0x00_4 AltName="Physical Correction: LCK" IsBool="" />
+	<_0x00_5 AltName="Magic Correction: STR" IsBool="" />
+    <_0x00_6 AltName="Magic Correction: DEX" IsBool="" />
+    <_0x00_7 AltName="Magic Correction: INT" IsBool="" />
+    <_0x00_8 AltName="Magic Correction: FTH" IsBool="" />
+    <_0x00_9 AltName="Magic Correction: LCK" IsBool="" />
+    <_0x00_10 AltName="Fire Correction: STR" IsBool="" />
+    <_0x00_11 AltName="Fire Correction: DEX" IsBool="" />
+    <_0x00_12 AltName="Fire Correction: INT" IsBool="" />
+    <_0x00_13 AltName="Fire Correction: FTH" IsBool="" />
+    <_0x00_14 AltName="Fire Correction: LCK" IsBool="" />
+    <_0x00_15 AltName="Lightning Correction: STR" IsBool="" />
+    <_0x00_16 AltName="Lightning Correction: DEX" IsBool="" />
+    <_0x00_17 AltName="Lightning Correction: INT" IsBool="" />
+    <_0x00_18 AltName="Lightning Correction: FTH" IsBool="" />
+    <_0x00_19 AltName="Lightning Correction: LCK" IsBool="" />
+    <_0x00_20 AltName="Dark Correction: STR" IsBool="" />
+    <_0x00_21 AltName="Dark Correction: DEX" IsBool="" />
+    <_0x00_22 AltName="Dark Correction: INT" IsBool="" />
+    <_0x00_23 AltName="Dark Correction: FTH" IsBool="" />
+    <_0x00_24 AltName="Dark Correction: LCK" IsBool="" />
+	<_0x00_25 AltName="Unk1" />
+	<_0x00_26 AltName="Unk2" />
+	<_0x00_27 AltName="Unk3" />
+	<_0x00_28 AltName="Unk4" />
+	<_0x00_29 AltName="Unk5" />
+	<_0x00_30 AltName="Unk6" />
+	<_0x00_31 AltName="Unk7" />
 	<addRate0 AltName="Physical Replacement Correction: STR" />
     <addRate1 AltName="Physical Replacement Correction: DEX" />
     <addRate2 AltName="Physical Replacement Correction: INT" />

--- a/StudioCore/Assets/Paramdex/DS3/Meta/NETWORK_PARAM_ST.xml
+++ b/StudioCore/Assets/Paramdex/DS3/Meta/NETWORK_PARAM_ST.xml
@@ -6,21 +6,21 @@
     <signVerticalOffset AltName="Common - Sign Height Offset" Wiki="" />
     <maxSignPosCorrectionRange AltName="Common - Max Sign Position Correction Range" Wiki="" />
     <summonTimeoutTime AltName="Common - Summon Timeout Time" Wiki="" />
-    <pad AltName=""/>
+    <pad_0 AltName=""/>
     <signPuddleActiveMessageIntervalSec AltName="Summon Sign - Sign Puddle Active Message Interval" Wiki="" />
-    <keyGuideHeight AltName="Summon Sign - Key Guide Height" Wiki="" />
+    <keyGuideHeight_0 AltName="Summon Sign - Key Guide Height" Wiki="" />
     <reloadSignIntervalTime1 AltName="Summon Sign - Reload Sign Interval Time [1]" Wiki="" />
     <reloadSignIntervalTime2 AltName="Summon Sign - Reload Sign Interval Time [2]" Wiki="" />
-    <reloadSignTotalCount AltName="Summon Sign - Reload Sign Total Count" Wiki="Actually u8 is enough" />
-    <reloadSignCellCount AltName="Summon Sign - Reload Sign Cell Count" Wiki="Actually u8 is enough" />
+    <reloadSignTotalCount_0 AltName="Summon Sign - Reload Sign Total Count" Wiki="Actually u8 is enough" />
+    <reloadSignCellCount_0 AltName="Summon Sign - Reload Sign Cell Count" Wiki="Actually u8 is enough" />
     <updateSignIntervalTime AltName="Summon Sign - Update Sign Interval Time" Wiki="" />
-    <basicExclusiveRange AltName="Summon Sign - Basic Horizontal Drawing Range" Wiki="" />
-    <basicExclusiveHeight AltName="Summon Sign - Basic Vertical Drawing Height" Wiki="" />
+    <basicExclusiveRange_0 AltName="Summon Sign - Basic Horizontal Drawing Range" Wiki="" />
+    <basicExclusiveHeight_0 AltName="Summon Sign - Basic Vertical Drawing Height" Wiki="" />
     <previewChrWaitingTime AltName="Summon Sign - Preview Chr Waiting Time" Wiki="" />
-    <signVisibleRange AltName="Summon Sign - Sign Visible Range" Wiki="" />
-    <cellGroupHorizontalRange AltName="Summon Sign - Acquisition Cell Range (Horizontal)" Wiki="Actually u8 is enough" />
-    <cellGroupTopRange AltName="Summon Sign - Acquisition Cell Range (Top)" Wiki="Actually u8 is enough" />
-    <cellGroupBottomRange AltName="Summon Sign - Acquisition Cell Range (Bottom)" Wiki="Actually u8 is enough" />
+    <signVisibleRange_0 AltName="Summon Sign - Sign Visible Range" Wiki="" />
+    <cellGroupHorizontalRange_0 AltName="Summon Sign - Acquisition Cell Range (Horizontal)" Wiki="Actually u8 is enough" />
+    <cellGroupTopRange_0 AltName="Summon Sign - Acquisition Cell Range (Top)" Wiki="Actually u8 is enough" />
+    <cellGroupBottomRange_0 AltName="Summon Sign - Acquisition Cell Range (Bottom)" Wiki="Actually u8 is enough" />
     <minWhitePhantomLimitTimeScale AltName="Summon Sign - Min White Phantom Limit Time Scale" Wiki="" />
     <minSmallPhantomLimitTimeScale AltName="Summon Sign - Min Small Phantom Limit Time Scale" Wiki="" />
     <whiteKeywordLimitTimeScale AltName="Summon Sign - White Keyword Limit Time Scale" Wiki="" />
@@ -34,46 +34,46 @@
     <maxBreakInTargetListCount AltName="Intrusion - Max Intruder List Count" Wiki="" />
     <breakInRequestIntervalTimeSec AltName="Intrusion - Intruder Request Interval Time" Wiki="" />
     <breakInRequestTimeOutSec AltName="Intrusion - Intruder Request Timeout" Wiki="" />
-    <pad AltName=""/>
+    <pad_1 AltName=""/>
     <keyGuideRange AltName="Blood Message - Key Guide Horionztal Range" Wiki="" />
-    <keyGuideHeight AltName="Blood Message - Key Guide Vertical Range" Wiki="" />
-    <reloadSignTotalCount AltName="Blood Message - Reload Sign Total Count" Wiki="Actually u8 is enough" />
+    <keyGuideHeight_1 AltName="Blood Message - Key Guide Vertical Range" Wiki="" />
+    <reloadSignTotalCount_1 AltName="Blood Message - Reload Sign Total Count" Wiki="Actually u8 is enough" />
     <reloadNewSignCellCount AltName="Blood Message - Reload New Sign Cell Count" Wiki="Actually u8 is enough" />
     <reloadRandomSignCellCount AltName="Blood Message - Reload Random Sign Cell Count" Wiki="Actually u8 is enough" />
-    <maxSignTotalCount AltName="Blood Message - Max Sign Total Count" Wiki="Actually u16 is enough" />
-    <maxSignCellCount AltName="Blood Message - Max Sign Cell Count" Wiki="Actually u8 is enough" />
-    <basicExclusiveRange AltName="Blood Message - Basic Exclusive Range" Wiki="" />
-    <basicExclusiveHeight AltName="Blood Message - Basic Exclusive Height" Wiki="" />
-    <signVisibleRange AltName="Blood Message - Sign Visible Range" Wiki="" />
+    <maxSignTotalCount_0 AltName="Blood Message - Max Sign Total Count" Wiki="Actually u16 is enough" />
+    <maxSignCellCount_0 AltName="Blood Message - Max Sign Cell Count" Wiki="Actually u8 is enough" />
+    <basicExclusiveRange_1 AltName="Blood Message - Basic Exclusive Range" Wiki="" />
+    <basicExclusiveHeight_1 AltName="Blood Message - Basic Exclusive Height" Wiki="" />
+    <signVisibleRange_1 AltName="Blood Message - Sign Visible Range" Wiki="" />
     <maxWriteSignCount AltName="Blood Message - Max Write Sign Count" Wiki="Actually u8 is enough" />
     <maxReadSignCount AltName="Blood Message - Max Read Sign Count" Wiki="Actually u8 is enough" />
-    <reloadSignIntervalTime AltName="Blood Message - Reload Sign Interval Time" Wiki="" />
-    <cellGroupHorizontalRange AltName="Blood Message - Cell Group Horizontal Range" Wiki="Actually u8 is enough" />
-    <cellGroupTopRange AltName="Blood Message - Cell Group Top Range" Wiki="Actually u8 is enough" />
-    <cellGroupBottomRange AltName="Blood Message - Cell Group Bottom Range" Wiki="Actually u8 is enough" />
-    <lifeTime AltName="Blood Message - Lifetime" Wiki="Actually u16 is enough" />
-    <downloadSpan AltName="Blood Message - Download Span" Wiki="" />
+    <reloadSignIntervalTime_0 AltName="Blood Message - Reload Sign Interval Time" Wiki="" />
+    <cellGroupHorizontalRange_1 AltName="Blood Message - Cell Group Horizontal Range" Wiki="Actually u8 is enough" />
+    <cellGroupTopRange_1 AltName="Blood Message - Cell Group Top Range" Wiki="Actually u8 is enough" />
+    <cellGroupBottomRange_1 AltName="Blood Message - Cell Group Bottom Range" Wiki="Actually u8 is enough" />
+    <lifeTime_0 AltName="Blood Message - Lifetime" Wiki="Actually u16 is enough" />
+    <downloadSpan_0 AltName="Blood Message - Download Span" Wiki="" />
     <downloadEvaluationSpan AltName="Blood Message - Download Evaluation Span" Wiki="" />
-    <pad AltName=""/>
+    <pad_2 AltName=""/>
     <deadingGhostStartPosThreshold AltName="Bloodstain - Dead Ghost Start Position Threshold" Wiki="If the distance between the bloodstain position and the illusion start position is farther than this value, the server will not be registered." />
-    <keyGuideHeight AltName="Bloodstain - Key Guide Height" Wiki="" />
+    <keyGuideHeight_2 AltName="Bloodstain - Key Guide Height" Wiki="" />
     <keyGuideRangePlayer AltName="Bloodstain - Key Guide Range Player" Wiki="" />
     <keyGuideHeightPlayer AltName="Bloodstain - Key Guide Height Player" Wiki="" />
-    <reloadSignTotalCount AltName="Bloodstain - Reload Sign Total Count" Wiki="Actually u8 is enough" />
-    <reloadSignCellCount AltName="Bloodstain - Reload Sign Cell Count" Wiki="Actually u8 is enough" />
-    <maxSignTotalCount AltName="Bloodstain - Max Sign Total Count" Wiki="Actually u16 is enough" />
-    <maxSignCellCount AltName="Bloodstain - Max Sign Cell Count" Wiki="Actually u8 is enough" />
-    <reloadSignIntervalTime AltName="Bloodstain - Reload Sign Interval Time" Wiki="" />
-    <signVisibleRange AltName="Bloodstain - Sign Visible Range" Wiki="" />
-    <basicExclusiveRange AltName="Bloodstain - Basic Exclusive Range" Wiki="" />
-    <basicExclusiveHeight AltName="Bloodstain - Basic Exclusive Height" Wiki="" />
-    <cellGroupHorizontalRange AltName="Bloodstain - Cell Group Horizontal Range" Wiki="Actually u8 is enough" />
-    <cellGroupTopRange AltName="Bloodstain - Cell Group Top Range" Wiki="Actually u8 is enough" />
-    <cellGroupBottomRange AltName="Bloodstain - Cell Group Bottom Range" Wiki="Actually u8 is enough" />
-    <lifeTime AltName="Bloodstain - Lifetime" Wiki="Actually u16 is enough" />
+    <reloadSignTotalCount_2 AltName="Bloodstain - Reload Sign Total Count" Wiki="Actually u8 is enough" />
+    <reloadSignCellCount_1 AltName="Bloodstain - Reload Sign Cell Count" Wiki="Actually u8 is enough" />
+    <maxSignTotalCount_1 AltName="Bloodstain - Max Sign Total Count" Wiki="Actually u16 is enough" />
+    <maxSignCellCount_1 AltName="Bloodstain - Max Sign Cell Count" Wiki="Actually u8 is enough" />
+    <reloadSignIntervalTime_1 AltName="Bloodstain - Reload Sign Interval Time" Wiki="" />
+    <signVisibleRange_2 AltName="Bloodstain - Sign Visible Range" Wiki="" />
+    <basicExclusiveRange_2 AltName="Bloodstain - Basic Exclusive Range" Wiki="" />
+    <basicExclusiveHeight_2 AltName="Bloodstain - Basic Exclusive Height" Wiki="" />
+    <cellGroupHorizontalRange_2 AltName="Bloodstain - Cell Group Horizontal Range" Wiki="Actually u8 is enough" />
+    <cellGroupTopRange_2 AltName="Bloodstain - Cell Group Top Range" Wiki="Actually u8 is enough" />
+    <cellGroupBottomRange_2 AltName="Bloodstain - Cell Group Bottom Range" Wiki="Actually u8 is enough" />
+    <lifeTime_1 AltName="Bloodstain - Lifetime" Wiki="Actually u16 is enough" />
     <recordDeadingGhostTotalTime AltName="Bloodstain - Record Dead Ghost Total Time" Wiki="" />
     <recordDeadingGhostMinTime AltName="Bloodstain - Record Dead Ghost Min Time" Wiki="Death illusions less than this recording time will not register the server" />
-    <downloadSpan AltName="Bloodstain - Download Span" Wiki="" />
+    <downloadSpan_1 AltName="Bloodstain - Download Span" Wiki="" />
     <statueCreatableDistance AltName="Bloodstain - Statue Creatable Distance" Wiki="For open fields. When a stone statue is generated, it can be generated if the distance between the PC and the generation position is greater than or equal to this value." />
     <reloadGhostTotalCount AltName="Ghost - Reload Ghost Total Count" Wiki="Actually u8 is enough" />
     <reloadGhostCellCount AltName="Ghost - Reload Ghost Cell Count" Wiki="Actually u8 is enough" />
@@ -93,8 +93,8 @@
     <minReplayIntervalTime AltName="Ghost - Replay Interval Min Time" Wiki="" />
     <maxReplayIntervalTime AltName="Ghost - Replay Interval Max Time" Wiki="" />
     <reloadGhostIntervalTime AltName="Ghost - Reload Ghost Interval Time" Wiki="" />
-    <cellGroupHorizontalRange AltName="Ghost - Cell Group Horizontal Range" Wiki="Actually u8 is enough" />
-    <cellGroupTopRange AltName="Ghost - Cell Group Top Range" Wiki="Actually u8 is enough" />
+    <cellGroupHorizontalRange_3 AltName="Ghost - Cell Group Horizontal Range" Wiki="Actually u8 is enough" />
+    <cellGroupTopRange_3 AltName="Ghost - Cell Group Top Range" Wiki="Actually u8 is enough" />
     <replayBonfirePhantomParamIdForCodename AltName="Ghost - Replay Bonfire Phantom Param ID (CodeDisplayName)" Wiki="Phantom bonfire mode phantom parameter ID used when codename matches" />
     <replayBonfireModeRange AltName="Ghost - Replay Bonfire Mode Range" Wiki="" />
     <replayBonfirePhantomParamId AltName="Ghost - Replay Bonfire Phantom Param ID" Wiki="Phantom bonfire mode phantom parameter ID" />
@@ -149,15 +149,15 @@
     <pad11 AltName=""/>
     <VisitorListMax AltName="Visitor - Visitor List Max" Wiki="Actually u8 is enough" />
     <VisitorTimeOutTime AltName="Visitor - Visitor Time Out Time" Wiki="" />
-    <DownloadSpan AltName="Visitor - Download Span" Wiki="" />
+    <DownloadSpan_2 AltName="Visitor - Download Span" Wiki="" />
     <VisitorGuestRequestMessageIntervalSec AltName="Visitor - Visitor Guest Request Message Interval" Wiki="Display interval [seconds] of messages sent by visiting guests while searching for a destination" />
     <wanderGhostIntervalLifeTime AltName="Ghost Addition - Wandering Ghost Interval Lifetime" Wiki="Wandering illusion life" />
     <pad13 AltName=""/>
     <YellowMonkTimeOutTime AltName="Yellow Monk - Yellow Monk Timeout Time" Wiki="" />
     <YellowMonkDownloadSpan AltName="Yellow Monk - Yellow Monk Download Span" Wiki="" />
     <YellowMonkOverallFlowTimeOutTime AltName="Yellow Monk - Yellow Monk Overall Flow Time Out Time" Wiki="" />
-    <pad14 AltName=""/>
-    <pad14 AltName=""/>
+    <pad14_0 AltName=""/>
+    <pad14_1 AltName=""/>
   </Field>
   <Self Wiki="Network data"/>
 </PARAMMETA>

--- a/StudioCore/Assets/Paramdex/ER/Defs/CoolTimeParam.xml
+++ b/StudioCore/Assets/Paramdex/ER/Defs/CoolTimeParam.xml
@@ -6,7 +6,7 @@
   <Unicode>True</Unicode>
   <FormatVersion>203</FormatVersion>
   <Fields>
-    <Field Def="f32 limitationTime">
+    <Field Def="f32 limitationTime_0">
       <DisplayName>制限時間（協力霊数0）</DisplayName>
       <Description>制限時間[sec]（協力霊数0）</Description>
       <DisplayFormat>%.2f</DisplayFormat>
@@ -19,7 +19,7 @@
       <UnkC0>LIMIT_BY_COOP_NUM</UnkC0>
       <UnkC8>協力霊数0</UnkC8>
     </Field>
-    <Field Def="f32 observeTime">
+    <Field Def="f32 observeTime_0">
       <DisplayName>監視時間（協力霊数0）</DisplayName>
       <Description>監視時間[sec]（協力霊数0）</Description>
       <DisplayFormat>%.2f</DisplayFormat>
@@ -32,7 +32,7 @@
       <UnkC0>LIMIT_BY_COOP_NUM</UnkC0>
       <UnkC8>協力霊数0</UnkC8>
     </Field>
-    <Field Def="f32 limitationTime">
+    <Field Def="f32 limitationTime_1">
       <DisplayName>制限時間（協力霊数1）</DisplayName>
       <Description>制限時間[sec]（協力霊数1）</Description>
       <DisplayFormat>%.2f</DisplayFormat>
@@ -45,7 +45,7 @@
       <UnkC0>LIMIT_BY_COOP_NUM</UnkC0>
       <UnkC8>協力霊数1</UnkC8>
     </Field>
-    <Field Def="f32 observeTime">
+    <Field Def="f32 observeTime_1">
       <DisplayName>監視時間（協力霊数1）</DisplayName>
       <Description>監視時間[sec]（協力霊数1）</Description>
       <DisplayFormat>%.2f</DisplayFormat>
@@ -58,7 +58,7 @@
       <UnkC0>LIMIT_BY_COOP_NUM</UnkC0>
       <UnkC8>協力霊数1</UnkC8>
     </Field>
-    <Field Def="f32 limitationTime">
+    <Field Def="f32 limitationTime_2">
       <DisplayName>制限時間（協力霊数2）</DisplayName>
       <Description>制限時間[sec]（協力霊数2）</Description>
       <DisplayFormat>%.2f</DisplayFormat>
@@ -71,7 +71,7 @@
       <UnkC0>LIMIT_BY_COOP_NUM</UnkC0>
       <UnkC8>協力霊数2</UnkC8>
     </Field>
-    <Field Def="f32 observeTime">
+    <Field Def="f32 observeTime_2">
       <DisplayName>監視時間（協力霊数2）</DisplayName>
       <Description>監視時間[sec]（協力霊数2）</Description>
       <DisplayFormat>%.2f</DisplayFormat>
@@ -84,7 +84,7 @@
       <UnkC0>LIMIT_BY_COOP_NUM</UnkC0>
       <UnkC8>協力霊数2</UnkC8>
     </Field>
-    <Field Def="f32 limitationTime">
+    <Field Def="f32 limitationTime_3">
       <DisplayName>制限時間（協力霊数3）</DisplayName>
       <Description>制限時間[sec]（協力霊数3）</Description>
       <DisplayFormat>%.2f</DisplayFormat>
@@ -97,7 +97,7 @@
       <UnkC0>LIMIT_BY_COOP_NUM</UnkC0>
       <UnkC8>協力霊数3</UnkC8>
     </Field>
-    <Field Def="f32 observeTime">
+    <Field Def="f32 observeTime_3">
       <DisplayName>監視時間（協力霊数3）</DisplayName>
       <Description>監視時間[sec]（協力霊数3）</Description>
       <DisplayFormat>%.2f</DisplayFormat>

--- a/StudioCore/Assets/Paramdex/ER/Defs/DefaultKeyAssign.xml
+++ b/StudioCore/Assets/Paramdex/ER/Defs/DefaultKeyAssign.xml
@@ -266,7 +266,7 @@
       <SortID>1000</SortID>
       <UnkC8>下位優先度抑制（高⇔低）</UnkC8>
     </Field>
-    <Field Def="s32 phyisicalKey = -1">
+    <Field Def="s32 phyisicalKey_0 = -1">
       <DisplayName>パッド物理キー</DisplayName>
       <Enum>DefaultKeyAssignPadKey</Enum>
       <Description>パッド物理キー</Description>
@@ -277,7 +277,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー1</UnkC8>
     </Field>
-    <Field Def="u8 traitsType">
+    <Field Def="u8 traitsType_0">
       <DisplayName>押され方</DisplayName>
       <Enum>DefaultKeyAssignTraits</Enum>
       <Description>押され方</Description>
@@ -286,7 +286,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー1</UnkC8>
     </Field>
-    <Field Def="u8 a2dOperator">
+    <Field Def="u8 a2dOperator_0">
       <DisplayName>アナログ→デジタル変換方法</DisplayName>
       <Enum>DefaultKeyAssignA2DOperator</Enum>
       <Description>アナログ→デジタル変換方法</Description>
@@ -295,7 +295,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー1</UnkC8>
     </Field>
-    <Field Def="u8 applyTarget">
+    <Field Def="u8 applyTarget_0">
       <DisplayName>適用ターゲット</DisplayName>
       <Enum>DefaultKeyAssignApplyTarget</Enum>
       <Description>反映ターゲット</Description>
@@ -304,7 +304,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー1</UnkC8>
     </Field>
-    <Field Def="u8 isAnalog:1">
+    <Field Def="u8 isAnalog_0:1">
       <DisplayName>デジタル・アナログ</DisplayName>
       <Enum>DefaultKeyAssignDigitalAnalog</Enum>
       <Description>デジタルorアナログ</Description>
@@ -314,7 +314,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー1</UnkC8>
     </Field>
-    <Field Def="u8 enableWin64:1 = 1">
+    <Field Def="u8 enableWin64_0:1 = 1">
       <DisplayName>Win64</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>Win64で使用されるか</Description>
@@ -324,7 +324,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー1</UnkC8>
     </Field>
-    <Field Def="u8 enablePS4:1 = 1">
+    <Field Def="u8 enablePS4_0:1 = 1">
       <DisplayName>PS4</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>PS4で使用されるか</Description>
@@ -334,7 +334,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー1</UnkC8>
     </Field>
-    <Field Def="u8 enableXboxOne:1 = 1">
+    <Field Def="u8 enableXboxOne_0:1 = 1">
       <DisplayName>XboxOne</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>XboxOneで使用されるか</Description>
@@ -344,7 +344,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー1</UnkC8>
     </Field>
-    <Field Def="f32 time1">
+    <Field Def="f32 time1_0">
       <DisplayName>時間</DisplayName>
       <Description>時間</Description>
       <Minimum>0</Minimum>
@@ -354,7 +354,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー1</UnkC8>
     </Field>
-    <Field Def="f32 time2">
+    <Field Def="f32 time2_0">
       <DisplayName>リピート用インターバル時間</DisplayName>
       <Description>リピート用インターバル時間</Description>
       <Minimum>0</Minimum>
@@ -364,7 +364,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー1</UnkC8>
     </Field>
-    <Field Def="f32 a2dThreshold = 0.5">
+    <Field Def="f32 a2dThreshold_0 = 0.5">
       <DisplayName>アナログ→デジタル変換閾値</DisplayName>
       <Description>アナログ→デジタル変換閾値</Description>
       <Minimum>0</Minimum>
@@ -374,7 +374,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー1</UnkC8>
     </Field>
-    <Field Def="s32 phyisicalKey = -1">
+    <Field Def="s32 phyisicalKey_1 = -1">
       <DisplayName>パッド物理キー</DisplayName>
       <Enum>DefaultKeyAssignPadKey</Enum>
       <Description>パッド物理キー</Description>
@@ -385,7 +385,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー2</UnkC8>
     </Field>
-    <Field Def="u8 traitsType">
+    <Field Def="u8 traitsType_1">
       <DisplayName>押され方</DisplayName>
       <Enum>DefaultKeyAssignTraits</Enum>
       <Description>押され方</Description>
@@ -394,7 +394,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー2</UnkC8>
     </Field>
-    <Field Def="u8 a2dOperator">
+    <Field Def="u8 a2dOperator_1">
       <DisplayName>アナログ→デジタル変換方法</DisplayName>
       <Enum>DefaultKeyAssignA2DOperator</Enum>
       <Description>アナログ→デジタル変換方法</Description>
@@ -403,7 +403,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー2</UnkC8>
     </Field>
-    <Field Def="u8 applyTarget">
+    <Field Def="u8 applyTarget_1">
       <DisplayName>適用ターゲット</DisplayName>
       <Enum>DefaultKeyAssignApplyTarget</Enum>
       <Description>反映ターゲット</Description>
@@ -412,7 +412,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー2</UnkC8>
     </Field>
-    <Field Def="u8 isAnalog:1">
+    <Field Def="u8 isAnalog_1:1">
       <DisplayName>デジタル・アナログ</DisplayName>
       <Enum>DefaultKeyAssignDigitalAnalog</Enum>
       <Description>デジタルorアナログ</Description>
@@ -422,7 +422,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー2</UnkC8>
     </Field>
-    <Field Def="u8 enableWin64:1 = 1">
+    <Field Def="u8 enableWin64_1:1 = 1">
       <DisplayName>Win64</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>Win64で使用されるか</Description>
@@ -432,7 +432,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー2</UnkC8>
     </Field>
-    <Field Def="u8 enablePS4:1 = 1">
+    <Field Def="u8 enablePS4_1:1 = 1">
       <DisplayName>PS4</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>PS4で使用されるか</Description>
@@ -442,7 +442,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー2</UnkC8>
     </Field>
-    <Field Def="u8 enableXboxOne:1 = 1">
+    <Field Def="u8 enableXboxOne_1:1 = 1">
       <DisplayName>XboxOne</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>XboxOneで使用されるか</Description>
@@ -452,7 +452,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー2</UnkC8>
     </Field>
-    <Field Def="f32 time1">
+    <Field Def="f32 time1_1">
       <DisplayName>時間</DisplayName>
       <Description>時間</Description>
       <Minimum>0</Minimum>
@@ -462,7 +462,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー2</UnkC8>
     </Field>
-    <Field Def="f32 time2">
+    <Field Def="f32 time2_1">
       <DisplayName>リピート用インターバル時間</DisplayName>
       <Description>リピート用インターバル時間</Description>
       <Minimum>0</Minimum>
@@ -472,7 +472,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー2</UnkC8>
     </Field>
-    <Field Def="f32 a2dThreshold = 0.5">
+    <Field Def="f32 a2dThreshold_1 = 0.5">
       <DisplayName>アナログ→デジタル変換閾値</DisplayName>
       <Description>アナログ→デジタル変換閾値</Description>
       <Minimum>0</Minimum>
@@ -482,7 +482,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー2</UnkC8>
     </Field>
-    <Field Def="s32 phyisicalKey = -1">
+    <Field Def="s32 phyisicalKey_2 = -1">
       <DisplayName>パッド物理キー</DisplayName>
       <Enum>DefaultKeyAssignPadKey</Enum>
       <Description>パッド物理キー</Description>
@@ -493,7 +493,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー3</UnkC8>
     </Field>
-    <Field Def="u8 traitsType">
+    <Field Def="u8 traitsType_2">
       <DisplayName>押され方</DisplayName>
       <Enum>DefaultKeyAssignTraits</Enum>
       <Description>押され方</Description>
@@ -502,7 +502,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー3</UnkC8>
     </Field>
-    <Field Def="u8 a2dOperator">
+    <Field Def="u8 a2dOperator_2">
       <DisplayName>アナログ→デジタル変換方法</DisplayName>
       <Enum>DefaultKeyAssignA2DOperator</Enum>
       <Description>アナログ→デジタル変換方法</Description>
@@ -511,7 +511,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー3</UnkC8>
     </Field>
-    <Field Def="u8 applyTarget">
+    <Field Def="u8 applyTarget_2">
       <DisplayName>適用ターゲット</DisplayName>
       <Enum>DefaultKeyAssignApplyTarget</Enum>
       <Description>反映ターゲット</Description>
@@ -520,7 +520,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー3</UnkC8>
     </Field>
-    <Field Def="u8 isAnalog:1">
+    <Field Def="u8 isAnalog_2:1">
       <DisplayName>デジタル・アナログ</DisplayName>
       <Enum>DefaultKeyAssignDigitalAnalog</Enum>
       <Description>デジタルorアナログ</Description>
@@ -530,7 +530,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー3</UnkC8>
     </Field>
-    <Field Def="u8 enableWin64:1 = 1">
+    <Field Def="u8 enableWin64_2:1 = 1">
       <DisplayName>Win64</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>Win64で使用されるか</Description>
@@ -540,7 +540,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー3</UnkC8>
     </Field>
-    <Field Def="u8 enablePS4:1 = 1">
+    <Field Def="u8 enablePS4_2:1 = 1">
       <DisplayName>PS4</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>PS4で使用されるか</Description>
@@ -550,7 +550,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー3</UnkC8>
     </Field>
-    <Field Def="u8 enableXboxOne:1 = 1">
+    <Field Def="u8 enableXboxOne_2:1 = 1">
       <DisplayName>XboxOne</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>XboxOneで使用されるか</Description>
@@ -560,7 +560,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー3</UnkC8>
     </Field>
-    <Field Def="f32 time1">
+    <Field Def="f32 time1_2">
       <DisplayName>時間</DisplayName>
       <Description>時間</Description>
       <Minimum>0</Minimum>
@@ -570,7 +570,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー3</UnkC8>
     </Field>
-    <Field Def="f32 time2">
+    <Field Def="f32 time2_2">
       <DisplayName>リピート用インターバル時間</DisplayName>
       <Description>リピート用インターバル時間</Description>
       <Minimum>0</Minimum>
@@ -580,7 +580,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー3</UnkC8>
     </Field>
-    <Field Def="f32 a2dThreshold = 0.5">
+    <Field Def="f32 a2dThreshold_2 = 0.5">
       <DisplayName>アナログ→デジタル変換閾値</DisplayName>
       <Description>アナログ→デジタル変換閾値</Description>
       <Minimum>0</Minimum>
@@ -590,7 +590,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー3</UnkC8>
     </Field>
-    <Field Def="s32 phyisicalKey = -1">
+    <Field Def="s32 phyisicalKey_3 = -1">
       <DisplayName>パッド物理キー</DisplayName>
       <Enum>DefaultKeyAssignPadKey</Enum>
       <Description>パッド物理キー</Description>
@@ -601,7 +601,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー4</UnkC8>
     </Field>
-    <Field Def="u8 traitsType">
+    <Field Def="u8 traitsType_3">
       <DisplayName>押され方</DisplayName>
       <Enum>DefaultKeyAssignTraits</Enum>
       <Description>押され方</Description>
@@ -610,7 +610,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー4</UnkC8>
     </Field>
-    <Field Def="u8 a2dOperator">
+    <Field Def="u8 a2dOperator_3">
       <DisplayName>アナログ→デジタル変換方法</DisplayName>
       <Enum>DefaultKeyAssignA2DOperator</Enum>
       <Description>アナログ→デジタル変換方法</Description>
@@ -619,7 +619,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー4</UnkC8>
     </Field>
-    <Field Def="u8 applyTarget">
+    <Field Def="u8 applyTarget_3">
       <DisplayName>適用ターゲット</DisplayName>
       <Enum>DefaultKeyAssignApplyTarget</Enum>
       <Description>反映ターゲット</Description>
@@ -628,7 +628,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー4</UnkC8>
     </Field>
-    <Field Def="u8 isAnalog:1">
+    <Field Def="u8 isAnalog_3:1">
       <DisplayName>デジタル・アナログ</DisplayName>
       <Enum>DefaultKeyAssignDigitalAnalog</Enum>
       <Description>デジタルorアナログ</Description>
@@ -638,7 +638,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー4</UnkC8>
     </Field>
-    <Field Def="u8 enableWin64:1 = 1">
+    <Field Def="u8 enableWin64_3:1 = 1">
       <DisplayName>Win64</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>Win64で使用されるか</Description>
@@ -648,7 +648,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー4</UnkC8>
     </Field>
-    <Field Def="u8 enablePS4:1 = 1">
+    <Field Def="u8 enablePS4_3:1 = 1">
       <DisplayName>PS4</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>PS4で使用されるか</Description>
@@ -658,7 +658,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー4</UnkC8>
     </Field>
-    <Field Def="u8 enableXboxOne:1 = 1">
+    <Field Def="u8 enableXboxOne_3:1 = 1">
       <DisplayName>XboxOne</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>XboxOneで使用されるか</Description>
@@ -668,7 +668,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー4</UnkC8>
     </Field>
-    <Field Def="f32 time1">
+    <Field Def="f32 time1_3">
       <DisplayName>時間</DisplayName>
       <Description>時間</Description>
       <Minimum>0</Minimum>
@@ -678,7 +678,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー4</UnkC8>
     </Field>
-    <Field Def="f32 time2">
+    <Field Def="f32 time2_3">
       <DisplayName>リピート用インターバル時間</DisplayName>
       <Description>リピート用インターバル時間</Description>
       <Minimum>0</Minimum>
@@ -688,7 +688,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー4</UnkC8>
     </Field>
-    <Field Def="f32 a2dThreshold = 0.5">
+    <Field Def="f32 a2dThreshold_3 = 0.5">
       <DisplayName>アナログ→デジタル変換閾値</DisplayName>
       <Description>アナログ→デジタル変換閾値</Description>
       <Minimum>0</Minimum>
@@ -698,7 +698,7 @@
       <UnkC0>PadItem</UnkC0>
       <UnkC8>パッドキー4</UnkC8>
     </Field>
-    <Field Def="s32 phyisicalKey = -1">
+    <Field Def="s32 phyisicalKey_4 = -1">
       <DisplayName>PC物理キー</DisplayName>
       <Enum>DefaultKeyAssignPcKey</Enum>
       <Description>PC物理キー</Description>
@@ -709,7 +709,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー1</UnkC8>
     </Field>
-    <Field Def="u8 traitsType">
+    <Field Def="u8 traitsType_4">
       <DisplayName>押され方</DisplayName>
       <Enum>DefaultKeyAssignTraits</Enum>
       <Description>押され方</Description>
@@ -718,7 +718,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー1</UnkC8>
     </Field>
-    <Field Def="u8 a2dOperator">
+    <Field Def="u8 a2dOperator_4">
       <DisplayName>アナログ→デジタル変換方法</DisplayName>
       <Enum>DefaultKeyAssignA2DOperator</Enum>
       <Description>アナログ→デジタル変換方法</Description>
@@ -727,7 +727,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー1</UnkC8>
     </Field>
-    <Field Def="u8 applyTarget">
+    <Field Def="u8 applyTarget_4">
       <DisplayName>適用ターゲット</DisplayName>
       <Enum>DefaultKeyAssignApplyTarget</Enum>
       <Description>反映ターゲット</Description>
@@ -736,7 +736,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー1</UnkC8>
     </Field>
-    <Field Def="u8 isAnalog:1">
+    <Field Def="u8 isAnalog_4:1">
       <DisplayName>デジタル・アナログ</DisplayName>
       <Enum>DefaultKeyAssignDigitalAnalog</Enum>
       <Description>デジタルorアナログ</Description>
@@ -746,7 +746,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー1</UnkC8>
     </Field>
-    <Field Def="u8 enableWin64:1 = 1">
+    <Field Def="u8 enableWin64_4:1 = 1">
       <DisplayName>Win64</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>Win64で使用されるか</Description>
@@ -756,7 +756,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー1</UnkC8>
     </Field>
-    <Field Def="u8 enablePS4:1 = 1">
+    <Field Def="u8 enablePS4_4:1 = 1">
       <DisplayName>PS4</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>PS4で使用されるか</Description>
@@ -766,7 +766,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー1</UnkC8>
     </Field>
-    <Field Def="u8 enableXboxOne:1 = 1">
+    <Field Def="u8 enableXboxOne_4:1 = 1">
       <DisplayName>XboxOne</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>XboxOneで使用されるか</Description>
@@ -776,7 +776,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー1</UnkC8>
     </Field>
-    <Field Def="f32 time1">
+    <Field Def="f32 time1_4">
       <DisplayName>時間</DisplayName>
       <Description>時間</Description>
       <Minimum>0</Minimum>
@@ -786,7 +786,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー1</UnkC8>
     </Field>
-    <Field Def="f32 time2">
+    <Field Def="f32 time2_4">
       <DisplayName>リピート用インターバル時間</DisplayName>
       <Description>リピート用インターバル時間</Description>
       <Minimum>0</Minimum>
@@ -796,7 +796,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー1</UnkC8>
     </Field>
-    <Field Def="f32 a2dThreshold = 0.5">
+    <Field Def="f32 a2dThreshold_4 = 0.5">
       <DisplayName>アナログ→デジタル変換閾値</DisplayName>
       <Description>アナログ→デジタル変換閾値</Description>
       <Minimum>0</Minimum>
@@ -806,7 +806,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー1</UnkC8>
     </Field>
-    <Field Def="s32 phyisicalKey = -1">
+    <Field Def="s32 phyisicalKey_5 = -1">
       <DisplayName>PC物理キー</DisplayName>
       <Enum>DefaultKeyAssignPcKey</Enum>
       <Description>PC物理キー</Description>
@@ -817,7 +817,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー2</UnkC8>
     </Field>
-    <Field Def="u8 traitsType">
+    <Field Def="u8 traitsType_5">
       <DisplayName>押され方</DisplayName>
       <Enum>DefaultKeyAssignTraits</Enum>
       <Description>押され方</Description>
@@ -826,7 +826,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー2</UnkC8>
     </Field>
-    <Field Def="u8 a2dOperator">
+    <Field Def="u8 a2dOperator_5">
       <DisplayName>アナログ→デジタル変換方法</DisplayName>
       <Enum>DefaultKeyAssignA2DOperator</Enum>
       <Description>アナログ→デジタル変換方法</Description>
@@ -835,7 +835,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー2</UnkC8>
     </Field>
-    <Field Def="u8 applyTarget">
+    <Field Def="u8 applyTarget_5">
       <DisplayName>適用ターゲット</DisplayName>
       <Enum>DefaultKeyAssignApplyTarget</Enum>
       <Description>反映ターゲット</Description>
@@ -844,7 +844,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー2</UnkC8>
     </Field>
-    <Field Def="u8 isAnalog:1">
+    <Field Def="u8 isAnalog_5:1">
       <DisplayName>デジタル・アナログ</DisplayName>
       <Enum>DefaultKeyAssignDigitalAnalog</Enum>
       <Description>デジタルorアナログ</Description>
@@ -854,7 +854,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー2</UnkC8>
     </Field>
-    <Field Def="u8 enableWin64:1 = 1">
+    <Field Def="u8 enableWin64_5:1 = 1">
       <DisplayName>Win64</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>Win64で使用されるか</Description>
@@ -864,7 +864,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー2</UnkC8>
     </Field>
-    <Field Def="u8 enablePS4:1 = 1">
+    <Field Def="u8 enablePS4_5:1 = 1">
       <DisplayName>PS4</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>PS4で使用されるか</Description>
@@ -874,7 +874,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー2</UnkC8>
     </Field>
-    <Field Def="u8 enableXboxOne:1 = 1">
+    <Field Def="u8 enableXboxOne_5:1 = 1">
       <DisplayName>XboxOne</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>XboxOneで使用されるか</Description>
@@ -884,7 +884,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー2</UnkC8>
     </Field>
-    <Field Def="f32 time1">
+    <Field Def="f32 time1_5">
       <DisplayName>時間</DisplayName>
       <Description>時間</Description>
       <Minimum>0</Minimum>
@@ -894,7 +894,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー2</UnkC8>
     </Field>
-    <Field Def="f32 time2">
+    <Field Def="f32 time2_5">
       <DisplayName>リピート用インターバル時間</DisplayName>
       <Description>リピート用インターバル時間</Description>
       <Minimum>0</Minimum>
@@ -904,7 +904,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー2</UnkC8>
     </Field>
-    <Field Def="f32 a2dThreshold = 0.5">
+    <Field Def="f32 a2dThreshold_5 = 0.5">
       <DisplayName>アナログ→デジタル変換閾値</DisplayName>
       <Description>アナログ→デジタル変換閾値</Description>
       <Minimum>0</Minimum>
@@ -914,7 +914,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー2</UnkC8>
     </Field>
-    <Field Def="s32 phyisicalKey = -1">
+    <Field Def="s32 phyisicalKey_6 = -1">
       <DisplayName>PC物理キー</DisplayName>
       <Enum>DefaultKeyAssignPcKey</Enum>
       <Description>PC物理キー</Description>
@@ -925,7 +925,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー3</UnkC8>
     </Field>
-    <Field Def="u8 traitsType">
+    <Field Def="u8 traitsType_6">
       <DisplayName>押され方</DisplayName>
       <Enum>DefaultKeyAssignTraits</Enum>
       <Description>押され方</Description>
@@ -934,7 +934,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー3</UnkC8>
     </Field>
-    <Field Def="u8 a2dOperator">
+    <Field Def="u8 a2dOperator_6">
       <DisplayName>アナログ→デジタル変換方法</DisplayName>
       <Enum>DefaultKeyAssignA2DOperator</Enum>
       <Description>アナログ→デジタル変換方法</Description>
@@ -943,7 +943,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー3</UnkC8>
     </Field>
-    <Field Def="u8 applyTarget">
+    <Field Def="u8 applyTarget_6">
       <DisplayName>適用ターゲット</DisplayName>
       <Enum>DefaultKeyAssignApplyTarget</Enum>
       <Description>反映ターゲット</Description>
@@ -952,7 +952,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー3</UnkC8>
     </Field>
-    <Field Def="u8 isAnalog:1">
+    <Field Def="u8 isAnalog_6:1">
       <DisplayName>デジタル・アナログ</DisplayName>
       <Enum>DefaultKeyAssignDigitalAnalog</Enum>
       <Description>デジタルorアナログ</Description>
@@ -962,7 +962,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー3</UnkC8>
     </Field>
-    <Field Def="u8 enableWin64:1 = 1">
+    <Field Def="u8 enableWin64_6:1 = 1">
       <DisplayName>Win64</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>Win64で使用されるか</Description>
@@ -972,7 +972,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー3</UnkC8>
     </Field>
-    <Field Def="u8 enablePS4:1 = 1">
+    <Field Def="u8 enablePS4_6:1 = 1">
       <DisplayName>PS4</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>PS4で使用されるか</Description>
@@ -982,7 +982,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー3</UnkC8>
     </Field>
-    <Field Def="u8 enableXboxOne:1 = 1">
+    <Field Def="u8 enableXboxOne_6:1 = 1">
       <DisplayName>XboxOne</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>XboxOneで使用されるか</Description>
@@ -992,7 +992,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー3</UnkC8>
     </Field>
-    <Field Def="f32 time1">
+    <Field Def="f32 time1_6">
       <DisplayName>時間</DisplayName>
       <Description>時間</Description>
       <Minimum>0</Minimum>
@@ -1002,7 +1002,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー3</UnkC8>
     </Field>
-    <Field Def="f32 time2">
+    <Field Def="f32 time2_6">
       <DisplayName>リピート用インターバル時間</DisplayName>
       <Description>リピート用インターバル時間</Description>
       <Minimum>0</Minimum>
@@ -1012,7 +1012,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー3</UnkC8>
     </Field>
-    <Field Def="f32 a2dThreshold = 0.5">
+    <Field Def="f32 a2dThreshold_6 = 0.5">
       <DisplayName>アナログ→デジタル変換閾値</DisplayName>
       <Description>アナログ→デジタル変換閾値</Description>
       <Minimum>0</Minimum>
@@ -1022,7 +1022,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー3</UnkC8>
     </Field>
-    <Field Def="s32 phyisicalKey = -1">
+    <Field Def="s32 phyisicalKey_7 = -1">
       <DisplayName>PC物理キー</DisplayName>
       <Enum>DefaultKeyAssignPcKey</Enum>
       <Description>PC物理キー</Description>
@@ -1033,7 +1033,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー4</UnkC8>
     </Field>
-    <Field Def="u8 traitsType">
+    <Field Def="u8 traitsType_7">
       <DisplayName>押され方</DisplayName>
       <Enum>DefaultKeyAssignTraits</Enum>
       <Description>押され方</Description>
@@ -1042,7 +1042,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー4</UnkC8>
     </Field>
-    <Field Def="u8 a2dOperator">
+    <Field Def="u8 a2dOperator_7">
       <DisplayName>アナログ→デジタル変換方法</DisplayName>
       <Enum>DefaultKeyAssignA2DOperator</Enum>
       <Description>アナログ→デジタル変換方法</Description>
@@ -1051,7 +1051,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー4</UnkC8>
     </Field>
-    <Field Def="u8 applyTarget">
+    <Field Def="u8 applyTarget_7">
       <DisplayName>適用ターゲット</DisplayName>
       <Enum>DefaultKeyAssignApplyTarget</Enum>
       <Description>反映ターゲット</Description>
@@ -1060,7 +1060,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー4</UnkC8>
     </Field>
-    <Field Def="u8 isAnalog:1">
+    <Field Def="u8 isAnalog_7:1">
       <DisplayName>デジタル・アナログ</DisplayName>
       <Enum>DefaultKeyAssignDigitalAnalog</Enum>
       <Description>デジタルorアナログ</Description>
@@ -1070,7 +1070,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー4</UnkC8>
     </Field>
-    <Field Def="u8 enableWin64:1 = 1">
+    <Field Def="u8 enableWin64_7:1 = 1">
       <DisplayName>Win64</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>Win64で使用されるか</Description>
@@ -1080,7 +1080,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー4</UnkC8>
     </Field>
-    <Field Def="u8 enablePS4:1 = 1">
+    <Field Def="u8 enablePS4_7:1 = 1">
       <DisplayName>PS4</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>PS4で使用されるか</Description>
@@ -1090,7 +1090,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー4</UnkC8>
     </Field>
-    <Field Def="u8 enableXboxOne:1 = 1">
+    <Field Def="u8 enableXboxOne_7:1 = 1">
       <DisplayName>XboxOne</DisplayName>
       <Enum>BOOL_CIRCLECROSS_TYPE</Enum>
       <Description>XboxOneで使用されるか</Description>
@@ -1100,7 +1100,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー4</UnkC8>
     </Field>
-    <Field Def="f32 time1">
+    <Field Def="f32 time1_7">
       <DisplayName>時間</DisplayName>
       <Description>時間</Description>
       <Minimum>0</Minimum>
@@ -1110,7 +1110,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー4</UnkC8>
     </Field>
-    <Field Def="f32 time2">
+    <Field Def="f32 time2_7">
       <DisplayName>リピート用インターバル時間</DisplayName>
       <Description>リピート用インターバル時間</Description>
       <Minimum>0</Minimum>
@@ -1120,7 +1120,7 @@
       <UnkC0>PCItem</UnkC0>
       <UnkC8>PCキー4</UnkC8>
     </Field>
-    <Field Def="f32 a2dThreshold = 0.5">
+    <Field Def="f32 a2dThreshold_7 = 0.5">
       <DisplayName>アナログ→デジタル変換閾値</DisplayName>
       <Description>アナログ→デジタル変換閾値</Description>
       <Minimum>0</Minimum>

--- a/StudioCore/Assets/Paramdex/ER/Defs/NetworkParam.xml
+++ b/StudioCore/Assets/Paramdex/ER/Defs/NetworkParam.xml
@@ -33,7 +33,7 @@
       <UnkC0>NET_COMMON_PARAM</UnkC0>
       <UnkC8>共通</UnkC8>
     </Field>
-    <Field Def="dummy8 pad[4]">
+    <Field Def="dummy8 pad_0[4]">
       <DisplayName>予約</DisplayName>
       <SortID>3</SortID>
       <UnkB8>common</UnkB8>
@@ -50,7 +50,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="f32 keyGuideHeight = 1">
+    <Field Def="f32 keyGuideHeight_0 = 1">
       <DisplayName>キーガイド垂直範囲[m]</DisplayName>
       <Minimum>1</Minimum>
       <Maximum>1000</Maximum>
@@ -80,7 +80,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="u32 reloadSignTotalCount = 1">
+    <Field Def="u32 reloadSignTotalCount_0 = 1">
       <DisplayName>召喚サイン所持可能数上限(全体)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -91,7 +91,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="u32 reloadSignCellCount = 1">
+    <Field Def="u32 reloadSignCellCount_0 = 1">
       <DisplayName>召喚サイン所持可能数上限(セル)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -112,7 +112,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveRange = 1">
+    <Field Def="f32 basicExclusiveRange_0 = 1">
       <DisplayName>召喚サイン間描画排他水平範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -122,7 +122,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveHeight = 1">
+    <Field Def="f32 basicExclusiveHeight_0 = 1">
       <DisplayName>召喚サイン間描画排他垂直範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -142,7 +142,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="f32 signVisibleRange = 1">
+    <Field Def="f32 signVisibleRange_0 = 1">
       <DisplayName>召喚サインPC間描画距離[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -152,7 +152,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupHorizontalRange = 1">
+    <Field Def="u32 cellGroupHorizontalRange_0 = 1">
       <DisplayName>召喚サイン取得セル範囲(水平)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -162,7 +162,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupTopRange = 1">
+    <Field Def="u32 cellGroupTopRange_0 = 1">
       <DisplayName>召喚サイン取得セル範囲(上方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -172,7 +172,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupBottomRange = 1">
+    <Field Def="u32 cellGroupBottomRange_0 = 1">
       <DisplayName>召喚サイン取得セル範囲(下方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -309,7 +309,7 @@
       <UnkC0>NET_BREAKIN_PARAM</UnkC0>
       <UnkC8>乱入</UnkC8>
     </Field>
-    <Field Def="dummy8 pad[4]">
+    <Field Def="dummy8 pad_1[4]">
       <DisplayName>予約</DisplayName>
       <DisplayFormat>%f</DisplayFormat>
       <EditFlags>Wrap</EditFlags>
@@ -328,7 +328,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 keyGuideHeight = 1">
+    <Field Def="f32 keyGuideHeight_1 = 1">
       <DisplayName>キーガイド垂直範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -338,7 +338,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 reloadSignTotalCount = 1">
+    <Field Def="u32 reloadSignTotalCount_1 = 1">
       <DisplayName>血文字取得数(全体)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -371,7 +371,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 maxSignTotalCount = 1">
+    <Field Def="u32 maxSignTotalCount_0 = 1">
       <DisplayName>血文字所持可能数上限(全体)</DisplayName>
       <Description>本当はu16くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -382,7 +382,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 maxSignCellCount = 1">
+    <Field Def="u32 maxSignCellCount_0 = 1">
       <DisplayName>血文字所持可能数上限(セル)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -393,7 +393,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveRange = 1">
+    <Field Def="f32 basicExclusiveRange_1 = 1">
       <DisplayName>血文字間描画排他水平範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -403,7 +403,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveHeight = 1">
+    <Field Def="f32 basicExclusiveHeight_1 = 1">
       <DisplayName>血文字間描画排他垂直範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -413,7 +413,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 signVisibleRange = 1">
+    <Field Def="f32 signVisibleRange_1 = 1">
       <DisplayName>血文字PC間描画距離[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -443,7 +443,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 reloadSignIntervalTime = 1">
+    <Field Def="f32 reloadSignIntervalTime_0 = 1">
       <DisplayName>血文字再取得待機時間[秒]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -453,7 +453,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupHorizontalRange = 1">
+    <Field Def="u32 cellGroupHorizontalRange_1 = 1">
       <DisplayName>血文字取得セル範囲(水平)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -463,7 +463,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupTopRange = 1">
+    <Field Def="u32 cellGroupTopRange_1 = 1">
       <DisplayName>血文字取得セル範囲(上方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -473,7 +473,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupBottomRange = 1">
+    <Field Def="u32 cellGroupBottomRange_1 = 1">
       <DisplayName>血文字取得セル範囲(下方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -483,7 +483,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 lifeTime = 1">
+    <Field Def="u32 lifeTime_0 = 1">
       <DisplayName>血文字データ保持期間上限[秒]</DisplayName>
       <Description>本当はu16くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -494,7 +494,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 downloadSpan">
+    <Field Def="f32 downloadSpan_0">
       <DisplayName>血文字ダウンロード間隔</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>10000</Maximum>
@@ -514,7 +514,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="dummy8 pad[4]">
+    <Field Def="dummy8 pad_2[4]">
       <DisplayName>予約</DisplayName>
       <SortID>319</SortID>
       <UnkB8>bloodMessage</UnkB8>
@@ -532,7 +532,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 keyGuideHeight = 1">
+    <Field Def="f32 keyGuideHeight_2 = 1">
       <DisplayName>キーガイド垂直範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -562,7 +562,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 reloadSignTotalCount = 1">
+    <Field Def="u32 reloadSignTotalCount_2 = 1">
       <DisplayName>血痕取得数(全体)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -572,7 +572,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 reloadSignCellCount = 1">
+    <Field Def="u32 reloadSignCellCount_1 = 1">
       <DisplayName>血痕取得数(セル)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -582,7 +582,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 maxSignTotalCount = 1">
+    <Field Def="u32 maxSignTotalCount_1 = 1">
       <DisplayName>血痕所持可能数上限(全体)</DisplayName>
       <Description>本当はu16くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -592,7 +592,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 maxSignCellCount = 1">
+    <Field Def="u32 maxSignCellCount_1 = 1">
       <DisplayName>血痕所持可能数上限(セル)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -602,7 +602,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 reloadSignIntervalTime = 1">
+    <Field Def="f32 reloadSignIntervalTime_1 = 1">
       <DisplayName>血痕再取得待機時間[秒]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -612,7 +612,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 signVisibleRange = 1">
+    <Field Def="f32 signVisibleRange_2 = 1">
       <DisplayName>血痕PC間描画距離[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -622,7 +622,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveRange = 1">
+    <Field Def="f32 basicExclusiveRange_2 = 1">
       <DisplayName>血痕間描画排他水平範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -632,7 +632,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveHeight = 1">
+    <Field Def="f32 basicExclusiveHeight_2 = 1">
       <DisplayName>血痕間描画排他垂直範囲[m]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>1000</Maximum>
@@ -642,7 +642,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupHorizontalRange = 1">
+    <Field Def="u32 cellGroupHorizontalRange_2 = 1">
       <DisplayName>血痕取得セル範囲(水平)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -652,7 +652,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupTopRange = 1">
+    <Field Def="u32 cellGroupTopRange_2 = 1">
       <DisplayName>血痕取得セル範囲(上方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -662,7 +662,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupBottomRange = 1">
+    <Field Def="u32 cellGroupBottomRange_2 = 1">
       <DisplayName>血痕取得セル範囲(下方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -672,7 +672,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 lifeTime = 1">
+    <Field Def="u32 lifeTime_1 = 1">
       <DisplayName>血痕データ保持期間上限[秒]</DisplayName>
       <Description>本当はu16くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -704,7 +704,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 downloadSpan">
+    <Field Def="f32 downloadSpan_1">
       <DisplayName>血痕ダウンロード間隔</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>10000</Maximum>
@@ -908,7 +908,7 @@
       <UnkC0>NET_GHOST_PARAM</UnkC0>
       <UnkC8>幻影</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupHorizontalRange = 1">
+    <Field Def="u32 cellGroupHorizontalRange_3 = 1">
       <DisplayName>幻影取得セル範囲(水平)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -918,7 +918,7 @@
       <UnkC0>NET_GHOST_PARAM</UnkC0>
       <UnkC8>幻影</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupTopRange = 1">
+    <Field Def="u32 cellGroupTopRange_3 = 1">
       <DisplayName>幻影取得セル範囲(上方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <DisplayFormat>%u</DisplayFormat>
@@ -1440,7 +1440,7 @@
       <UnkC0>VISITOR</UnkC0>
       <UnkC8>訪問</UnkC8>
     </Field>
-    <Field Def="f32 DownloadSpan = 1">
+    <Field Def="f32 DownloadSpan_2 = 1">
       <DisplayName>訪問者リストダウンロード間隔[秒]</DisplayName>
       <Minimum>0</Minimum>
       <Maximum>10000</Maximum>
@@ -1513,14 +1513,14 @@
       <UnkC0>YELLOW_MONK_PARAM</UnkC0>
       <UnkC8>黄衣の翁</UnkC8>
     </Field>
-    <Field Def="dummy8 pad14[4]">
+    <Field Def="dummy8 pad14_0[4]">
       <DisplayName>予約</DisplayName>
       <SortID>2030</SortID>
       <UnkB8>YellowMonk</UnkB8>
       <UnkC0>YELLOW_MONK_PARAM</UnkC0>
       <UnkC8>黄衣の翁</UnkC8>
     </Field>
-    <Field Def="dummy8 pad14[8]">
+    <Field Def="dummy8 pad14_1[8]">
       <DisplayName>予約</DisplayName>
       <SortID>2031</SortID>
     </Field>

--- a/StudioCore/Assets/Paramdex/ER/Meta/CoolTimeParam.xml
+++ b/StudioCore/Assets/Paramdex/ER/Meta/CoolTimeParam.xml
@@ -3,14 +3,14 @@
   <Enums>
   </Enums>
   <Field>
-    <limitationTime AltName="Limitation Time - 0 Co-op Phantoms" Wiki="Time limit [sec] (number of cooperating spirits 0)" />
-    <observeTime AltName="Observation Time - 0 Co-op Phantoms" Wiki="Monitoring time [sec] (number of cooperating spirits 0)" />
-    <limitationTime AltName="Limitation Time - 1 Co-op Phantoms" Wiki="Time limit [sec] (number of cooperating spirits 1)" />
-    <observeTime AltName="Observation Time - 1 Co-op Phantoms" Wiki="Monitoring time [sec] (number of cooperating spirits 1)" />
-    <limitationTime AltName="Limitation Time - 2 Co-op Phantoms" Wiki="Time limit [sec] (number of cooperating spirits 2)" />
-    <observeTime AltName="Observation Time - 2 Co-op Phantoms" Wiki="Monitoring time [sec] (number of cooperating spirits 2)" />
-    <limitationTime AltName="Limitation Time - 3 Co-op Phantoms" Wiki="Time limit [sec] (number of cooperating spirits 3)" />
-    <observeTime AltName="Observation Time - 3 Co-op Phantoms" Wiki="Monitoring time [sec] (number of cooperating spirits 3)" />
+    <limitationTime_0 AltName="Limitation Time - 0 Co-op Phantoms" Wiki="Time limit [sec] (number of cooperating spirits 0)" />
+    <observeTime_0 AltName="Observation Time - 0 Co-op Phantoms" Wiki="Monitoring time [sec] (number of cooperating spirits 0)" />
+    <limitationTime_1 AltName="Limitation Time - 1 Co-op Phantoms" Wiki="Time limit [sec] (number of cooperating spirits 1)" />
+    <observeTime_1 AltName="Observation Time - 1 Co-op Phantoms" Wiki="Monitoring time [sec] (number of cooperating spirits 1)" />
+    <limitationTime_2 AltName="Limitation Time - 2 Co-op Phantoms" Wiki="Time limit [sec] (number of cooperating spirits 2)" />
+    <observeTime_2 AltName="Observation Time - 2 Co-op Phantoms" Wiki="Monitoring time [sec] (number of cooperating spirits 2)" />
+    <limitationTime_3 AltName="Limitation Time - 3 Co-op Phantoms" Wiki="Time limit [sec] (number of cooperating spirits 3)" />
+    <observeTime_3 AltName="Observation Time - 3 Co-op Phantoms" Wiki="Monitoring time [sec] (number of cooperating spirits 3)" />
   </Field>
   <Self />
 </PARAMMETA>

--- a/StudioCore/Assets/Paramdex/ER/Meta/DefaultKeyAssign.xml
+++ b/StudioCore/Assets/Paramdex/ER/Meta/DefaultKeyAssign.xml
@@ -50,94 +50,94 @@
     <priority30 AltName="Pad 30" Wiki="Lower suppression pad 30" Enum="DefaultKeyAssignPrioritySuppression" />
     <priority31 AltName="Pad 31" Wiki="Lower suppression pad 31" Enum="DefaultKeyAssignPrioritySuppression" />
     <dummy AltName=""/>
-    <phyisicalKey AltName="Pad physical key" Wiki="Pad physical key" Enum="DefaultKeyAssignPadKey" />
-    <traitsType AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
-    <a2dOperator AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
-    <applyTarget AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
-    <isAnalog AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
-    <enableWin64 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
-    <enablePS4 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
-    <enableXboxOne AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
-    <time1 AltName="time" Wiki="time" />
-    <time2 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
-    <a2dThreshold AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
-    <phyisicalKey AltName="Pad physical key" Wiki="Pad physical key" Enum="DefaultKeyAssignPadKey" />
-    <traitsType AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
-    <a2dOperator AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
-    <applyTarget AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
-    <isAnalog AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
-    <enableWin64 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
-    <enablePS4 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
-    <enableXboxOne AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
-    <time1 AltName="time" Wiki="time" />
-    <time2 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
-    <a2dThreshold AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
-    <phyisicalKey AltName="Pad physical key" Wiki="Pad physical key" Enum="DefaultKeyAssignPadKey" />
-    <traitsType AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
-    <a2dOperator AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
-    <applyTarget AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
-    <isAnalog AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
-    <enableWin64 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
-    <enablePS4 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
-    <enableXboxOne AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
-    <time1 AltName="time" Wiki="time" />
-    <time2 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
-    <a2dThreshold AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
-    <phyisicalKey AltName="Pad physical key" Wiki="Pad physical key" Enum="DefaultKeyAssignPadKey" />
-    <traitsType AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
-    <a2dOperator AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
-    <applyTarget AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
-    <isAnalog AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
-    <enableWin64 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
-    <enablePS4 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
-    <enableXboxOne AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
-    <time1 AltName="time" Wiki="time" />
-    <time2 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
-    <a2dThreshold AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
-    <phyisicalKey AltName="PC physical key" Wiki="PC physical key" Enum="DefaultKeyAssignPcKey" />
-    <traitsType AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
-    <a2dOperator AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
-    <applyTarget AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
-    <isAnalog AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
-    <enableWin64 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
-    <enablePS4 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
-    <enableXboxOne AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
-    <time1 AltName="time" Wiki="time" />
-    <time2 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
-    <a2dThreshold AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
-    <phyisicalKey AltName="PC physical key" Wiki="PC physical key" Enum="DefaultKeyAssignPcKey" />
-    <traitsType AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
-    <a2dOperator AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
-    <applyTarget AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
-    <isAnalog AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
-    <enableWin64 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
-    <enablePS4 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
-    <enableXboxOne AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
-    <time1 AltName="time" Wiki="time" />
-    <time2 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
-    <a2dThreshold AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
-    <phyisicalKey AltName="PC physical key" Wiki="PC physical key" Enum="DefaultKeyAssignPcKey" />
-    <traitsType AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
-    <a2dOperator AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
-    <applyTarget AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
-    <isAnalog AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
-    <enableWin64 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
-    <enablePS4 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
-    <enableXboxOne AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
-    <time1 AltName="time" Wiki="time" />
-    <time2 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
-    <a2dThreshold AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
-    <phyisicalKey AltName="PC physical key" Wiki="PC physical key" Enum="DefaultKeyAssignPcKey" />
-    <traitsType AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
-    <a2dOperator AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
-    <applyTarget AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
-    <isAnalog AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
-    <enableWin64 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
-    <enablePS4 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
-    <enableXboxOne AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
-    <time1 AltName="time" Wiki="time" />
-    <time2 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
-    <a2dThreshold AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
+    <phyisicalKey_0 AltName="Pad physical key" Wiki="Pad physical key" Enum="DefaultKeyAssignPadKey" />
+    <traitsType_0 AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
+    <a2dOperator_0 AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
+    <applyTarget_0 AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
+    <isAnalog_0 AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
+    <enableWin64_0 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
+    <enablePS4_0 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
+    <enableXboxOne_0 AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
+    <time1_0 AltName="time" Wiki="time" />
+    <time2_0 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
+    <a2dThreshold_0 AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
+    <phyisicalKey_1 AltName="Pad physical key" Wiki="Pad physical key" Enum="DefaultKeyAssignPadKey" />
+    <traitsType_1 AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
+    <a2dOperator_1 AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
+    <applyTarget_1 AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
+    <isAnalog_1 AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
+    <enableWin64_1 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
+    <enablePS4_1 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
+    <enableXboxOne_1 AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
+    <time1_1 AltName="time" Wiki="time" />
+    <time2_1 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
+    <a2dThreshold_1 AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
+    <phyisicalKey_2 AltName="Pad physical key" Wiki="Pad physical key" Enum="DefaultKeyAssignPadKey" />
+    <traitsType_2 AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
+    <a2dOperator_2 AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
+    <applyTarget_2 AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
+    <isAnalog_2 AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
+    <enableWin64_2 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
+    <enablePS4_2 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
+    <enableXboxOne_2 AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
+    <time1_2 AltName="time" Wiki="time" />
+    <time2_2 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
+    <a2dThreshold_2 AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
+    <phyisicalKey_3 AltName="Pad physical key" Wiki="Pad physical key" Enum="DefaultKeyAssignPadKey" />
+    <traitsType_3 AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
+    <a2dOperator_3 AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
+    <applyTarget_3 AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
+    <isAnalog_3 AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
+    <enableWin64_3 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
+    <enablePS4_3 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
+    <enableXboxOne_3 AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
+    <time1_3 AltName="time" Wiki="time" />
+    <time2_3 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
+    <a2dThreshold_3 AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
+    <phyisicalKey_4 AltName="PC physical key" Wiki="PC physical key" Enum="DefaultKeyAssignPcKey" />
+    <traitsType_4 AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
+    <a2dOperator_4 AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
+    <applyTarget_4 AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
+    <isAnalog_4 AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
+    <enableWin64_4 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
+    <enablePS4_4 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
+    <enableXboxOne_4 AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
+    <time1_4 AltName="time" Wiki="time" />
+    <time2_4 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
+    <a2dThreshold_4 AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
+    <phyisicalKey_5 AltName="PC physical key" Wiki="PC physical key" Enum="DefaultKeyAssignPcKey" />
+    <traitsType_5 AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
+    <a2dOperator_5 AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
+    <applyTarget_5 AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
+    <isAnalog_5 AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
+    <enableWin64_5 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
+    <enablePS4_5 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
+    <enableXboxOne_5 AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
+    <time1_5 AltName="time" Wiki="time" />
+    <time2_5 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
+    <a2dThreshold_5 AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
+    <phyisicalKey_6 AltName="PC physical key" Wiki="PC physical key" Enum="DefaultKeyAssignPcKey" />
+    <traitsType_6 AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
+    <a2dOperator_6 AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
+    <applyTarget_6 AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
+    <isAnalog_6 AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
+    <enableWin64_6 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
+    <enablePS4_6 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
+    <enableXboxOne_6 AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
+    <time1_6 AltName="time" Wiki="time" />
+    <time2_6 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
+    <a2dThreshold_6 AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
+    <phyisicalKey_7 AltName="PC physical key" Wiki="PC physical key" Enum="DefaultKeyAssignPcKey" />
+    <traitsType_7 AltName="How to be pushed" Wiki="How to be pushed" Enum="DefaultKeyAssignTraits" />
+    <a2dOperator_7 AltName="Analog-to-digital conversion method" Wiki="Analog-to-digital conversion method" Enum="DefaultKeyAssignA2DOperator" />
+    <applyTarget_7 AltName="Applicable target" Wiki="Reflection target" Enum="DefaultKeyAssignApplyTarget" />
+    <isAnalog_7 AltName="Digital / analog" Wiki="Digital or analog" Enum="DefaultKeyAssignDigitalAnalog" />
+    <enableWin64_7 AltName="Win64" Wiki="Will it be used in Win64?" IsBool="" />
+    <enablePS4_7 AltName="PS4" Wiki="Will it be used on PS4" IsBool="" />
+    <enableXboxOne_7 AltName="Xbox One" Wiki="Will it be used on Xbox One" IsBool="" />
+    <time1_7 AltName="time" Wiki="time" />
+    <time2_7 AltName="Interval time for repeat" Wiki="Interval time for repeat" />
+    <a2dThreshold_7 AltName="Analog-to-digital conversion threshold" Wiki="Analog-to-digital conversion threshold" />
   </Field>
   <Self />
 </PARAMMETA>

--- a/StudioCore/Assets/Paramdex/ER/Meta/GameSystemCommonParam.xml
+++ b/StudioCore/Assets/Paramdex/ER/Meta/GameSystemCommonParam.xml
@@ -286,7 +286,7 @@
     <actionButtonInputCancelTime AltName="Action Button Input Cancel Time" Wiki="Time to disable action button operation by holding down the action button" />
     <blockClearBonusDelayTime AltName="Boss Kill - Rune Acquisition Delay Time" Wiki="Clear bonus acquisition delay time after boss defeat processing" />
     <bonfireCheckEnemyRange AltName="Bonfire Check Enemy Range" Wiki="[Unused] (Refer to SEQ25048) Distance from PC to bonfire that determines invalidation of bonfire by enemy [m] (0 or less PC distance is not checked. Checked at all distances)" />
-    <reserved_124 AltName=""/>
+    <reserved_124_0 AltName=""/>
   </Field>
   <Self />
 </PARAMMETA>

--- a/StudioCore/Assets/Paramdex/ER/Meta/NetworkParam.xml
+++ b/StudioCore/Assets/Paramdex/ER/Meta/NetworkParam.xml
@@ -6,21 +6,21 @@
     <signVerticalOffset AltName="Common - Sign Height Offset" Wiki="" />
     <maxSignPosCorrectionRange AltName="Common - Max Sign Position Correction Range" Wiki="" />
     <summonTimeoutTime AltName="Common - Summon Timeout Time" Wiki="" />
-    <pad AltName=""/>
+    <pad_0 AltName=""/>
     <signPuddleActiveMessageIntervalSec AltName="Summon Sign - Sign Puddle Active Message Interval" Wiki="" />
-    <keyGuideHeight AltName="Summon Sign - Key Guide Height" Wiki="" />
+    <keyGuideHeight_0 AltName="Summon Sign - Key Guide Height" Wiki="" />
     <reloadSignIntervalTime1 AltName="Summon Sign - Reload Sign Interval Time [1]" Wiki="" />
     <reloadSignIntervalTime2 AltName="Summon Sign - Reload Sign Interval Time [2]" Wiki="" />
-    <reloadSignTotalCount AltName="Summon Sign - Reload Sign Total Count" Wiki="Actually u8 is enough" />
-    <reloadSignCellCount AltName="Summon Sign - Reload Sign Cell Count" Wiki="Actually u8 is enough" />
+    <reloadSignTotalCount_0 AltName="Summon Sign - Reload Sign Total Count" Wiki="Actually u8 is enough" />
+    <reloadSignCellCount_0 AltName="Summon Sign - Reload Sign Cell Count" Wiki="Actually u8 is enough" />
     <updateSignIntervalTime AltName="Summon Sign - Update Sign Interval Time" Wiki="" />
-    <basicExclusiveRange AltName="Summon Sign - Basic Horizontal Drawing Range" Wiki="" />
-    <basicExclusiveHeight AltName="Summon Sign - Basic Vertical Drawing Height" Wiki="" />
+    <basicExclusiveRange_0 AltName="Summon Sign - Basic Horizontal Drawing Range" Wiki="" />
+    <basicExclusiveHeight_0 AltName="Summon Sign - Basic Vertical Drawing Height" Wiki="" />
     <previewChrWaitingTime AltName="Summon Sign - Preview Chr Waiting Time" Wiki="" />
-    <signVisibleRange AltName="Summon Sign - Sign Visible Range" Wiki="" />
-    <cellGroupHorizontalRange AltName="Summon Sign - Acquisition Cell Range (Horizontal)" Wiki="Actually u8 is enough" />
-    <cellGroupTopRange AltName="Summon Sign - Acquisition Cell Range (Top)" Wiki="Actually u8 is enough" />
-    <cellGroupBottomRange AltName="Summon Sign - Acquisition Cell Range (Bottom)" Wiki="Actually u8 is enough" />
+    <signVisibleRange_0 AltName="Summon Sign - Sign Visible Range" Wiki="" />
+    <cellGroupHorizontalRange_0 AltName="Summon Sign - Acquisition Cell Range (Horizontal)" Wiki="Actually u8 is enough" />
+    <cellGroupTopRange_0 AltName="Summon Sign - Acquisition Cell Range (Top)" Wiki="Actually u8 is enough" />
+    <cellGroupBottomRange_0 AltName="Summon Sign - Acquisition Cell Range (Bottom)" Wiki="Actually u8 is enough" />
     <minWhitePhantomLimitTimeScale AltName="Summon Sign - Min White Phantom Limit Time Scale" Wiki="" />
     <minSmallPhantomLimitTimeScale AltName="Summon Sign - Min Small Phantom Limit Time Scale" Wiki="" />
     <whiteKeywordLimitTimeScale AltName="Summon Sign - White Keyword Limit Time Scale" Wiki="" />
@@ -34,46 +34,46 @@
     <maxBreakInTargetListCount AltName="Intrusion - Max Intruder List Count" Wiki="" />
     <breakInRequestIntervalTimeSec AltName="Intrusion - Intruder Request Interval Time" Wiki="" />
     <breakInRequestTimeOutSec AltName="Intrusion - Intruder Request Timeout" Wiki="" />
-    <pad AltName=""/>
+    <pad_1 AltName=""/>
     <keyGuideRange AltName="Blood Message - Key Guide Horionztal Range" Wiki="" />
-    <keyGuideHeight AltName="Blood Message - Key Guide Vertical Range" Wiki="" />
-    <reloadSignTotalCount AltName="Blood Message - Reload Sign Total Count" Wiki="Actually u8 is enough" />
+    <keyGuideHeight_1 AltName="Blood Message - Key Guide Vertical Range" Wiki="" />
+    <reloadSignTotalCount_1 AltName="Blood Message - Reload Sign Total Count" Wiki="Actually u8 is enough" />
     <reloadNewSignCellCount AltName="Blood Message - Reload New Sign Cell Count" Wiki="Actually u8 is enough" />
     <reloadRandomSignCellCount AltName="Blood Message - Reload Random Sign Cell Count" Wiki="Actually u8 is enough" />
-    <maxSignTotalCount AltName="Blood Message - Max Sign Total Count" Wiki="Actually u16 is enough" />
-    <maxSignCellCount AltName="Blood Message - Max Sign Cell Count" Wiki="Actually u8 is enough" />
-    <basicExclusiveRange AltName="Blood Message - Basic Exclusive Range" Wiki="" />
-    <basicExclusiveHeight AltName="Blood Message - Basic Exclusive Height" Wiki="" />
-    <signVisibleRange AltName="Blood Message - Sign Visible Range" Wiki="" />
+    <maxSignTotalCount_0 AltName="Blood Message - Max Sign Total Count" Wiki="Actually u16 is enough" />
+    <maxSignCellCount_0 AltName="Blood Message - Max Sign Cell Count" Wiki="Actually u8 is enough" />
+    <basicExclusiveRange_1 AltName="Blood Message - Basic Exclusive Range" Wiki="" />
+    <basicExclusiveHeight_1 AltName="Blood Message - Basic Exclusive Height" Wiki="" />
+    <signVisibleRange_1 AltName="Blood Message - Sign Visible Range" Wiki="" />
     <maxWriteSignCount AltName="Blood Message - Max Write Sign Count" Wiki="Actually u8 is enough" />
     <maxReadSignCount AltName="Blood Message - Max Read Sign Count" Wiki="Actually u8 is enough" />
-    <reloadSignIntervalTime AltName="Blood Message - Reload Sign Interval Time" Wiki="" />
-    <cellGroupHorizontalRange AltName="Blood Message - Cell Group Horizontal Range" Wiki="Actually u8 is enough" />
-    <cellGroupTopRange AltName="Blood Message - Cell Group Top Range" Wiki="Actually u8 is enough" />
-    <cellGroupBottomRange AltName="Blood Message - Cell Group Bottom Range" Wiki="Actually u8 is enough" />
-    <lifeTime AltName="Blood Message - Lifetime" Wiki="Actually u16 is enough" />
-    <downloadSpan AltName="Blood Message - Download Span" Wiki="" />
+    <reloadSignIntervalTime_0 AltName="Blood Message - Reload Sign Interval Time" Wiki="" />
+    <cellGroupHorizontalRange_1 AltName="Blood Message - Cell Group Horizontal Range" Wiki="Actually u8 is enough" />
+    <cellGroupTopRange_1 AltName="Blood Message - Cell Group Top Range" Wiki="Actually u8 is enough" />
+    <cellGroupBottomRange_1 AltName="Blood Message - Cell Group Bottom Range" Wiki="Actually u8 is enough" />
+    <lifeTime_0 AltName="Blood Message - Lifetime" Wiki="Actually u16 is enough" />
+    <downloadSpan_0 AltName="Blood Message - Download Span" Wiki="" />
     <downloadEvaluationSpan AltName="Blood Message - Download Evaluation Span" Wiki="" />
-    <pad AltName=""/>
+    <pad_2 AltName=""/>
     <deadingGhostStartPosThreshold AltName="Bloodstain - Dead Ghost Start Position Threshold" Wiki="If the distance between the bloodstain position and the illusion start position is farther than this value, the server will not be registered." />
-    <keyGuideHeight AltName="Bloodstain - Key Guide Height" Wiki="" />
+    <keyGuideHeight_2 AltName="Bloodstain - Key Guide Height" Wiki="" />
     <keyGuideRangePlayer AltName="Bloodstain - Key Guide Range Player" Wiki="" />
     <keyGuideHeightPlayer AltName="Bloodstain - Key Guide Height Player" Wiki="" />
-    <reloadSignTotalCount AltName="Bloodstain - Reload Sign Total Count" Wiki="Actually u8 is enough" />
-    <reloadSignCellCount AltName="Bloodstain - Reload Sign Cell Count" Wiki="Actually u8 is enough" />
-    <maxSignTotalCount AltName="Bloodstain - Max Sign Total Count" Wiki="Actually u16 is enough" />
-    <maxSignCellCount AltName="Bloodstain - Max Sign Cell Count" Wiki="Actually u8 is enough" />
-    <reloadSignIntervalTime AltName="Bloodstain - Reload Sign Interval Time" Wiki="" />
-    <signVisibleRange AltName="Bloodstain - Sign Visible Range" Wiki="" />
-    <basicExclusiveRange AltName="Bloodstain - Basic Exclusive Range" Wiki="" />
-    <basicExclusiveHeight AltName="Bloodstain - Basic Exclusive Height" Wiki="" />
-    <cellGroupHorizontalRange AltName="Bloodstain - Cell Group Horizontal Range" Wiki="Actually u8 is enough" />
-    <cellGroupTopRange AltName="Bloodstain - Cell Group Top Range" Wiki="Actually u8 is enough" />
-    <cellGroupBottomRange AltName="Bloodstain - Cell Group Bottom Range" Wiki="Actually u8 is enough" />
-    <lifeTime AltName="Bloodstain - Lifetime" Wiki="Actually u16 is enough" />
+    <reloadSignTotalCount_2 AltName="Bloodstain - Reload Sign Total Count" Wiki="Actually u8 is enough" />
+    <reloadSignCellCount_1 AltName="Bloodstain - Reload Sign Cell Count" Wiki="Actually u8 is enough" />
+    <maxSignTotalCount_1 AltName="Bloodstain - Max Sign Total Count" Wiki="Actually u16 is enough" />
+    <maxSignCellCount_1 AltName="Bloodstain - Max Sign Cell Count" Wiki="Actually u8 is enough" />
+    <reloadSignIntervalTime_1 AltName="Bloodstain - Reload Sign Interval Time" Wiki="" />
+    <signVisibleRange_2 AltName="Bloodstain - Sign Visible Range" Wiki="" />
+    <basicExclusiveRange_2 AltName="Bloodstain - Basic Exclusive Range" Wiki="" />
+    <basicExclusiveHeight_2 AltName="Bloodstain - Basic Exclusive Height" Wiki="" />
+    <cellGroupHorizontalRange_2 AltName="Bloodstain - Cell Group Horizontal Range" Wiki="Actually u8 is enough" />
+    <cellGroupTopRange_2 AltName="Bloodstain - Cell Group Top Range" Wiki="Actually u8 is enough" />
+    <cellGroupBottomRange_2 AltName="Bloodstain - Cell Group Bottom Range" Wiki="Actually u8 is enough" />
+    <lifeTime_1 AltName="Bloodstain - Lifetime" Wiki="Actually u16 is enough" />
     <recordDeadingGhostTotalTime AltName="Bloodstain - Record Dead Ghost Total Time" Wiki="" />
     <recordDeadingGhostMinTime AltName="Bloodstain - Record Dead Ghost Min Time" Wiki="Death illusions less than this recording time will not register the server" />
-    <downloadSpan AltName="Bloodstain - Download Span" Wiki="" />
+    <downloadSpan_1 AltName="Bloodstain - Download Span" Wiki="" />
     <statueCreatableDistance AltName="Bloodstain - Statue Creatable Distance" Wiki="For open fields. When a stone statue is generated, it can be generated if the distance between the PC and the generation position is greater than or equal to this value." />
     <reloadGhostTotalCount AltName="Ghost - Reload Ghost Total Count" Wiki="Actually u8 is enough" />
     <reloadGhostCellCount AltName="Ghost - Reload Ghost Cell Count" Wiki="Actually u8 is enough" />
@@ -93,8 +93,8 @@
     <minReplayIntervalTime AltName="Ghost - Replay Interval Min Time" Wiki="" />
     <maxReplayIntervalTime AltName="Ghost - Replay Interval Max Time" Wiki="" />
     <reloadGhostIntervalTime AltName="Ghost - Reload Ghost Interval Time" Wiki="" />
-    <cellGroupHorizontalRange AltName="Ghost - Cell Group Horizontal Range" Wiki="Actually u8 is enough" />
-    <cellGroupTopRange AltName="Ghost - Cell Group Top Range" Wiki="Actually u8 is enough" />
+    <cellGroupHorizontalRange_3 AltName="Ghost - Cell Group Horizontal Range" Wiki="Actually u8 is enough" />
+    <cellGroupTopRange_3 AltName="Ghost - Cell Group Top Range" Wiki="Actually u8 is enough" />
     <replayBonfirePhantomParamIdForCodename AltName="Ghost - Replay Bonfire Phantom Param ID (CodeDisplayName)" Wiki="Phantom bonfire mode phantom parameter ID used when codename matches" />
     <replayBonfireModeRange AltName="Ghost - Replay Bonfire Mode Range" Wiki="" />
     <replayBonfirePhantomParamId AltName="Ghost - Replay Bonfire Phantom Param ID" Wiki="Phantom bonfire mode phantom parameter ID" />
@@ -149,15 +149,15 @@
     <pad11 AltName=""/>
     <VisitorListMax AltName="Visitor - Visitor List Max" Wiki="Actually u8 is enough" />
     <VisitorTimeOutTime AltName="Visitor - Visitor Time Out Time" Wiki="" />
-    <DownloadSpan AltName="Visitor - Download Span" Wiki="" />
+    <DownloadSpan_2 AltName="Visitor - Download Span" Wiki="" />
     <VisitorGuestRequestMessageIntervalSec AltName="Visitor - Visitor Guest Request Message Interval" Wiki="Display interval [seconds] of messages sent by visiting guests while searching for a destination" />
     <wanderGhostIntervalLifeTime AltName="Ghost Addition - Wandering Ghost Interval Lifetime" Wiki="Wandering illusion life" />
     <pad13 AltName=""/>
     <YellowMonkTimeOutTime AltName="Yellow Monk - Yellow Monk Timeout Time" Wiki="" />
     <YellowMonkDownloadSpan AltName="Yellow Monk - Yellow Monk Download Span" Wiki="" />
     <YellowMonkOverallFlowTimeOutTime AltName="Yellow Monk - Yellow Monk Overall Flow Time Out Time" Wiki="" />
-    <pad14 AltName=""/>
-    <pad14 AltName=""/>
+    <pad14_0 AltName=""/>
+    <pad14_1 AltName=""/>
   </Field>
   <Self />
 </PARAMMETA>

--- a/StudioCore/Assets/Paramdex/SDT/Defs/CoolTimeParam.xml
+++ b/StudioCore/Assets/Paramdex/SDT/Defs/CoolTimeParam.xml
@@ -6,7 +6,7 @@
   <Unicode>True</Unicode>
   <FormatVersion>202</FormatVersion>
   <Fields>
-    <Field Def="f32 limitationTime">
+    <Field Def="f32 limitationTime_0">
       <DisplayName>制限時間（協力霊数0）</DisplayName>
       <Description>制限時間[sec]（協力霊数0）</Description>
       <DisplayFormat>%.2f</DisplayFormat>
@@ -19,7 +19,7 @@
       <UnkC0>LIMIT_BY_COOP_NUM</UnkC0>
       <UnkC8>協力霊数0</UnkC8>
     </Field>
-    <Field Def="f32 observeTime">
+    <Field Def="f32 observeTime_0">
       <DisplayName>監視時間（協力霊数0）</DisplayName>
       <Description>監視時間[sec]（協力霊数0）</Description>
       <DisplayFormat>%.2f</DisplayFormat>
@@ -32,7 +32,7 @@
       <UnkC0>LIMIT_BY_COOP_NUM</UnkC0>
       <UnkC8>協力霊数0</UnkC8>
     </Field>
-    <Field Def="f32 limitationTime">
+    <Field Def="f32 limitationTime_1">
       <DisplayName>制限時間（協力霊数1）</DisplayName>
       <Description>制限時間[sec]（協力霊数1）</Description>
       <DisplayFormat>%.2f</DisplayFormat>
@@ -45,7 +45,7 @@
       <UnkC0>LIMIT_BY_COOP_NUM</UnkC0>
       <UnkC8>協力霊数1</UnkC8>
     </Field>
-    <Field Def="f32 observeTime">
+    <Field Def="f32 observeTime_1">
       <DisplayName>監視時間（協力霊数1）</DisplayName>
       <Description>監視時間[sec]（協力霊数1）</Description>
       <DisplayFormat>%.2f</DisplayFormat>
@@ -58,7 +58,7 @@
       <UnkC0>LIMIT_BY_COOP_NUM</UnkC0>
       <UnkC8>協力霊数1</UnkC8>
     </Field>
-    <Field Def="f32 limitationTime">
+    <Field Def="f32 limitationTime_2">
       <DisplayName>制限時間（協力霊数2）</DisplayName>
       <Description>制限時間[sec]（協力霊数2）</Description>
       <DisplayFormat>%.2f</DisplayFormat>
@@ -71,7 +71,7 @@
       <UnkC0>LIMIT_BY_COOP_NUM</UnkC0>
       <UnkC8>協力霊数2</UnkC8>
     </Field>
-    <Field Def="f32 observeTime">
+    <Field Def="f32 observeTime_2">
       <DisplayName>監視時間（協力霊数2）</DisplayName>
       <Description>監視時間[sec]（協力霊数2）</Description>
       <DisplayFormat>%.2f</DisplayFormat>
@@ -84,7 +84,7 @@
       <UnkC0>LIMIT_BY_COOP_NUM</UnkC0>
       <UnkC8>協力霊数2</UnkC8>
     </Field>
-    <Field Def="f32 limitationTime">
+    <Field Def="f32 limitationTime_3">
       <DisplayName>制限時間（協力霊数3）</DisplayName>
       <Description>制限時間[sec]（協力霊数3）</Description>
       <DisplayFormat>%.2f</DisplayFormat>
@@ -97,7 +97,7 @@
       <UnkC0>LIMIT_BY_COOP_NUM</UnkC0>
       <UnkC8>協力霊数3</UnkC8>
     </Field>
-    <Field Def="f32 observeTime">
+    <Field Def="f32 observeTime_3">
       <DisplayName>監視時間（協力霊数3）</DisplayName>
       <Description>監視時間[sec]（協力霊数3）</Description>
       <DisplayFormat>%.2f</DisplayFormat>

--- a/StudioCore/Assets/Paramdex/SDT/Defs/NetworkParam.xml
+++ b/StudioCore/Assets/Paramdex/SDT/Defs/NetworkParam.xml
@@ -36,7 +36,7 @@
       <UnkC0>NET_COMMON_PARAM</UnkC0>
       <UnkC8>共通</UnkC8>
     </Field>
-    <Field Def="dummy8 pad[4]">
+    <Field Def="dummy8 pad_0[4]">
       <DisplayName>予約</DisplayName>
       <Maximum>999</Maximum>
       <Increment>1</Increment>
@@ -45,7 +45,7 @@
       <UnkC0>NET_COMMON_PARAM</UnkC0>
       <UnkC8>共通</UnkC8>
     </Field>
-    <Field Def="f32 keyGuideRange = 1">
+    <Field Def="f32 keyGuideRange_0 = 1">
       <DisplayName>キーガイド水平範囲[m]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>1</Minimum>
@@ -56,7 +56,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="f32 keyGuideHeight = 1">
+    <Field Def="f32 keyGuideHeight_0 = 1">
       <DisplayName>キーガイド垂直範囲[m]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>1</Minimum>
@@ -89,7 +89,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="u32 reloadSignTotalCount = 1">
+    <Field Def="u32 reloadSignTotalCount_0 = 1">
       <DisplayName>召喚サイン所持可能数上限(全体)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -100,7 +100,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="u32 reloadSignCellCount = 1">
+    <Field Def="u32 reloadSignCellCount_0 = 1">
       <DisplayName>召喚サイン所持可能数上限(セル)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -122,7 +122,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveRange = 1">
+    <Field Def="f32 basicExclusiveRange_0 = 1">
       <DisplayName>召喚サイン間描画排他水平範囲[m]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -133,7 +133,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveHeight = 1">
+    <Field Def="f32 basicExclusiveHeight_0 = 1">
       <DisplayName>召喚サイン間描画排他垂直範囲[m]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -155,7 +155,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="f32 signVisibleRange = 1">
+    <Field Def="f32 signVisibleRange_0 = 1">
       <DisplayName>召喚サインPC間描画距離[m]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -166,7 +166,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupHorizontalRange = 1">
+    <Field Def="u32 cellGroupHorizontalRange_0 = 1">
       <DisplayName>召喚サイン取得セル範囲(水平)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -176,7 +176,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupTopRange = 1">
+    <Field Def="u32 cellGroupTopRange_0 = 1">
       <DisplayName>召喚サイン取得セル範囲(上方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -186,7 +186,7 @@
       <UnkC0>NET_SUMMON_SIGN_PARAM</UnkC0>
       <UnkC8>召喚サイン</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupBottomRange = 1">
+    <Field Def="u32 cellGroupBottomRange_0 = 1">
       <DisplayName>召喚サイン取得セル範囲(下方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -333,7 +333,7 @@
       <UnkC0>NET_BREAKIN_PARAM</UnkC0>
       <UnkC8>乱入</UnkC8>
     </Field>
-    <Field Def="dummy8 pad[4] = 1">
+    <Field Def="dummy8 pad_1[4] = 1">
       <DisplayName>予約</DisplayName>
       <Minimum>1</Minimum>
       <Maximum>1000</Maximum>
@@ -343,7 +343,7 @@
       <UnkC0>NET_BREAKIN_PARAM</UnkC0>
       <UnkC8>乱入</UnkC8>
     </Field>
-    <Field Def="f32 keyGuideRange = 1">
+    <Field Def="f32 keyGuideRange_1 = 1">
       <DisplayName>キーガイド水平範囲[m]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -354,7 +354,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 keyGuideHeight = 1">
+    <Field Def="f32 keyGuideHeight_1 = 1">
       <DisplayName>キーガイド垂直範囲[m]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -365,7 +365,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 reloadSignTotalCount = 1">
+    <Field Def="u32 reloadSignTotalCount_1 = 1">
       <DisplayName>血文字取得数(全体)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -398,7 +398,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 maxSignTotalCount = 1">
+    <Field Def="u32 maxSignTotalCount_0 = 1">
       <DisplayName>血文字所持可能数上限(全体)</DisplayName>
       <Description>本当はu16くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -409,7 +409,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 maxSignCellCount = 1">
+    <Field Def="u32 maxSignCellCount_0 = 1">
       <DisplayName>血文字所持可能数上限(セル)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -420,7 +420,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveRange = 1">
+    <Field Def="f32 basicExclusiveRange_1 = 1">
       <DisplayName>血文字間描画排他水平範囲[m]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -431,7 +431,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveHeight = 1">
+    <Field Def="f32 basicExclusiveHeight_1 = 1">
       <DisplayName>血文字間描画排他垂直範囲[m]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -442,7 +442,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 signVisibleRange = 1">
+    <Field Def="f32 signVisibleRange_1 = 1">
       <DisplayName>血文字PC間描画距離[m]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -473,7 +473,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 reloadSignIntervalTime = 1">
+    <Field Def="f32 reloadSignIntervalTime_0 = 1">
       <DisplayName>血文字再取得待機時間[秒]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -484,7 +484,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupHorizontalRange = 1">
+    <Field Def="u32 cellGroupHorizontalRange_1 = 1">
       <DisplayName>血文字取得セル範囲(水平)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -494,7 +494,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupTopRange = 1">
+    <Field Def="u32 cellGroupTopRange_1 = 1">
       <DisplayName>血文字取得セル範囲(上方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -504,7 +504,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupBottomRange = 1">
+    <Field Def="u32 cellGroupBottomRange_1 = 1">
       <DisplayName>血文字取得セル範囲(下方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -514,7 +514,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="u32 lifeTime = 1">
+    <Field Def="u32 lifeTime_0 = 1">
       <DisplayName>血文字データ保持期間上限[秒]</DisplayName>
       <Description>本当はu16くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -525,7 +525,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 downloadSpan">
+    <Field Def="f32 downloadSpan_0">
       <DisplayName>血文字ダウンロード間隔</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -547,7 +547,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="dummy8 pad[4] = 1">
+    <Field Def="dummy8 pad_2[4] = 1">
       <DisplayName>予約</DisplayName>
       <Minimum>1</Minimum>
       <Maximum>1800</Maximum>
@@ -557,7 +557,7 @@
       <UnkC0>NET_BLOOD_MESSAGE_PARAM</UnkC0>
       <UnkC8>血文字</UnkC8>
     </Field>
-    <Field Def="f32 keyGuideRange = 1">
+    <Field Def="f32 keyGuideRange_2 = 1">
       <DisplayName>キーガイド水平範囲[m]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -568,7 +568,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 keyGuideHeight = 1">
+    <Field Def="f32 keyGuideHeight_2 = 1">
       <DisplayName>キーガイド垂直範囲[m]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -601,7 +601,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 reloadSignTotalCount = 1">
+    <Field Def="u32 reloadSignTotalCount_2 = 1">
       <DisplayName>血痕取得数(全体)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -611,7 +611,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 reloadSignCellCount = 1">
+    <Field Def="u32 reloadSignCellCount_1 = 1">
       <DisplayName>血痕取得数(セル)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -621,7 +621,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 maxSignTotalCount = 1">
+    <Field Def="u32 maxSignTotalCount_1 = 1">
       <DisplayName>血痕所持可能数上限(全体)</DisplayName>
       <Description>本当はu16くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -631,7 +631,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 maxSignCellCount = 1">
+    <Field Def="u32 maxSignCellCount_1 = 1">
       <DisplayName>血痕所持可能数上限(セル)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -641,7 +641,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 reloadSignIntervalTime = 1">
+    <Field Def="f32 reloadSignIntervalTime_1 = 1">
       <DisplayName>血痕再取得待機時間[秒]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -652,7 +652,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 signVisibleRange = 1">
+    <Field Def="f32 signVisibleRange_2 = 1">
       <DisplayName>血痕PC間描画距離[m]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -663,7 +663,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveRange = 1">
+    <Field Def="f32 basicExclusiveRange_2 = 1">
       <DisplayName>血痕間描画排他水平範囲[m]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -674,7 +674,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 basicExclusiveHeight = 1">
+    <Field Def="f32 basicExclusiveHeight_2 = 1">
       <DisplayName>血痕間描画排他垂直範囲[m]</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -685,7 +685,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupHorizontalRange = 1">
+    <Field Def="u32 cellGroupHorizontalRange_2 = 1">
       <DisplayName>血痕取得セル範囲(水平)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -695,7 +695,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupTopRange = 1">
+    <Field Def="u32 cellGroupTopRange_2 = 1">
       <DisplayName>血痕取得セル範囲(上方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -705,7 +705,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupBottomRange = 1">
+    <Field Def="u32 cellGroupBottomRange_2 = 1">
       <DisplayName>血痕取得セル範囲(下方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -715,7 +715,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="u32 lifeTime = 1">
+    <Field Def="u32 lifeTime_1 = 1">
       <DisplayName>血痕データ保持期間上限[秒]</DisplayName>
       <Description>本当はu16くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -748,7 +748,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="f32 downloadSpan">
+    <Field Def="f32 downloadSpan_1">
       <DisplayName>血痕ダウンロード間隔</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>
@@ -759,7 +759,7 @@
       <UnkC0>NET_BLOODSTAIN_PARAM</UnkC0>
       <UnkC8>血痕</UnkC8>
     </Field>
-    <Field Def="dummy8 pad[4]">
+    <Field Def="dummy8 pad_3[4]">
       <DisplayName>予約</DisplayName>
       <Maximum>10</Maximum>
       <Increment>1</Increment>
@@ -965,7 +965,7 @@
       <UnkC0>NET_GHOST_PARAM</UnkC0>
       <UnkC8>幻影</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupHorizontalRange = 1">
+    <Field Def="u32 cellGroupHorizontalRange_3 = 1">
       <DisplayName>幻影取得セル範囲(水平)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -975,7 +975,7 @@
       <UnkC0>NET_GHOST_PARAM</UnkC0>
       <UnkC8>幻影</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupTopRange = 1">
+    <Field Def="u32 cellGroupTopRange_3 = 1">
       <DisplayName>幻影取得セル範囲(上方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -985,7 +985,7 @@
       <UnkC0>NET_GHOST_PARAM</UnkC0>
       <UnkC8>幻影</UnkC8>
     </Field>
-    <Field Def="u32 cellGroupBottomRange = 1">
+    <Field Def="u32 cellGroupBottomRange_3 = 1">
       <DisplayName>幻影取得セル範囲(下方向)</DisplayName>
       <Description>本当はu8くらいで十分</Description>
       <EditFlags>None</EditFlags>
@@ -1595,7 +1595,7 @@
       <UnkC0>VISITOR</UnkC0>
       <UnkC8>訪問</UnkC8>
     </Field>
-    <Field Def="f32 DownloadSpan = 1">
+    <Field Def="f32 DownloadSpan_2 = 1">
       <DisplayName>訪問者リストダウンロード間隔</DisplayName>
       <EditFlags>None</EditFlags>
       <Minimum>0</Minimum>


### PR DESCRIPTION
Renames fields when the same field appears multiple times.
This should help not only with user tools such as mapstudio's editor and massedit, but should help support versioned paramdef fields better.