### PR TITLE
FMG editor fixes/improvements

### DIFF
--- a/src/StudioCore/TextEditor/FMGBank.cs
+++ b/src/StudioCore/TextEditor/FMGBank.cs
@@ -1428,6 +1428,16 @@ public static class FMGBank
         public FMGInfo PatchParent;
         public FmgUICategory UICategory;
 
+        private string _patchPrefix = null;
+        public string PatchPrefix
+        {
+            get
+            {
+                _patchPrefix ??= Name.Replace(RemovePatchStrings(Name), "");
+                return _patchPrefix;
+            }
+        }
+
         public void AddParent(FMGInfo parent)
         {
             if (CFG.Current.FMG_NoFmgPatching)
@@ -1464,6 +1474,7 @@ public static class FMGBank
                     EntryFMGInfoPair match = list.Find(e => e.Entry.ID == entry.ID);
                     if (match != null)
                     {
+                        // This is a patch entry
                         // Only non-null text will overrwrite
                         if (entry.Text != null)
                         {
@@ -1508,10 +1519,12 @@ public static class FMGBank
                     FMG.Entry match = list.Find(e => e.ID == entry.ID);
                     if (match != null)
                     {
-                        // Only non-null text will overrwrite
+                        // This is a patch entry
                         if (entry.Text != null)
                         {
-                            match = entry;
+                            // Text is not null, so it will overwrite non-patch entries.
+                            list.Remove(match);
+                            list.Add(entry);
                         }
                     }
                     else
@@ -1527,6 +1540,22 @@ public static class FMGBank
             }
 
             return list;
+        }
+
+        /// <summary>
+        ///     Returns title FMGInfo that shares this FMGInfo's EntryCategory.
+        ///     If none are found, an exception will be thrown.
+        /// </summary>
+        public FMGInfo GetTitleFmgInfo()
+        {
+            foreach (var info in FMGBank.FmgInfoBank)
+            {
+                if (info.EntryCategory == EntryCategory && info.EntryType == FmgEntryTextType.Title && info.PatchPrefix == PatchPrefix)
+                {
+                    return info;
+                }
+            }
+            throw new InvalidOperationException($"Couldn't find title FMGInfo for {this.Name}");
         }
 
         /// <summary>

--- a/src/StudioCore/TextEditor/TextEditorScreen.cs
+++ b/src/StudioCore/TextEditor/TextEditorScreen.cs
@@ -3,6 +3,7 @@ using SoulsFormats;
 using StudioCore.Editor;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using Veldrid;
 using Veldrid.Sdl2;
@@ -449,7 +450,7 @@ public class TextEditorScreen : EditorScreen
                     {
                         _searchFilter = _fmgSearchAllString;
                         _searchFilterCached = "";
-                }
+                    }
                 }
 
                 if (doFocus && info == _activeFmgInfo)
@@ -507,12 +508,19 @@ public class TextEditorScreen : EditorScreen
             {
                 if (info.PatchParent == null)
                 {
-                    foreach (var entry in info.GetPatchedEntries())
+                    foreach (var entry in info.GetPatchedEntries(false))
                     {
                         if ((entry.Text != null && entry.Text.Contains(_fmgSearchAllString, StringComparison.CurrentCultureIgnoreCase))
                             || entry.ID.ToString().Contains(_fmgSearchAllString))
                         {
-                            _filteredFmgInfo.Add(info);
+                            if (info.EntryType is not FmgEntryTextType.Title and not FmgEntryTextType.TextBody)
+                            {
+                                _filteredFmgInfo.Add(info.GetTitleFmgInfo());
+                            }
+                            else
+                            {
+                                _filteredFmgInfo.Add(info);
+                            }
                             break;
                         }
                     }

--- a/src/StudioCore/TextEditor/TextEditorScreen.cs
+++ b/src/StudioCore/TextEditor/TextEditorScreen.cs
@@ -518,6 +518,7 @@ public class TextEditorScreen : EditorScreen
                     }
                 }
             }
+            _filteredFmgInfo = _filteredFmgInfo.Distinct().ToList();
         }
         if (_fmgSearchAllString == "")
         {

--- a/src/StudioCore/TextEditor/TextEditorScreen.cs
+++ b/src/StudioCore/TextEditor/TextEditorScreen.cs
@@ -445,6 +445,11 @@ public class TextEditorScreen : EditorScreen
                 {
                     ClearTextEditorCache();
                     _activeFmgInfo = info;
+                    if (_fmgSearchAllActive)
+                    {
+                        _searchFilter = _fmgSearchAllString;
+                        _searchFilterCached = "";
+                }
                 }
 
                 if (doFocus && info == _activeFmgInfo)

--- a/src/StudioCore/TextEditor/TextEditorScreen.cs
+++ b/src/StudioCore/TextEditor/TextEditorScreen.cs
@@ -395,6 +395,8 @@ public class TextEditorScreen : EditorScreen
                     }
                 }
 
+                matches = matches.OrderBy(e => e.ID).ToList();
+
                 _EntryLabelCacheFiltered = matches;
                 _searchFilterCached = _searchFilter;
                 doFocus = true;


### PR DESCRIPTION
Sorts filtered FMG entries by ID.
Auto-fills entry filter when using search all FMGs.
Fixes search all FMGs being able to show dupes in FMG list.
Fixes search all FMGs not displaying certain grouped/patch entry results properly.