### PR TITLE
Fix zlib being included in dcx check

### DIFF
--- a/SoulsFormats/SoulsFormats/Formats/DCX.cs
+++ b/SoulsFormats/SoulsFormats/Formats/DCX.cs
@@ -15,11 +15,8 @@ namespace SoulsFormats
         {
             if (br.Length < 4)
                 return false;
-
-            byte b0 = br.GetByte(0);
-            byte b1 = br.GetByte(1);
             string magic = br.GetASCII(0, 4);
-            return magic == "DCP\0" || magic == "DCX\0" || b0 == 0x78 && (b1 == 0x01 || b1 == 0x5E || b1 == 0x9C || b1 == 0xDA);
+            return magic == "DCP\0" || magic == "DCX\0";
         }
 
         /// <summary>


### PR DESCRIPTION
This is for parity with sf which apparently never got fixed.