### PR TITLE
Tentative paramtype fixes

### DIFF
--- a/StudioCore/Assets/Paramdex/AC6/Defs/TentativeParamType.csv
+++ b/StudioCore/Assets/Paramdex/AC6/Defs/TentativeParamType.csv
@@ -24,3 +24,4 @@ CutsceneTimezoneConvertParam,CUTSCENE_TIMEZONE_CONVERT_PARAM_ST
 CutsceneMapIdParam,CUTSCENE_MAP_ID_PARAM_ST
 MapAreaParam,MapAreaParam_TENTATIVE
 RuntimeSoundGlobalParam,RuntimeSoundGlobalParam_TENTATIVE
+SpEffectParam,SP_EFFECT_PARAM_ST

--- a/StudioCore/ParamEditor/ParamBank.cs
+++ b/StudioCore/ParamEditor/ParamBank.cs
@@ -232,6 +232,7 @@ namespace StudioCore.ParamEditor
                             {
                                 TaskLogs.AddLog($"Couldn't find ParamDef for param {paramName} and no tentative ParamType exists.",
                                     Microsoft.Extensions.Logging.LogLevel.Error, TaskLogs.LogPriority.High);
+                                continue;
                             }
                         }
                     }
@@ -247,6 +248,7 @@ namespace StudioCore.ParamEditor
                         {
                             TaskLogs.AddLog($"Couldn't read ParamType for {paramName} and no tentative ParamType exists.",
                                 Microsoft.Extensions.Logging.LogLevel.Error, TaskLogs.LogPriority.High);
+                            continue;
                         }
                     }
                 }


### PR DESCRIPTION
Adds tentative paramtype for spEffectParam, which was stripped from AC6 1.02.1 regulation.
Makes parambank load loop continue when tentative paramtype cannot be found (in order to continue to log errors instead of being able to throw an exception)