### PR TITLE
Ds2 material rendering fix + DS2 chr texture path setup

### DIFF
--- a/StudioCore/AssetLocator.cs
+++ b/StudioCore/AssetLocator.cs
@@ -1227,6 +1227,10 @@ namespace StudioCore
                 }
                 return GetOverridenFilePath($@"chr\{chrid}.chrbnd");
             }
+            else if (Type is GameType.DarkSoulsIISOTFS)
+            {
+                return GetOverridenFilePath($@"model\chr\{chrid}.texbnd");
+            }
             else if (Type is GameType.DarkSoulsRemastered)
             {
                 // TODO: Some textures require getting chrtpfbhd from chrbnd, then using it with chrtpfbdt in chr folder.
@@ -1285,6 +1289,16 @@ namespace StudioCore
             else if (Type is GameType.DarkSoulsRemastered)
             {
                 // TODO: Some textures require getting chrtpfbhd from chrbnd, then using it with chrtpfbdt in chr folder.
+                string path = GetChrTexturePath(chrid);
+                if (path != null)
+                {
+                    ad = new AssetDescription();
+                    ad.AssetPath = path;
+                    ad.AssetVirtualPath = $@"chr/{chrid}/tex";
+                }
+            }
+            else if (Type is GameType.DarkSoulsIISOTFS)
+            {
                 string path = GetChrTexturePath(chrid);
                 if (path != null)
                 {

--- a/StudioCore/MsbEditor/Universe.cs
+++ b/StudioCore/MsbEditor/Universe.cs
@@ -494,6 +494,11 @@ namespace StudioCore.MsbEditor
                         generatorObjs[row.ID].RenderSceneMesh = model;
                         model.SetSelectable(generatorObjs[row.ID]);
                         chrsToLoad.Add(asset);
+                        var tasset = _assetLocator.GetChrTextures($@"c{chrid}");
+                        if (tasset.AssetVirtualPath != null || tasset.AssetArchiveVirtualPath != null)
+                        {
+                            chrsToLoad.Add(tasset);
+                        }
                     }
                 }
             }

--- a/StudioCore/Resource/FlverResource.cs
+++ b/StudioCore/Resource/FlverResource.cs
@@ -406,7 +406,7 @@ namespace StudioCore.Resource
             }
             else if (paramNameCheck == "G_SPECULARTEXTURE2" || paramNameCheck == "G_SPECULAR2" || paramNameCheck.Contains("SPECULAR_2"))
             {
-                if (gameType == GameType.DarkSoulsRemastered)
+                if (gameType is GameType.DarkSoulsRemastered or GameType.DarkSoulsIISOTFS)
                 {
                     LookupTexture(FlverMaterial.TextureType.ShininessTextureResource2, dest, texType, mpath, mtd);
                     blend = true;
@@ -421,7 +421,7 @@ namespace StudioCore.Resource
             }
             else if (paramNameCheck == "G_SPECULARTEXTURE" || paramNameCheck == "G_SPECULAR" || paramNameCheck.Contains("SPECULAR"))
             {
-                if (gameType == GameType.DarkSoulsRemastered)
+                if (gameType is GameType.DarkSoulsRemastered or GameType.DarkSoulsIISOTFS)
                 {
                     LookupTexture(FlverMaterial.TextureType.ShininessTextureResource, dest, texType, mpath, mtd);
                 }


### PR DESCRIPTION
Material fix seems to be the same story as #599.
DS2 chr textures still aren't working, in spite of texture info being delivered to resource handler. Not sure why.