### PR TITLE
Fix scrollHeight on row select being at 0

### DIFF
--- a/src/StudioCore/ParamEditor/ParamEditorView.cs
+++ b/src/StudioCore/ParamEditor/ParamEditorView.cs
@@ -514,7 +514,7 @@ public class ParamEditorView
 
                 if (doFocus)
                 {
-                    ImGui.SetScrollFromPosYFloat(scrollTo - ImGui.GetScrollY(), 0);
+                    ImGui.SetScrollFromPosYFloat(scrollTo - ImGui.GetScrollY(), 0.33f);
                 }
 
                 ImGui.EndTable();


### PR DESCRIPTION
The first row would be underneath the header row, even.