### PR TITLE
Always instantiate MSB enums with an enum value.

### DIFF
--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSB1/EventParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSB1/EventParam.cs
@@ -843,7 +843,7 @@ namespace SoulsFormats
                 /// <summary>
                 /// Unknown.
                 /// </summary>
-                public StateType ObjActState { get; set; }
+                public StateType ObjActState { get; set; } = StateType.Default;
 
                 /// <summary>
                 /// Unknown, probably enables or disables the ObjAct.

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSB2/PartsParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSB2/PartsParam.cs
@@ -447,7 +447,7 @@ namespace SoulsFormats
                 /// <summary>
                 /// Modifies sounds while the player is touching this collision.
                 /// </summary>
-                public SoundSpace SoundSpaceType { get; set; }
+                public SoundSpace SoundSpaceType { get; set; } = SoundSpace.NoReverb;
 
                 /// <summary>
                 /// Unknown.

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/EventParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/EventParam.cs
@@ -655,7 +655,7 @@ namespace SoulsFormats
                 /// <summary>
                 /// Unknown.
                 /// </summary>
-                public ObjActState ObjActStateType { get; set; }
+                public ObjActState ObjActStateType { get; set; } = ObjActState.OneState;
 
                 /// <summary>
                 /// Unknown.
@@ -818,12 +818,12 @@ namespace SoulsFormats
                 /// <summary>
                 /// Player type to use while in pseudo world. 
                 /// </summary>
-                public PseudoPlayerChrType PlayerChrType { get; set; }
+                public PseudoPlayerChrType PlayerChrType { get; set; } = PseudoPlayerChrType.WhitePhantom;
 
                 /// <summary>
                 /// Determines which set of FMG entries to use in pseudo world.
                 /// </summary>
-                public PseudoMessageSetType MessageSetType { get; set; }
+                public PseudoMessageSetType MessageSetType { get; set; } = PseudoMessageSetType.Default;
 
                 /// <summary>
                 /// ID of FMG entry to display when trying to join pseudo world.

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/PartsParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/PartsParam.cs
@@ -1230,7 +1230,7 @@ namespace SoulsFormats
                 /// <summary>
                 /// Modifies sounds while the player is touching this collision.
                 /// </summary>
-                public SoundSpace SoundSpaceType { get; set; }
+                public SoundSpace SoundSpaceType { get; set; } = SoundSpace.NoReverb;
 
                 /// <summary>
                 /// Unknown.
@@ -1303,7 +1303,7 @@ namespace SoulsFormats
                 /// <summary>
                 /// Unknown.
                 /// </summary>
-                public MapVisiblity MapVisType { get; set; }
+                public MapVisiblity MapVisType { get; set; } = MapVisiblity.Good;
 
                 /// <summary>
                 /// Creates a Collision with default values.

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/PointParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/PointParam.cs
@@ -627,7 +627,7 @@ namespace SoulsFormats
                 /// <summary>
                 /// Type of sound in this region; determines mixing behavior like muffling.
                 /// </summary>
-                public SndType SoundType { get; set; }
+                public SndType SoundType { get; set; } = SndType.Environment;
 
                 /// <summary>
                 /// ID of the sound to play in this region, or 0 for child regions.

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBB/EventParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBB/EventParam.cs
@@ -904,7 +904,7 @@ namespace SoulsFormats
                 /// <summary>
                 /// Unknown.
                 /// </summary>
-                public StateType ObjActState { get; set; }
+                public StateType ObjActState { get; set; } = StateType.Default;
 
                 /// <summary>
                 /// Unknown, probably enables or disables the ObjAct.

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBB/PartsParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBB/PartsParam.cs
@@ -1219,7 +1219,7 @@ namespace SoulsFormats
                 /// <summary>
                 /// Determines if enemy think will use dark and pitch dark eye distances.
                 /// </summary>
-                public MapVisibilityTypeEnum MapVisibilityType { get; set; }
+                public MapVisibilityTypeEnum MapVisibilityType { get; set; } = MapVisibilityTypeEnum.Good;
 
                 /// <summary>
                 /// If set, disables a bonfire when any enemy is on the collision.

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PartsParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PartsParam.cs
@@ -205,7 +205,7 @@ namespace SoulsFormats
             /// <summary>
             /// 1 disables the part, 2 and 3 are unknown.
             /// </summary>
-            public UnkEnabledStateType UnkEnabledState { get; set; }
+            public UnkEnabledStateType UnkEnabledState { get; set; } = UnkEnabledStateType.Default;
 
             /// <summary>
             /// Very speculative
@@ -1924,7 +1924,7 @@ namespace SoulsFormats
                 /// <summary>
                 /// Sets collision behavior. Fall collision, death collision, enemy-only collision, etc.
                 /// </summary>
-                public HitFilterType HitFilterID { get; set; }
+                public HitFilterType HitFilterID { get; set; } = HitFilterType.Standard;
 
                 /// <summary>
                 /// Unknown.

--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PointParam.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PointParam.cs
@@ -2429,7 +2429,7 @@ namespace SoulsFormats
                 /// <summary>
                 /// 1 = Forbid riding torrent, 2 = Permit riding torrent
                 /// </summary>
-                public HorseRideOverrideType OverrideType { get; set; }
+                public HorseRideOverrideType OverrideType { get; set; } = HorseRideOverrideType.PreventRiding;
 
                 /// <summary>
                 /// Creates a HorseRideOverride with default values.


### PR DESCRIPTION
This is done by assigning property instantiator.
The alternative is to insert an assignment for each enum into each constructor, as we have done so far for some reason.
Hopefully we can tell this problem to go away entirely when we finally come up with msbdefs.