### PR TITLE
Imgui float input display format: retain trailing zeroes

### DIFF
--- a/StudioCore/MsbEditor/PropertyEditor.cs
+++ b/StudioCore/MsbEditor/PropertyEditor.cs
@@ -146,7 +146,7 @@ namespace StudioCore.MsbEditor
             else if (typ == typeof(float))
             {
                 float val = (float)oldval;
-                if (ImGui.DragFloat("##value", ref val, 0.1f, float.MinValue, float.MaxValue, "%.5g"))
+                if (ImGui.DragFloat("##value", ref val, 0.1f, float.MinValue, float.MaxValue, Utils.ImGui_InputFloatFormat(val)))
                 {
                     newval = val;
                     isChanged = true;

--- a/StudioCore/ParamEditor/ParamRowEditor.cs
+++ b/StudioCore/ParamEditor/ParamRowEditor.cs
@@ -166,7 +166,7 @@ namespace StudioCore.ParamEditor
             else if (typ == typeof(float))
             {
                 float val = (float)oldval;
-                if (ImGui.InputFloat("##value", ref val, 0.1f, 1.0f, "%.5g"))
+                if (ImGui.InputFloat("##value", ref val, 0.1f, 1.0f, Utils.ImGui_InputFloatFormat(val)))
                 {
                     newval = val;
                     _editedPropCache = newval;

--- a/StudioCore/Utils.cs
+++ b/StudioCore/Utils.cs
@@ -869,5 +869,16 @@ namespace StudioCore
             }
             return text;
         }
+
+        /// <summary>
+        /// Generates display format for ImGui float input.
+        /// Made to display trailing zeroes even if value is an integer,
+        /// and limit number of decimals to appropriate values.
+        /// </summary>
+        public static string ImGui_InputFloatFormat(float f)
+        {
+            var split = f.ToString("F6").TrimEnd('0').Split('.');
+            return $"%.{Math.Clamp(split[1].Length, 3, 6)}f";
+        }
     }
 }


### PR DESCRIPTION
More helpful version of #704. Retains improvements made there (shows more decimals), but also restores trailing zeroes for integer floats so users can still easily identify float values vs non floats.