### PR TITLE
Log inner exception information for silent fail tasks.

### DIFF
--- a/StudioCore/Editor/TaskManager.cs
+++ b/StudioCore/Editor/TaskManager.cs
@@ -132,7 +132,7 @@ namespace StudioCore.Editor
                         if (SilentFail)
                         {
                             TaskLogs.AddLog($"Task Failed: {TaskId}",
-                                Microsoft.Extensions.Logging.LogLevel.Error, LogPriority, e);
+                                Microsoft.Extensions.Logging.LogLevel.Error, LogPriority, e.InnerException);
                         }
                         else
                         {


### PR DESCRIPTION
Fixes stack trace not being helpful.