### PR TITLE
Set up CalcCorrectDefinition for FCS param + improvements

### DIFF
--- a/StudioCore/ParamEditor/ParamMeta.cs
+++ b/StudioCore/ParamEditor/ParamMeta.cs
@@ -560,21 +560,41 @@ namespace StudioCore.ParamEditor
         public string[] stageMaxVal;
         public string[] stageMaxGrowVal;
         public string[] adjPoint_maxGrowVal;
+        public string fcsMaxdist = null;
 
         internal CalcCorrectDefinition(string ccd)
         {
             string[] parts = ccd.Split(',');
-            int cclength = (parts.Length+1)/3;
-            stageMaxVal = new string[cclength];
-            stageMaxGrowVal = new string[cclength];
-            adjPoint_maxGrowVal = new string[cclength-1];
-            Array.Copy(parts, 0, stageMaxVal, 0, cclength);
-            Array.Copy(parts, cclength, stageMaxGrowVal, 0, cclength);
-            Array.Copy(parts, cclength*2, adjPoint_maxGrowVal, 0, cclength-1);
+            if (parts.Length == 11)
+            {
+                // FCS param curve
+                int cclength = 5;
+                stageMaxVal = new string[cclength];
+                stageMaxGrowVal = new string[cclength];
+                Array.Copy(parts, 0, stageMaxVal, 0, cclength);
+                Array.Copy(parts, cclength, stageMaxGrowVal, 0, cclength);
+                adjPoint_maxGrowVal = null;
+                fcsMaxdist = parts[10];
+            }
+            else
+            {
+                int cclength = (parts.Length + 1) / 3;
+                stageMaxVal = new string[cclength];
+                stageMaxGrowVal = new string[cclength];
+                adjPoint_maxGrowVal = new string[cclength - 1];
+                Array.Copy(parts, 0, stageMaxVal, 0, cclength);
+                Array.Copy(parts, cclength, stageMaxGrowVal, 0, cclength);
+                Array.Copy(parts, cclength * 2, adjPoint_maxGrowVal, 0, cclength - 1);
+            }
         }
         internal string getStringForm()
         {
-            return string.Join(',', stageMaxVal) + ',' + string.Join(',', stageMaxGrowVal) + ',' + string.Join(',', adjPoint_maxGrowVal);
+            var str = string.Join(',', stageMaxVal) + ',' + string.Join(',', stageMaxGrowVal) + ',';
+            if (adjPoint_maxGrowVal != null)
+                str += string.Join(',', adjPoint_maxGrowVal);
+            if (fcsMaxdist != null)
+                str += string.Join(',', fcsMaxdist);
+            return str;
         }
     }
 

--- a/StudioCore/ParamEditor/ParamRowEditor.cs
+++ b/StudioCore/ParamEditor/ParamRowEditor.cs
@@ -419,6 +419,7 @@ namespace StudioCore.ParamEditor
             {
                 ImGui.Separator();
                 ImGui.NewLine();
+                ImGui.Indent();
                 var ccd = meta.CalcCorrectDef;
                 var scd = meta.SoulCostDef;
                 float[] values;
@@ -428,19 +429,20 @@ namespace StudioCore.ParamEditor
                 if (scd != null && scd.cost_row == row.ID)
                 {
                     (values, maxY) = CacheBank.GetCached(_paramEditor, row, "soulCostData", () => ParamUtils.getSoulCostData(scd, row));
-                    ImGui.PlotLines("##graph", ref values[0], values.Length, 0, "", 0, maxY, new Vector2(ImGui.GetColumnWidth(-1), ImGui.GetColumnWidth(-1)*0.5625f));
+                    ImGui.PlotLines("##graph", ref values[0], values.Length, 0, "", 0, maxY, new Vector2(ImGui.GetColumnWidth(-1) - 30.0f, ImGui.GetColumnWidth(-1) * 0.5625f - 30.0f));
                 
                 }
                 else if (ccd != null)
                 {
                     (values, xOffset, minY, maxY) = CacheBank.GetCached(_paramEditor, row, "calcCorrectData", () => ParamUtils.getCalcCorrectedData(ccd, row));
-                    ImGui.PlotLines("##graph", ref values[0], values.Length, 0, xOffset == 0 ? "" : $@"Note: add {xOffset} to x coordinate", minY, maxY, new Vector2(ImGui.GetColumnWidth(-1), ImGui.GetColumnWidth(-1)*0.5625f));
+                    ImGui.PlotLines("##graph", ref values[0], values.Length, 0, xOffset == 0 ? "" : $@"Note: add {xOffset} to x coordinate", minY, maxY, new Vector2(ImGui.GetColumnWidth(-1) - 30f, ImGui.GetColumnWidth(-1) * 0.5625f - 30f));
                 }
             }
             catch (Exception e)
             {
                 ImGui.TextUnformatted("Unable to draw graph");
             }
+            ImGui.NewLine();
         }
 
         // Many parameter options, which may be simplified.


### PR DESCRIPTION
Make CalcCorrectDefinition work with FCS param calculation curves (present in #685).
Fixes bug with plot if final growval was lower than first growval.
Fix plot not fitting well on screen.
Other visual improvements.