### PR TITLE
Fix viewport camera stutter & add setting for camera sensitivity

### DIFF
--- a/src/StudioCore/CFG.cs
+++ b/src/StudioCore/CFG.cs
@@ -68,6 +68,7 @@ public class CFG
     public float GFX_Camera_MoveSpeed_Slow { get; set; } = 1.0f;
     public float GFX_Camera_MoveSpeed_Normal { get; set; } = 20.0f;
     public float GFX_Camera_MoveSpeed_Fast { get; set; } = 200.0f;
+    public float GFX_Camera_Sensitivity { get; set; } = 0.0160f;
     public float GFX_RenderDistance_Max { get; set; } = 50000.0f;
     public float Map_ArbitraryRotation_X_Shift { get; set; } = 90.0f;
     public float Map_ArbitraryRotation_Y_Shift { get; set; } = 90.0f;

--- a/src/StudioCore/SettingsMenu.cs
+++ b/src/StudioCore/SettingsMenu.cs
@@ -297,6 +297,8 @@ public class SettingsMenu
                 }
                 if (ImGui.Button("Reset##ViewportCamera"))
                 {
+                    CFG.Current.GFX_Camera_Sensitivity = CFG.Default.GFX_Camera_Sensitivity;
+
                     CFG.Current.GFX_Camera_FOV = CFG.Default.GFX_Camera_FOV;
 
                     CFG.Current.GFX_RenderDistance_Max = CFG.Default.GFX_RenderDistance_Max;
@@ -309,6 +311,18 @@ public class SettingsMenu
 
                     MsbEditor.Viewport.WorldView.CameraMoveSpeed_Fast = CFG.Default.GFX_Camera_MoveSpeed_Fast;
                     CFG.Current.GFX_Camera_MoveSpeed_Fast = MsbEditor.Viewport.WorldView.CameraMoveSpeed_Fast;
+                }
+
+                var cam_sensitivity = CFG.Current.GFX_Camera_Sensitivity;
+
+                if (CFG.Current.ShowUITooltips)
+                {
+                    ShowHelpMarker("Mouse sensitivty for turning the camera.");
+                    ImGui.SameLine();
+                }
+                if (ImGui.SliderFloat("Camera sensitivity", ref cam_sensitivity, 0.0f, 0.1f))
+                {
+                    CFG.Current.GFX_Camera_Sensitivity = cam_sensitivity;
                 }
 
                 var cam_fov = CFG.Current.GFX_Camera_FOV;

--- a/src/StudioCore/WorldView.cs
+++ b/src/StudioCore/WorldView.cs
@@ -530,21 +530,16 @@ public class WorldView
             }
             else
             {
+                int windowX = 0;
+                int windowY = 0;
                 Vector2 mouseDelta = MousePressedPos - InputTracker.MousePosition;
                 SDL.WarpMouseInWindow(window.SdlWindowHandle, (int)MousePressedPos.X, (int)MousePressedPos.Y);
 
-                if (mouseDelta.LengthSquared() == 0)
-                {
-                    // Prevents a meme
-                    //oldWheel = currentWheel;
-                    return true;
-                }
+                SDL.GetWindowPosition(window.SdlWindowHandle, ref windowX, ref windowY);
+                SDL.WarpMouseGlobal(windowX + (int)MousePressedPos.X, windowY + (int)MousePressedPos.Y);
 
-                //Mouse.SetPosition(game.ClientBounds.X + game.ClientBounds.Width / 2, game.ClientBounds.Y + game.ClientBounds.Height / 2);
-
-
-                var camH = mouseDelta.X * 1 * CameraTurnSpeedMouse * 0.0160f;
-                var camV = mouseDelta.Y * -1 * CameraTurnSpeedMouse * 0.0160f;
+                var camH = mouseDelta.X * 1 * CameraTurnSpeedMouse * CFG.Current.GFX_Camera_Sensitivity;
+                var camV = mouseDelta.Y * -1 * CameraTurnSpeedMouse * CFG.Current.GFX_Camera_Sensitivity;
 
                 if (IsOrbitCam && !isMoveLightKeyPressed)
                 {

--- a/src/StudioCore/WorldView.cs
+++ b/src/StudioCore/WorldView.cs
@@ -258,12 +258,6 @@ public class WorldView
         mousePos = new Vector2(Utils.Lerp(oldMouse.X, InputTracker.MousePosition.X, clampedLerpF),
             Utils.Lerp(oldMouse.Y, InputTracker.MousePosition.Y, clampedLerpF));
 
-
-        //KeyboardState keyboard = DBG.EnableKeyboardInput ? Keyboard.GetState() : DBG.DisabledKeyboardState;
-        //int currentWheel = mouse.ScrollWheelValue;
-
-        //bool mouseInWindow = MapStudio.Active && mousePos.X >= game.ClientBounds.Left && mousePos.X < game.ClientBounds.Right && mousePos.Y > game.ClientBounds.Top && mousePos.Y < game.ClientBounds.Bottom;
-
         currentClickType = MouseClickType.None;
 
         if (InputTracker.GetMouseButton(MouseButton.Left))
@@ -533,7 +527,6 @@ public class WorldView
                 int windowX = 0;
                 int windowY = 0;
                 Vector2 mouseDelta = MousePressedPos - InputTracker.MousePosition;
-                SDL.WarpMouseInWindow(window.SdlWindowHandle, (int)MousePressedPos.X, (int)MousePressedPos.Y);
 
                 SDL.GetWindowPosition(window.SdlWindowHandle, ref windowX, ref windowY);
                 SDL.WarpMouseGlobal(windowX + (int)MousePressedPos.X, windowY + (int)MousePressedPos.Y);
@@ -554,7 +547,6 @@ public class WorldView
                     }
 
                     RotateCameraOrbit(camH, camV, Utils.PiOver2);
-                    //PointCameraToModel();
                 }
                 else if (isMoveLightKeyPressed)
                 {
@@ -569,12 +561,6 @@ public class WorldView
                     CameraTransform.EulerRotation = eu;
                 }
             }
-
-
-            //CameraTransform.Rotation.Z -= (float)Math.Cos(MathHelper.PiOver2 - CameraTransform.Rotation.Y) * camV;
-
-            //RotateCamera(mouseDelta.Y * -0.01f * (float)moveMult, 0, 0, moveMult);
-            //RotateCamera(0, mouseDelta.X * 0.01f * (float)moveMult, 0, moveMult);
         }
         else
         {
@@ -590,12 +576,6 @@ public class WorldView
             {
                 RotateCameraOrbit(0, 0, Utils.PiOver2);
             }
-
-            if (oldMouseClickL)
-            {
-                //Mouse.SetPosition((int)oldMouse.X, (int)oldMouse.Y);
-            }
-            //game.IsMouseVisible = true;
         }
 
 


### PR DESCRIPTION
Stuttering was being caused by SDL.WarpMouseInWindow(), which starting having issues after we updated SDL2. SDL.WarpMouseGlobal() doesn't have that issue so we can just use it instead.