### PR TITLE
Low requirements mode: disable map/model editors, fix update checker

### DIFF
--- a/src/Studio.App/DSMapStudio_LowRequirements/DSMapStudio_LowRequirements.csproj
+++ b/src/Studio.App/DSMapStudio_LowRequirements/DSMapStudio_LowRequirements.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
         <TargetFramework>net8.0-windows</TargetFramework>
@@ -20,6 +20,7 @@
         <TrimmerRootAssembly Include="SoulsFormats" />
         <TrimmerRootAssembly Include="StudioCore" />
         <TrimmerRootAssembly Include="HKX2" />
+        <TrimmerRootAssembly Include="Octokit" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Studio.App/DSMapStudio_LowRequirements/Program.cs
+++ b/src/Studio.App/DSMapStudio_LowRequirements/Program.cs
@@ -1,16 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.IO;
-using System.Reflection;
-using StudioCore;
-using System.Security.Permissions;
+﻿using StudioCore;
 using StudioCore.Graphics;
 using StudioCore.Platform;
-using Veldrid.Sdl2;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
 
 namespace DSMapStudio_LowRequirements
 {
@@ -28,6 +23,7 @@ namespace DSMapStudio_LowRequirements
             currentDomain.UnhandledException += CrashHandler;
             Directory.SetCurrentDirectory(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? throw new InvalidOperationException());
             _version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion ?? "undefined";
+            MapStudioNew.LowRequirementsMode = true;
             var mapStudio = new MapStudioNew(new OpenGLCompatGraphicsContext(), _version);
 #if !DEBUG
             try

--- a/src/StudioCore/MapStudioNew.cs
+++ b/src/StudioCore/MapStudioNew.cs
@@ -36,6 +36,8 @@ public class MapStudioNew
     private static bool _firstframe = true;
     public static bool FirstFrame = true;
 
+    public static bool LowRequirementsMode;
+
     private readonly AssetLocator _assetLocator;
 
     private readonly IGraphicsContext _context;

--- a/src/StudioCore/MsbEditor/AssetBrowser.cs
+++ b/src/StudioCore/MsbEditor/AssetBrowser.cs
@@ -57,6 +57,11 @@ public class AssetBrowser
     {
         if (ImGui.Begin($@"Asset Browser##{_id}"))
         {
+            if (MapStudioNew.LowRequirementsMode)
+            {
+                ImGui.BeginDisabled();
+            }
+
             ImGui.Columns(2);
             ImGui.BeginChild("AssetTypeList");
             if (ImGui.Selectable("Chr", _selected == "Chr"))
@@ -222,8 +227,14 @@ public class AssetBrowser
 
             ImGui.EndChild();
             ImGui.EndChild();
-        }
 
+            if (MapStudioNew.LowRequirementsMode)
+            {
+                ImGui.EndDisabled();
+            }
+        }
+        
         ImGui.End();
+
     }
 }

--- a/src/StudioCore/MsbEditor/SceneTree.cs
+++ b/src/StudioCore/MsbEditor/SceneTree.cs
@@ -600,6 +600,16 @@ public class SceneTree : IActionEventHandler
             }
 
             ImGui.PopStyleVar();
+
+            if (MapStudioNew.LowRequirementsMode)
+            {
+                ImGui.NewLine();
+                ImGui.Text("  This editor is not available in low requirements mode.");
+                ImGui.End();
+                ImGui.PopStyleColor();
+                return;
+            }
+
             if (_configuration == Configuration.MapEditor)
             {
                 if (_assetLocator.Type is GameType.DarkSoulsIISOTFS)


### PR DESCRIPTION
(The static bool is a bit silly, yes)
Also fixes low requirement exe octokit trimming issues (which was separately already fixed in 1.09.X releases)