### PR TITLE
Support MSB MissingReferenceException for MSB.FindIndicies()

### DIFF
--- a/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSB.cs
+++ b/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSB.cs
@@ -141,5 +141,13 @@ namespace SoulsFormats
                 indices[i] = FindIndex(list, names[i]);
             return indices;
         }
+
+        internal static int[] FindIndices<T>(IMsbEntry referrer, List<T> list, string[] names) where T : IMsbEntry
+        {
+            var indices = new int[names.Length];
+            for (int i = 0; i < names.Length; i++)
+                indices[i] = FindIndex(referrer, list, names[i]);
+            return indices;
+        }
     }
 }

--- a/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSB1/EventParam.cs
+++ b/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSB1/EventParam.cs
@@ -750,8 +750,8 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB1 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    SpawnPointIndices = MSB.FindIndices(entries.Regions, SpawnPointNames);
-                    SpawnPartIndices = MSB.FindIndices(entries.Parts, SpawnPartNames);
+                    SpawnPointIndices = MSB.FindIndices(this, entries.Regions, SpawnPointNames);
+                    SpawnPartIndices = MSB.FindIndices(this, entries.Parts, SpawnPartNames);
                 }
             }
 

--- a/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/EventParam.cs
+++ b/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/EventParam.cs
@@ -607,8 +607,8 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB3 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    SpawnPointIndices = MSB.FindIndices(entries.Regions, SpawnPointNames);
-                    SpawnPartIndices = MSB.FindIndices(entries.Parts, SpawnPartNames);
+                    SpawnPointIndices = MSB.FindIndices(this, entries.Regions, SpawnPointNames);
+                    SpawnPartIndices = MSB.FindIndices(this, entries.Parts, SpawnPartNames);
                 }
             }
 
@@ -1012,7 +1012,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB3 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    GroupPartsIndices = MSB.FindIndices(entries.Parts, GroupPartsNames);
+                    GroupPartsIndices = MSB.FindIndices(this, entries.Parts, GroupPartsNames);
                 }
             }
 

--- a/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/PointParam.cs
+++ b/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSB3/PointParam.cs
@@ -681,7 +681,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSB3 msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    ChildRegionIndices = MSB.FindIndices(entries.Regions, ChildRegionNames);
+                    ChildRegionIndices = MSB.FindIndices(this, entries.Regions, ChildRegionNames);
                 }
             }
 

--- a/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSBB/EventParam.cs
+++ b/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSBB/EventParam.cs
@@ -810,8 +810,8 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBB msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    SpawnPointIndices = MSB.FindIndices(entries.Regions, SpawnPointNames);
-                    SpawnPartIndices = MSB.FindIndices(entries.Parts, SpawnPartNames);
+                    SpawnPointIndices = MSB.FindIndices(this, entries.Regions, SpawnPointNames);
+                    SpawnPartIndices = MSB.FindIndices(this, entries.Parts, SpawnPartNames);
                 }
             }
 
@@ -1402,7 +1402,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBB msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    GroupPartsIndices = MSB.FindIndices(entries.Parts, GroupPartsNames);
+                    GroupPartsIndices = MSB.FindIndices(this, entries.Parts, GroupPartsNames);
                 }
             }
 

--- a/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSBD/EventParam.cs
+++ b/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSBD/EventParam.cs
@@ -694,8 +694,8 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBD msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    SpawnPointIndices = MSB.FindIndices(entries.Regions, SpawnPointNames);
-                    SpawnPartIndices = MSB.FindIndices(entries.Parts, SpawnPartNames);
+                    SpawnPointIndices = MSB.FindIndices(this, entries.Regions, SpawnPointNames);
+                    SpawnPartIndices = MSB.FindIndices(this, entries.Parts, SpawnPartNames);
                 }
             }
 

--- a/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/EventParam.cs
+++ b/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/EventParam.cs
@@ -648,8 +648,8 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBE msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    SpawnRegionIndices = MSB.FindIndices(entries.Regions, SpawnRegionNames);
-                    SpawnPartIndices = MSB.FindIndices(entries.Parts, SpawnPartNames);
+                    SpawnRegionIndices = MSB.FindIndices(this, entries.Regions, SpawnRegionNames);
+                    SpawnPartIndices = MSB.FindIndices(this, entries.Parts, SpawnPartNames);
                 }
             }
 
@@ -953,7 +953,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBE msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    GroupPartsIndices = MSB.FindIndices(entries.Parts, GroupPartsNames);
+                    GroupPartsIndices = MSB.FindIndices(this, entries.Parts, GroupPartsNames);
                 }
             }
 

--- a/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PartsParam.cs
+++ b/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PartsParam.cs
@@ -3157,7 +3157,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBE msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    UnkPartIndices = MSB.FindIndices(entries.Parts, UnkPartNames);
+                    UnkPartIndices = MSB.FindIndices(this, entries.Parts, UnkPartNames);
                 }
             }
         }

--- a/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PointParam.cs
+++ b/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSBE/PointParam.cs
@@ -1003,7 +1003,7 @@ namespace SoulsFormats
                 internal override void GetIndices(Entries entries)
                 {
                     base.GetIndices(entries);
-                    ChildRegionIndices = MSB.FindIndices(entries.Regions, ChildRegionNames);
+                    ChildRegionIndices = MSB.FindIndices(this, entries.Regions, ChildRegionNames);
                 }
             }
 
@@ -2040,7 +2040,7 @@ namespace SoulsFormats
                 internal override void GetIndices(Entries entries)
                 {
                     base.GetIndices(entries);
-                    PartIndices = MSB.FindIndices(entries.Parts, PartNames);
+                    PartIndices = MSB.FindIndices(this, entries.Parts, PartNames);
                 }
             }
 

--- a/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSBS/EventParam.cs
+++ b/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSBS/EventParam.cs
@@ -617,8 +617,8 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBS msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    SpawnRegionIndices = MSB.FindIndices(entries.Regions, SpawnRegionNames);
-                    SpawnPartIndices = MSB.FindIndices(entries.Parts, SpawnPartNames);
+                    SpawnRegionIndices = MSB.FindIndices(this, entries.Regions, SpawnRegionNames);
+                    SpawnPartIndices = MSB.FindIndices(this, entries.Parts, SpawnPartNames);
                 }
             }
 
@@ -973,7 +973,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBS msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    GroupPartIndices = MSB.FindIndices(entries.Parts, GroupPartNames);
+                    GroupPartIndices = MSB.FindIndices(this, entries.Parts, GroupPartNames);
                 }
             }
 
@@ -1153,7 +1153,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBS msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    Event21PartIndices = MSB.FindIndices(entries.Parts, Event21PartNames);
+                    Event21PartIndices = MSB.FindIndices(this, entries.Parts, Event21PartNames);
                 }
             }
 
@@ -1262,7 +1262,7 @@ namespace SoulsFormats
                 internal override void GetIndices(MSBS msb, Entries entries)
                 {
                     base.GetIndices(msb, entries);
-                    EnemyIndices = MSB.FindIndices(msb.Parts.Enemies, EnemyNames);
+                    EnemyIndices = MSB.FindIndices(this, msb.Parts.Enemies, EnemyNames);
                 }
             }
 

--- a/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSBS/PointParam.cs
+++ b/src/Studio.Core/SoulsFormats/SoulsFormats/Formats/MSB/MSBS/PointParam.cs
@@ -722,7 +722,7 @@ namespace SoulsFormats
                 internal override void GetIndices(Entries entries)
                 {
                     base.GetIndices(entries);
-                    ChildRegionIndices = MSB.FindIndices(entries.Regions, ChildRegionNames);
+                    ChildRegionIndices = MSB.FindIndices(this, entries.Regions, ChildRegionNames);
                 }
             }
 


### PR DESCRIPTION
Makes MSB MissingReferenceExceptions (and helpers) work with MSB.FindIndicies() instead of just MSB.FindIndex()