### PR TITLE
Fix DS2 BTLs saving by fixing BXF4 write/disposal. Improve BTL saving.

### DIFF
--- a/SoulsFormats/SoulsFormats/Binder/BXF4/BXF4.cs
+++ b/SoulsFormats/SoulsFormats/Binder/BXF4/BXF4.cs
@@ -73,7 +73,7 @@ namespace SoulsFormats
             IMappedMemoryOwner fsData = dataFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
             BinaryReaderEx bhdReader = new BinaryReaderEx(false, bhdBytes);
             BinaryReaderEx bdtReader = new BinaryReaderEx(false, fsData.Memory);
-            return new BXF4(bhdReader, bdtReader) {_mappedMemory = fsData };
+            return new BXF4(bhdReader, bdtReader) { _mappedMemory2 = fsData };
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace SoulsFormats
             IMappedMemoryOwner fsHeader = headerFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
             BinaryReaderEx bhdReader = new BinaryReaderEx(false, fsHeader.Memory);
             BinaryReaderEx bdtReader = new BinaryReaderEx(false, bdtBytes);
-            return new BXF4(bhdReader, bdtReader) { _mappedMemory = fsHeader } ;
+            return new BXF4(bhdReader, bdtReader) { _mappedMemory1 = fsHeader };
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace SoulsFormats
                 fsData = dataFile.CreateMemoryAccessor(0, 0, MemoryMappedFileAccess.Read);
             BinaryReaderEx bhdReader = new BinaryReaderEx(false, fsHeader.Memory);
             BinaryReaderEx bdtReader = new BinaryReaderEx(false, fsData.Memory);
-            return new BXF4(bhdReader, bdtReader) { _mappedMemory = fsHeader };
+            return new BXF4(bhdReader, bdtReader) { _mappedMemory1 = fsHeader, _mappedMemory2 = fsData };
         }
         #endregion
 
@@ -216,7 +216,9 @@ namespace SoulsFormats
         /// Creates an empty BXF4 formatted for DS3.
         /// </summary>
 
-        private IMappedMemoryOwner _mappedMemory = null;
+        private IMappedMemoryOwner _mappedMemory => throw new NotSupportedException();
+        private IMappedMemoryOwner _mappedMemory1 = null;
+        private IMappedMemoryOwner _mappedMemory2 = null;
 
         public BXF4()
         {
@@ -406,8 +408,10 @@ namespace SoulsFormats
 
         protected override void Dispose(bool disposing)
         {
-            _mappedMemory?.Dispose();
-            _mappedMemory = null;
+            _mappedMemory1?.Dispose();
+            _mappedMemory1 = null;
+            _mappedMemory2?.Dispose();
+            _mappedMemory2 = null;
         }
     }
 }

--- a/StudioCore/MsbEditor/Universe.cs
+++ b/StudioCore/MsbEditor/Universe.cs
@@ -1282,7 +1282,7 @@ namespace StudioCore.MsbEditor
             {
                 for (var i = 0; i < BTLs.Count; i++)
                 {
-                    var bdt = BXF4.Read(BTLs[i].AssetPath, BTLs[i].AssetPath[..^3] + "bdt");
+                    using var bdt = BXF4.Read(BTLs[i].AssetPath, BTLs[i].AssetPath[..^3] + "bdt");
                     var file = bdt.Files.Find(f => f.Name.EndsWith("light.btl.dcx"));
                     var btl = BTL.Read(file.Bytes);
                     if (btl != null)
@@ -1295,21 +1295,9 @@ namespace StudioCore.MsbEditor
                         {
                             btl.Lights = newLights;
                             file.Bytes = btl.Write(DCX.Type.DCX_DFLT_10000_24_9);
-                            try
-                            {
-                                var bdtPath = BTLs_w[i].AssetPath[..^3] + "bdt";
+                            var bdtPath = BTLs_w[i].AssetPath[..^3] + "bdt";
 
-                                if (!File.Exists(BTLs_w[i].AssetPath + ".bak") && File.Exists(BTLs_w[i].AssetPath))
-                                    File.Copy(BTLs_w[i].AssetPath, BTLs_w[i].AssetPath + ".bak", true);
-                                if (!File.Exists(bdtPath + ".bak") && File.Exists(bdtPath))
-                                    File.Copy(bdtPath, bdtPath + ".bak", true);
-
-                                bdt.Write(BTLs_w[i].AssetPath, bdtPath);
-                            }
-                            catch (Exception e)
-                            {
-                                throw new SavingFailedException(Path.GetFileName(map.Name), e);
-                            }
+                            Utils.WriteWithBackup(_assetLocator, Utils.GetLocalAssetPath(_assetLocator, bdtPath), bdt, Utils.GetLocalAssetPath(_assetLocator, BTLs_w[i].AssetPath));
                         }
                     }
                 }
@@ -1332,16 +1320,8 @@ namespace StudioCore.MsbEditor
                             JsonSerializer.Serialize(newLights, BtlLightSerializerContext.Default.ListLight))
                         {
                             btl.Lights = newLights;
-                            try
-                            {
-                                if (!File.Exists(BTLs_w[i].AssetPath + ".bak") && File.Exists(BTLs_w[i].AssetPath))
-                                    File.Copy(BTLs_w[i].AssetPath, BTLs_w[i].AssetPath + ".bak", true);
-                                btl.Write(BTLs_w[i].AssetPath, compressionType);
-                            }
-                            catch (Exception e)
-                            {
-                                throw new SavingFailedException(Path.GetFileName(map.Name), e);
-                            }
+
+                            Utils.WriteWithBackup(_assetLocator, Utils.GetLocalAssetPath(_assetLocator, BTLs_w[i].AssetPath), btl);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes DS2 BTLs not saving due to MemoryMappedFile BXF4 not being disposed.
Makes BTL saving use Utils.WriteWithBackup().
Makes Utils.WriteWithBackup() handle BXF3 and BXF4 properly.