### PR TITLE
Fix imgui input text - length + ctrlv crash

### DIFF
--- a/src/Andre/Andre.Native/ImGui.cs
+++ b/src/Andre/Andre.Native/ImGui.cs
@@ -218,6 +218,7 @@ public static unsafe partial class ImGuiBindings
         
         public static bool InputText(string label, ref string buf, int bufSize, ImGuiInputTextFlags flags=0)
         {
+            bufSize += 1;
             CString cBufString;
             if (bufSize <= STACKALLOCMAX)
             {
@@ -238,6 +239,7 @@ public static unsafe partial class ImGuiBindings
         }
         public static bool InputTextMultiline(string label, ref string buf, int bufSize, Vector2 size=default, ImGuiInputTextFlags flags=0)
         {
+            bufSize += 1;
             CString cBufString;
             if (bufSize <= STACKALLOCMAX)
             {
@@ -259,6 +261,7 @@ public static unsafe partial class ImGuiBindings
         
         public static bool InputTextWithHint(string label, string hint, ref string buf, int bufSize)
         {
+            bufSize += 1;
             CString cBufString;
             if (bufSize <= STACKALLOCMAX)
             {

--- a/src/Andre/Andre.Native/ImGui.cs
+++ b/src/Andre/Andre.Native/ImGui.cs
@@ -215,11 +215,11 @@ public static unsafe partial class ImGuiBindings
             v = i;
             return res;
         }
-        
         public static bool InputText(string label, ref string buf, int bufSize, ImGuiInputTextFlags flags=0)
         {
             bufSize += 1;
             CString cBufString;
+            nint nPtr = 0;
             if (bufSize <= STACKALLOCMAX)
             {
                 var cBuf = stackalloc byte[bufSize];
@@ -230,17 +230,25 @@ public static unsafe partial class ImGuiBindings
             }
             else
             {
-                cBufString = new CString(buf);
+                nPtr = Marshal.AllocHGlobal(bufSize);
+                byte* cBuf = (byte*)nPtr.ToPointer();
+                if (Encoding.UTF8.TryGetBytes(buf.AsSpan(), new Span<byte>(cBuf, bufSize), out int bw))
+                    cBufString = new CString(cBuf);
+                else
+                    cBufString = new CString(buf);
             }
             using var cLabel = (CString)label;
             var result = InputText(cLabel, cBufString, bufSize, flags, new ImGuiInputTextCallback(), null);
             buf = cBufString.ToString();
+            if (bufSize > STACKALLOCMAX)
+                Marshal.FreeHGlobal(nPtr);
             return result;
         }
         public static bool InputTextMultiline(string label, ref string buf, int bufSize, Vector2 size=default, ImGuiInputTextFlags flags=0)
         {
             bufSize += 1;
             CString cBufString;
+            nint nPtr = 0;
             if (bufSize <= STACKALLOCMAX)
             {
                 var cBuf = stackalloc byte[bufSize];
@@ -251,11 +259,18 @@ public static unsafe partial class ImGuiBindings
             }
             else
             {
-                cBufString = new CString(buf);
+                nPtr = Marshal.AllocHGlobal(bufSize);
+                byte* cBuf = (byte*)nPtr.ToPointer();
+                if (Encoding.UTF8.TryGetBytes(buf.AsSpan(), new Span<byte>(cBuf, bufSize), out int bw))
+                    cBufString = new CString(cBuf);
+                else
+                    cBufString = new CString(buf);
             }
             using var cLabel = (CString)label;
             var result = InputTextMultiline(cLabel, cBufString, bufSize, size, flags, new ImGuiInputTextCallback(), null);
             buf = cBufString.ToString();
+            if (bufSize > STACKALLOCMAX)
+                Marshal.FreeHGlobal(nPtr);
             return result;
         }
         
@@ -263,6 +278,7 @@ public static unsafe partial class ImGuiBindings
         {
             bufSize += 1;
             CString cBufString;
+            nint nPtr = 0;
             if (bufSize <= STACKALLOCMAX)
             {
                 var cBuf = stackalloc byte[bufSize];
@@ -273,12 +289,19 @@ public static unsafe partial class ImGuiBindings
             }
             else
             {
-                cBufString = new CString(buf);
+                nPtr = Marshal.AllocHGlobal(bufSize);
+                byte* cBuf = (byte*)nPtr.ToPointer();
+                if (Encoding.UTF8.TryGetBytes(buf.AsSpan(), new Span<byte>(cBuf, bufSize), out int bw))
+                    cBufString = new CString(cBuf);
+                else
+                    cBufString = new CString(buf);
             }
             using var cLabel = (CString)label;
             using var cHint = (CString)hint;
             var result = InputTextWithHint(cLabel, cHint, cBufString, bufSize, 0, new ImGuiInputTextCallback(), null);
             buf = cBufString.ToString();
+            if (bufSize > STACKALLOCMAX)
+                Marshal.FreeHGlobal(nPtr);
             return result;
         }
         

--- a/src/StudioCore/MsbEditor/SceneTree.cs
+++ b/src/StudioCore/MsbEditor/SceneTree.cs
@@ -184,7 +184,7 @@ public class SceneTree : IActionEventHandler
                 ImGui.PushStyleColorVec4(ImGuiCol.FrameBg, new Vector4(0.8f, 0.2f, 0.2f, 1.0f));
             }
 
-            if (ImGui.InputText("##chalicename", ref pname, 32))
+            if (ImGui.InputText("##chalicename", ref pname, 12))
             {
                 _chaliceMapID = pname;
             }
@@ -905,7 +905,7 @@ public class SceneTree : IActionEventHandler
                 }
             }
 
-            if (_assetLocator.Type == GameType.Bloodborne && _configuration == Configuration.MapEditor)
+            if (/*_assetLocator.Type == GameType.Bloodborne &&*/ _configuration == Configuration.MapEditor)
             {
                 ChaliceDungeonImportButton();
             }


### PR DESCRIPTION
Hopefully this isn't a massive memory leak. The failure-case on utf8 encoding persists.