### PR TITLE
Backup regulation before upgrading & clarify upgrade instructions (2)

### DIFF
--- a/src/StudioCore/ParamEditor/ParamBank.cs
+++ b/src/StudioCore/ParamEditor/ParamBank.cs
@@ -2166,7 +2166,11 @@ public class ParamBank
         if (!File.Exists(oldVanillaParamPath))
         {
             return ParamUpgradeResult.OldRegulationNotFound;
-        }
+        }    
+        
+        // Backup modded params
+        string modRegulationPath = $@"{AssetLocator.GameModDirectory}\regulation.bin";
+        File.Copy(modRegulationPath, $@"{modRegulationPath}.upgrade.bak", true);
 
         // Load old vanilla regulation
         BND4 oldVanillaParamBnd;

--- a/src/StudioCore/ParamEditor/ParamEditorScreen.cs
+++ b/src/StudioCore/ParamEditor/ParamEditorScreen.cs
@@ -1205,17 +1205,13 @@ public class ParamEditorScreen : EditorScreen
                 ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(0.0f, 1f, 0f, 1.0f));
                 if (ImGui.Button("Upgrade Params"))
                 {
-                    DialogResult message = PlatformUtils.Instance.MessageBox(
-                        $@"Your mod is currently on regulation version {ParamBank.PrimaryBank.ParamVersion} while the game is on param version " +
-                        $"{ParamBank.VanillaBank.ParamVersion}.\n\nWould you like to attempt to upgrade your mod's params to be based on the " +
-                        "latest game version? Params will be upgraded by copying all rows that you modified to the new regulation, " +
-                        "overwriting exiting rows if needed.\n\nIf both you and the game update added a row with the same ID, the merge " +
-                        "will fail and there will be a log saying what rows you will need to manually change the ID of before trying " +
-                        "to merge again.\n\nIn order to perform this operation, you must specify the original regulation on the version " +
-                        $"that your current mod is based on (version {ParamBank.PrimaryBank.ParamVersion}).\n\nOnce done, the upgraded params will appear " +
-                        "in the param editor where you can view and save them. This operation is not undoable, but you can reload the project without " +
-                        "saving to revert to the un-upgraded params.\n\n" +
-                        "Would you like to continue?", "Regulation upgrade",
+                    string oldVersionString = Utils.ParseRegulationVersion(ParamBank.PrimaryBank.ParamVersion);
+                    string newVersionString = Utils.ParseRegulationVersion(ParamBank.VanillaBank.ParamVersion);
+                    var message = PlatformUtils.Instance.MessageBox(
+                            $"Project regulation.bin version appears to be out of date vs game folder regulation. Upgrading is recommended since the game will typically not load out of date regulation." +
+                            $"\n\nUpgrading requires you to select a VANILLA REGULATION.BIN WITH THE SAME VERSION AS YOUR MOD ({oldVersionString})" +
+                            $"\n\nWould you like to proceed?",
+                            $"Regulation upgrade {oldVersionString} -> {newVersionString}",
                         MessageBoxButtons.OKCancel,
                         MessageBoxIcon.Information);
                     if (message == DialogResult.OK)

--- a/src/StudioCore/Utils.cs
+++ b/src/StudioCore/Utils.cs
@@ -1153,4 +1153,19 @@ public static class Utils
     {
         return int.Parse(str.Replace("0x", ""), System.Globalization.NumberStyles.HexNumber);
     }
+
+    public static string ParseRegulationVersion(ulong version)
+    {
+        string verStr = version.ToString();
+        if (verStr.Length != 8)
+        {
+            return "Unknown Version";
+        }
+        char major = verStr[0];
+        string minor = verStr[1..3];
+        char patch = verStr[3];
+        string rev = verStr[4..];
+
+        return $"{major}.{minor}.{patch}.{rev}";
+    }
 }


### PR DESCRIPTION
Newer version of #442 without the conflicts.

Also, this has been in a couple releases at this point. And because of it there have been SUBSTANTIALLY fewer people doing something wrong.