### PR TITLE
Property context menu improvements

### DIFF
--- a/src/StudioCore/MsbEditor/PropertyEditor.cs
+++ b/src/StudioCore/MsbEditor/PropertyEditor.cs
@@ -595,7 +595,7 @@ public class PropertyEditor
         {
             Utils.ImGui_DisplayPropertyInfo(prop);
 
-            if (ImGui.Button(@"Search##PropSearch"))
+            if (ImGui.Selectable(@"Search##PropSearch"))
             {
                 EditorCommandQueue.AddCommand($@"map/propsearch/{prop.Name}");
             }

--- a/src/StudioCore/MsbEditor/PropertyEditor.cs
+++ b/src/StudioCore/MsbEditor/PropertyEditor.cs
@@ -296,23 +296,6 @@ public class PropertyEditor
 
         var isDeactivatedAfterEdit = ImGui.IsItemDeactivatedAfterEdit() || !ImGui.IsAnyItemActive();
 
-        // Tooltip
-        if (ImGui.IsItemHovered(ImGuiHoveredFlags.DelayNormal | ImGuiHoveredFlags.NoSharedDelay))
-        {
-            var str = $"Value Type: {typ.Name}";
-            if (typ.IsValueType)
-            {
-                var min = typ.GetField("MinValue")?.GetValue(typ);
-                var max = typ.GetField("MaxValue")?.GetValue(typ);
-                if ((min != null) & (max != null))
-                {
-                    str += $" (Min {min}, Max {max})";
-                }
-            }
-
-            ImGui.SetTooltip(str);
-        }
-
         return (isChanged, isDeactivatedAfterEdit);
     }
 
@@ -585,14 +568,36 @@ public class PropertyEditor
         id++;
     }
 
-
-    private void PropertyContextMenu(object obj, PropertyInfo propinfo)
+    /// <summary>
+    /// Overlays ImGui selectable over prop name text for use as a selectable.
+    /// </summary>
+    private static void PropContextRowOpener()
     {
-        if (ImGui.BeginPopupContextItem(propinfo.Name))
+        ImGui.Selectable("", false, ImGuiSelectableFlags.AllowItemOverlap);
+        ImGui.SameLine();
+        if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
         {
-            if (ImGui.Selectable(@"Search"))
+            ImGui.OpenPopup("MsbPropContextMenu");
+        }
+    }
+
+    /// <summary>
+    /// Displays property context menu.
+    /// </summary>
+    private static void DisplayPropContextMenu(PropertyInfo prop, object obj)
+    {
+        if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
+        {
+            ImGui.OpenPopup("MsbPropContextMenu");
+        }
+
+        if (ImGui.BeginPopup("MsbPropContextMenu"))
+        {
+            Utils.ImGui_DisplayPropertyInfo(prop);
+
+            if (ImGui.Button(@"Search##PropSearch"))
             {
-                EditorCommandQueue.AddCommand($@"map/propsearch/{propinfo.Name}");
+                EditorCommandQueue.AddCommand($@"map/propsearch/{prop.Name}");
             }
 
             ImGui.EndPopup();
@@ -616,9 +621,16 @@ public class PropertyEditor
             ImGui.NextColumn();
             EditorDecorations.ParamRefsSelectables(ParamBank.PrimaryBank, refs, null, val);
             EditorDecorations.ParamRefEnumQuickLink(ParamBank.PrimaryBank, val, refs, null, null, null);
-            var opened = EditorDecorations.ParamRefEnumContextMenuItems(ParamBank.PrimaryBank, val, ref newObj,
-                refs, null, null, null, null);
-            return opened;
+
+            if (ImGui.BeginPopupContextItem($"{propinfo.Name}EnumContextMenu"))
+            {
+                Utils.ImGui_DisplayPropertyInfo(propinfo);
+
+                var opened = EditorDecorations.ParamRefEnumContextMenuItems(ParamBank.PrimaryBank, val, ref newObj,
+                    refs, null, null, null, null);
+                ImGui.EndPopup();
+                return opened;
+            }
         }
 
         return false;
@@ -637,8 +649,7 @@ public class PropertyEditor
 
     private void PropEditorGeneric(Selection selection, HashSet<Entity> entSelection, object target = null,
         bool decorate = true, int classIndex = -1)
-    {
-        var scale = MapStudioNew.GetUIScale();
+    {var scale = MapStudioNew.GetUIScale();
         Entity firstEnt = entSelection.First();
         var obj = target == null ? firstEnt.WrappedObject : target;
         Type type = obj.GetType();
@@ -718,6 +729,7 @@ public class PropertyEditor
                         }
                         else
                         {
+                            PropContextRowOpener();
                             ImGui.Text($@"{prop.Name}[{i}]");
                             ImGui.NextColumn();
                             ImGui.SetNextItemWidth(-1);
@@ -729,7 +741,7 @@ public class PropertyEditor
                                 PropertyRow(typ.GetElementType(), oldval, out newval, prop);
                             var changed = propEditResults.Item1;
                             var committed = propEditResults.Item2;
-                            PropertyContextMenu(obj, prop);
+                            DisplayPropContextMenu(prop, obj);
                             if (ImGui.IsItemActive() && !ImGui.IsWindowFocused())
                             {
                                 ImGui.SetItemDefaultFocus();
@@ -778,6 +790,7 @@ public class PropertyEditor
                         }
                         else
                         {
+                            PropContextRowOpener();
                             ImGui.Text($@"{prop.Name}[{i}]");
                             ImGui.NextColumn();
                             ImGui.SetNextItemWidth(-1);
@@ -788,7 +801,7 @@ public class PropertyEditor
                             (bool, bool) propEditResults = PropertyRow(arrtyp, oldval, out newval, prop);
                             var changed = propEditResults.Item1;
                             var committed = propEditResults.Item2;
-                            PropertyContextMenu(obj, prop);
+                            DisplayPropContextMenu(prop, obj);
                             if (ImGui.IsItemActive() && !ImGui.IsWindowFocused())
                             {
                                 ImGui.SetItemDefaultFocus();
@@ -949,6 +962,7 @@ public class PropertyEditor
                 }
                 else
                 {
+                    PropContextRowOpener();
                     ImGui.Text(prop.Name);
                     ImGui.NextColumn();
                     ImGui.SetNextItemWidth(-1);
@@ -959,7 +973,7 @@ public class PropertyEditor
                     (bool, bool) propEditResults = PropertyRow(typ, oldval, out newval, prop);
                     var changed = propEditResults.Item1;
                     var committed = propEditResults.Item2;
-                    PropertyContextMenu(obj, prop);
+                    DisplayPropContextMenu(prop, obj);
                     if (ImGui.IsItemActive() && !ImGui.IsWindowFocused())
                     {
                         ImGui.SetItemDefaultFocus();
@@ -976,7 +990,6 @@ public class PropertyEditor
                     ImGui.NextColumn();
                     ImGui.PopID();
                 }
-
                 id++;
             }
         }

--- a/src/StudioCore/MsbEditor/PropertyEditor.cs
+++ b/src/StudioCore/MsbEditor/PropertyEditor.cs
@@ -649,7 +649,8 @@ public class PropertyEditor
 
     private void PropEditorGeneric(Selection selection, HashSet<Entity> entSelection, object target = null,
         bool decorate = true, int classIndex = -1)
-    {var scale = MapStudioNew.GetUIScale();
+    {
+        var scale = MapStudioNew.GetUIScale();
         Entity firstEnt = entSelection.First();
         var obj = target == null ? firstEnt.WrappedObject : target;
         Type type = obj.GetType();
@@ -990,6 +991,7 @@ public class PropertyEditor
                     ImGui.NextColumn();
                     ImGui.PopID();
                 }
+
                 id++;
             }
         }

--- a/src/StudioCore/ParamEditor/ParamRowEditor.cs
+++ b/src/StudioCore/ParamEditor/ParamRowEditor.cs
@@ -320,8 +320,8 @@ public class ParamRowEditor
                 ImGui.SameLine();
             }
 
-            if (ImGui.Selectable("", false, ImGuiSelectableFlags.AllowItemOverlap)
-                || ImGui.IsItemClicked(ImGuiMouseButton.Right))
+            ImGui.Selectable("", false, ImGuiSelectableFlags.AllowItemOverlap);
+            if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
             {
                 ImGui.OpenPopup("ParamRowCommonMenu");
             }
@@ -616,57 +616,8 @@ public class ParamRowEditor
         var shownName = internalName;
 
         ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(0f, 10f) * scale);
-        var nameText = internalName;
-        if (!string.IsNullOrWhiteSpace(altName))
-        {
-            nameText += $"  /  {altName}";
-        }
 
-        ImGui.TextColored(new Vector4(1.0f, 0.7f, 0.4f, 1.0f), Utils.ImGuiEscape(nameText, "", true));
-        if (col.Def.BitSize != -1)
-        {
-            var str = $"Bitfield Type within: {propType.Name}";
-            var min = 0;
-            var max = (2ul << (col.Def.BitSize - 1)) - 1;
-            str += $" (Min {min}, Max {max})";
-            ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
-        }
-        else if (propType.IsValueType)
-        {
-            var str = $"Value Type: {propType.Name}";
-            var min = propType.GetField("MinValue")?.GetValue(propType);
-            var max = propType.GetField("MaxValue")?.GetValue(propType);
-            if (min != null && max != null)
-            {
-                str += $" (Min {min}, Max {max})";
-            }
-
-            ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
-        }
-        else if (propType.IsArray && col != null)
-        {
-            var str = $"Array Type: {propType.Name}";
-            var length = col.Def.ArrayLength;
-            if (length > 0)
-            {
-                str += $" (Length: {length})";
-            }
-
-            ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
-        }
-        else if (propType == typeof(string) && col != null)
-        {
-            var str = $"String Type: {propType.Name}";
-            var length = col.Def.ArrayLength;
-            if (length > 0)
-            {
-                str += $" (Length: {length})";
-            }
-
-            ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
-        }
-
-        ImGui.Separator();
+        Utils.ImGui_DisplayPropertyInfo(propType, internalName, altName, col.Def.ArrayLength, col.Def.BitSize);
 
         if (Wiki != null)
         {

--- a/src/StudioCore/Utils.cs
+++ b/src/StudioCore/Utils.cs
@@ -1015,37 +1015,43 @@ public static class Utils
             str += $" (Min {min}, Max {max})";
             ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
         }
-        else if (propType.IsValueType)
+        else
         {
-            var str = $"Value Type: {propType.Name}";
-            var min = propType.GetField("MinValue")?.GetValue(propType);
-            var max = propType.GetField("MaxValue")?.GetValue(propType);
-            if (min != null && max != null)
+            if (propType.IsArray)
             {
-                str += $" (Min {min}, Max {max})";
+                var str = $"Array Type: {propType.Name}";
+                if (arrayLength > 0)
+                {
+                    str += $" (Length: {arrayLength})";
+                }
+
+                propType = propType.GetElementType();
+
+                ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
             }
 
-            ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
-        }
-        else if (propType.IsArray)
-        {
-            var str = $"Array Type: {propType.Name}";
-            if (arrayLength > 0)
+            if (propType.IsValueType)
             {
-                str += $" (Length: {arrayLength})";
-            }
+                var str = $"Value Type: {propType.Name}";
+                var min = propType.GetField("MinValue")?.GetValue(propType);
+                var max = propType.GetField("MaxValue")?.GetValue(propType);
+                if (min != null && max != null)
+                {
+                    str += $" (Min {min}, Max {max})";
+                }
 
-            ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
-        }
-        else if (propType == typeof(string))
-        {
-            var str = $"String Type: {propType.Name}";
-            if (arrayLength > 0)
+                ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
+            }
+            else if (propType == typeof(string))
             {
-                str += $" (Length: {arrayLength})";
-            }
+                var str = $"String Type: {propType.Name}";
+                if (arrayLength > 0)
+                {
+                    str += $" (Length: {arrayLength})";
+                }
 
-            ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
+                ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
+            }
         }
 
         ImGui.Separator();

--- a/src/StudioCore/Utils.cs
+++ b/src/StudioCore/Utils.cs
@@ -987,4 +987,67 @@ public static class Utils
         var split = f.ToString("F6").TrimEnd('0').Split('.');
         return $"%.{Math.Clamp(split[1].Length, 3, 6)}f";
     }
+
+    /// <summary>
+    ///     Displays information about the provided property.
+    /// </summary>
+    public static void ImGui_DisplayPropertyInfo(PropertyInfo prop)
+    {
+        ImGui_DisplayPropertyInfo(prop.PropertyType, prop.Name);
+    }
+
+    /// <summary>
+    ///     Displays information about the provided property.
+    /// </summary>
+    public static void ImGui_DisplayPropertyInfo(Type propType, string fieldName, string altName = null, int arrayLength = -1, int bitSize = -1)
+    {
+        if (!string.IsNullOrWhiteSpace(altName))
+        {
+            fieldName += $"  /  {altName}";
+        }
+
+        ImGui.TextColored(new Vector4(1.0f, 0.7f, 0.4f, 1.0f), Utils.ImGuiEscape(fieldName, "", true));
+        if (bitSize != -1)
+        {
+            var str = $"Bitfield Type within: {fieldName}";
+            var min = 0;
+            var max = (2ul << (bitSize - 1)) - 1;
+            str += $" (Min {min}, Max {max})";
+            ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
+        }
+        else if (propType.IsValueType)
+        {
+            var str = $"Value Type: {propType.Name}";
+            var min = propType.GetField("MinValue")?.GetValue(propType);
+            var max = propType.GetField("MaxValue")?.GetValue(propType);
+            if (min != null && max != null)
+            {
+                str += $" (Min {min}, Max {max})";
+            }
+
+            ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
+        }
+        else if (propType.IsArray)
+        {
+            var str = $"Array Type: {propType.Name}";
+            if (arrayLength > 0)
+            {
+                str += $" (Length: {arrayLength})";
+            }
+
+            ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
+        }
+        else if (propType == typeof(string))
+        {
+            var str = $"String Type: {propType.Name}";
+            if (arrayLength > 0)
+            {
+                str += $" (Length: {arrayLength})";
+            }
+
+            ImGui.TextColored(new Vector4(.4f, 1f, .7f, 1f), str);
+        }
+
+        ImGui.Separator();
+    }
 }


### PR DESCRIPTION
Imports improvements made to param prop context menu to MSB prop context menu:
- Entire row can be selected to open context menu
- Context menu displays info regarding value type.

Fixes param ref UI elements in MSB prop editor not being within a context menu.
Left clicking no longer opens param context menu.
Remove MSB prop editor tooltip (info now in context menu, consistent with param context menu).