### PR TITLE
Check if MSB FindName index is >= list length

### DIFF
--- a/SoulsFormats/SoulsFormats/Formats/MSB/MSB.cs
+++ b/SoulsFormats/SoulsFormats/Formats/MSB/MSB.cs
@@ -83,6 +83,8 @@ namespace SoulsFormats
         {
             if (index == -1)
                 return null;
+            else if (index >= list.Count)
+                return null;
             else
                 return list[index].Name;
         }


### PR DESCRIPTION
Prevents MSBs being unreadable if index reference is invalid (which can be caused by an msb having 0 ref entries)